### PR TITLE
posting blockCalldata

### DIFF
--- a/contracts/V1/StateChannelDiamondProxy/AStateChannelManagerProxy.sol
+++ b/contracts/V1/StateChannelDiamondProxy/AStateChannelManagerProxy.sol
@@ -190,6 +190,13 @@ abstract contract AStateChannelManagerProxy is
         require(block.timestamp <= maxTimestamp, ErrorBlockCalldataTimestampTooLate());
         bytes32 commitment = keccak256(abi.encode(signedBlock,block.timestamp));
         Block memory _block = abi.decode(signedBlock.encodedBlock, (Block));
+        
+        //Don't allow overwriting the blockCalldataCommitment if it already exists
+        require(blockCalldataCommitments[_block.transaction.header.channelId]
+        [msg.sender]
+        [_block.transaction.header.forkCnt]
+        [_block.transaction.header.transactionCnt] == bytes32(0), ErrorBlockCalldataAlreadyPosted());
+
         blockCalldataCommitments
         [_block.transaction.header.channelId]
         [msg.sender]

--- a/contracts/V1/StateChannelDiamondProxy/DisputeManagerFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeManagerFacet.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.8;
 import "./StateChannelCommon.sol";
 import "./AStateChannelManagerProxy.sol";
 import "./StateChannelUtilLibrary.sol";
-import "./DisputeErrors.sol";
+import "./Errors.sol";
 
 contract DisputeManagerFacet is StateChannelCommon {
 

--- a/contracts/V1/StateChannelDiamondProxy/Errors.sol
+++ b/contracts/V1/StateChannelDiamondProxy/Errors.sol
@@ -100,3 +100,6 @@ error BlockNotLatestState();
 error DisputeInvalidRecursive();
 error DisputeInvalidPreviousRecursive();
 error DisputeInvalidExitChannelBlocks();
+
+//Posting block calldata
+error ErrorBlockCalldataTimestampTooLate();

--- a/contracts/V1/StateChannelDiamondProxy/Errors.sol
+++ b/contracts/V1/StateChannelDiamondProxy/Errors.sol
@@ -103,3 +103,4 @@ error DisputeInvalidExitChannelBlocks();
 
 //Posting block calldata
 error ErrorBlockCalldataTimestampTooLate();
+error ErrorBlockCalldataAlreadyPosted();

--- a/contracts/V1/StateChannelDiamondProxy/FraudProofFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/FraudProofFacet.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.8;
 import "./StateChannelCommon.sol";
 import "./AStateChannelManagerProxy.sol";
 import "./StateChannelUtilLibrary.sol";
-import "./DisputeErrors.sol";
+import "./Errors.sol";
 
 contract FraudProofFacet is StateChannelCommon {
     

--- a/contracts/V1/StateChannelManagerEvents.sol
+++ b/contracts/V1/StateChannelManagerEvents.sol
@@ -6,6 +6,7 @@ import "./DataTypes.sol";
 interface StateChannelManagerEvents {
     event BlockCalldataPosted(
         bytes32 indexed channelId,
+        address sender,
         SignedBlock signedBlock,
         uint timestamp
     );

--- a/contracts/V1/StateChannelManagerInterface.sol
+++ b/contracts/V1/StateChannelManagerInterface.sol
@@ -65,14 +65,14 @@ abstract contract StateChannelManagerInterface {
         Transaction memory _tx
     ) public virtual returns (bool, bytes memory);
 
-    function postBlockCalldata(SignedBlock memory signedBlock) public virtual;
+    function postBlockCalldata(SignedBlock memory signedBlock, uint maxTimestamp) public virtual;
 
     function getBlockCallDataCommitment(
         bytes32 channelId,
         uint forkCnt,
         uint blockHeight,
         address participant
-    ) public view virtual returns (bool found, bytes32 blockCallData);
+    ) public view virtual returns (bool found, bytes32 blockCalldataCommitment);
 
     function createDispute(
         Dispute memory dispute


### PR DESCRIPTION
This is everything we need for posting a block as calldata on-chain. I've left some comments above the function explaining thigs briefly.
I'll also expand here a bit more:
So in general anyone (even non-participants) can invoke this function and post whatever (junk), but they pay the on-chain fees. In general it's cheap. It's a small function that modifies a single storage slot. Transactions don't get cheaper than this - even a simple transfer is more expensive since it modifies 2 storage slots. The msg.sender takes full responsibility of the data committed. If msg.sender is not a participant, the off-chain clients just ignore the emitted events.

The maxTimestamp prevents race condition. In general there is some time logic that I didn't put in the docs (yet) - I'll explain it here and feel free to update the docs with it.

Time logic:
The off-chain blocks that are linked contain a timestamp and the difference between timestamps in 2 consecutive blocks has to be <= p2pTime. When a peer receives a block, apart from doing all other checks it checks the timestamp and compares it to the **previous block timestamp** . It needs to satisfy <=p2pTime. Apart from that, since peers can put arbitrary timestamps in the block, the timestamp is also compared to the local clock of the peer (subjective perception) and the difference can NOT be more than agreementTime (if it is the peer doesn't cosign the block). From the perspective of the block author, they'll wait agreementTime and expect to collect an N/N threshold. If for any reason that threshold is NOT reached, after agreementTime the block author has chainFallbackTime to post the block on-chain. So the check that needs to hold on-chain eventually is:

**previous block timestamp** + p2pTime + agreementTime + chainFallbackTime >= on-chain block.timetamp

The left part of the equation is 'maxTimestamp' used when posting blockCalldata.

One more thing to keep in mind! 
Since the on-chain timestamp 'overrides' the off-chain timestamp, we need to make sure that we account for that both on-chain and off-chain. So the **previous block timestamp** = previous block commitment posted ? emitted timestamp : original timestamp 

maxTimestamp also takes that into account 

@daiagi @MrishoLukamba take a look and let me know if you have questions 

