### PR TITLE
Refactor--codec

### DIFF
--- a/src/DisputeHandler.ts
+++ b/src/DisputeHandler.ts
@@ -6,7 +6,7 @@ import {
     DisputeStruct
 } from "@typechain-types/contracts/V1/DisputeTypes";
 import { SignedBlockStruct } from "@typechain-types/contracts/V1/DataTypes";
-import { EvmUtils, DebugProxy, retry } from "@/utils";
+import { DebugProxy, retry, Codec, Type } from "@/utils";
 import P2pEventHooks from "@/P2pEventHooks";
 import ProofManager from "./ProofManager";
 
@@ -77,8 +77,9 @@ class DisputeHandler {
     ): Promise<void> {
         const proof =
             this.proofManager.createDoubleSignProof(conflictingBlocks);
-        const _firstBlock = EvmUtils.decodeBlock(
-            conflictingBlocks[0].encodedBlock
+        const _firstBlock = Codec.decode(
+            conflictingBlocks[0].encodedBlock,
+            Type.Block
         );
         return this.createDispute(
             _firstBlock.transaction.header.forkCnt,
@@ -93,7 +94,10 @@ class DisputeHandler {
     ): Promise<void> {
         const proof =
             this.proofManager.createIncorrectDataProof(incorrectBlockSigned);
-        const _block = EvmUtils.decodeBlock(incorrectBlockSigned.encodedBlock);
+        const _block = Codec.decode(
+            incorrectBlockSigned.encodedBlock,
+            Type.Block
+        );
         return this.createDispute(
             _block.transaction.header.forkCnt,
             NO_PARTICIPANT_TO_FOLD,
@@ -129,7 +133,7 @@ class DisputeHandler {
         BlockSigned: SignedBlockStruct
     ): Promise<void> {
         const proof = ProofManager.createBlockTooFarInFutureProof(BlockSigned);
-        const block = EvmUtils.decodeBlock(BlockSigned.encodedBlock);
+        const block = Codec.decode(BlockSigned.encodedBlock, Type.Block);
         return this.createDispute(
             block.transaction.header.forkCnt,
             NO_PARTICIPANT_TO_FOLD,
@@ -336,8 +340,9 @@ class DisputeHandler {
         if (dispute.virtualVotingBlocks.length === 0) return 0;
 
         // Extract from the last block
-        const lastBlock = EvmUtils.decodeBlock(
-            dispute.virtualVotingBlocks.at(-1)!.encodedBlock
+        const lastBlock = Codec.decode(
+            dispute.virtualVotingBlocks.at(-1)!.encodedBlock,
+            Type.Block
         );
         return Number(lastBlock.transaction.header.transactionCnt);
     }

--- a/src/ProofManager.ts
+++ b/src/ProofManager.ts
@@ -2,7 +2,7 @@ import { ethers, AddressLike, BigNumberish, BytesLike } from "ethers";
 import * as dt from "@typechain-types/contracts/V1/DisputeTypes";
 import { SignedBlockStruct } from "@typechain-types/contracts/V1/DataTypes";
 import { getEthersTypeForDisputeProof, ProofType } from "@/types/disputes";
-import { EvmUtils } from "@/utils";
+import { Codec, Type } from "@/utils";
 import Clock from "@/Clock";
 import AgreementManager from "@/agreementManager";
 
@@ -35,7 +35,7 @@ class ProofManager {
             [getEthersTypeForDisputeProof(proofType)],
             encodedProof
         );
-        return EvmUtils.ethersResultToObjectRecursive(proofDecoded[0]);
+        return Codec.ethersResultToObjectRecursive(proofDecoded[0]);
     }
 
     // ===== Proof Creation Methods =====
@@ -53,7 +53,7 @@ class ProofManager {
             return undefined;
 
         const foldRechallengeProofStruct: dt.FoldRechallengeProofStruct = {
-            encodedBlock: EvmUtils.encodeBlock(block),
+            encodedBlock: Codec.encode(block, Type.Block),
             signatures: this.agreementManager.getSigantures(
                 block
             ) as BytesLike[]
@@ -105,8 +105,9 @@ class ProofManager {
     public createIncorrectDataProof(
         incorrectBlockSigned: SignedBlockStruct
     ): dt.ProofStruct {
-        const incorrectBlock = EvmUtils.decodeBlock(
-            incorrectBlockSigned.encodedBlock
+        const incorrectBlock = Codec.decode(
+            incorrectBlockSigned.encodedBlock,
+            Type.Block
         );
         const forkCnt = Number(incorrectBlock.transaction.header.forkCnt);
         const transactionCnt = Number(
@@ -159,7 +160,7 @@ class ProofManager {
 
         // Create the proof struct using the newer state
         const newerStateProofStruct: dt.NewerStateProofStruct = {
-            encodedBlock: EvmUtils.encodeBlock(signedBlock.block),
+            encodedBlock: Codec.encode(signedBlock.block, Type.Block),
             confirmationSignature: signedBlock.signature as string
         };
 
@@ -214,7 +215,10 @@ class ProofManager {
             proof.encodedProof
         ) as dt.FoldRechallengeProofStruct;
 
-        const block = EvmUtils.decodeBlock(foldRechallengeProof.encodedBlock);
+        const block = Codec.decode(
+            foldRechallengeProof.encodedBlock,
+            Type.Block
+        );
         const sameTransactionCnt =
             Number(block.transaction.header.transactionCnt) ===
             dispute.foldedTransactionCnt;
@@ -235,7 +239,10 @@ class ProofManager {
         ) as dt.DoubleSignProofStruct;
 
         return doubleSignProof.doubleSigns.some((doubleSign) => {
-            const block1 = EvmUtils.decodeBlock(doubleSign.block1.encodedBlock);
+            const block1 = Codec.decode(
+                doubleSign.block1.encodedBlock,
+                Type.Block
+            );
             return !dispute.slashedParticipants.includes(
                 block1.transaction.header.participant
             );
@@ -251,8 +258,9 @@ class ProofManager {
             proof.encodedProof
         ) as dt.IncorrectDataProofStruct;
 
-        const block2 = EvmUtils.decodeBlock(
-            incorrectDataProof.block2.encodedBlock
+        const block2 = Codec.decode(
+            incorrectDataProof.block2.encodedBlock,
+            Type.Block
         );
 
         return !dispute.slashedParticipants.includes(
@@ -269,13 +277,14 @@ class ProofManager {
             proof.encodedProof
         ) as dt.NewerStateProofStruct;
 
-        const block = EvmUtils.decodeBlock(newerStateProof.encodedBlock);
+        const block = Codec.decode(newerStateProof.encodedBlock, Type.Block);
 
         if (dispute.virtualVotingBlocks.length === 0) return false;
 
-        const latestBlock = EvmUtils.decodeBlock(
+        const latestBlock = Codec.decode(
             dispute.virtualVotingBlocks[dispute.virtualVotingBlocks.length - 1]
-                .encodedBlock
+                .encodedBlock,
+            Type.Block
         );
 
         const latestTransactionCnt = Number(
@@ -319,8 +328,9 @@ class ProofManager {
             proof.encodedProof
         ) as dt.BlockTooFarInFutureProofStruct;
 
-        const block = EvmUtils.decodeBlock(
-            blockTooFarInFutureProof.block1.encodedBlock
+        const block = Codec.decode(
+            blockTooFarInFutureProof.block1.encodedBlock,
+            Type.Block
         );
         const blockTimestamp = Number(block.transaction.header.timestamp);
 
@@ -420,7 +430,7 @@ class ProofManager {
         return {
             block1: incorrectBlockSigned,
             block2: {
-                encodedBlock: EvmUtils.encodeBlock(priorBlock),
+                encodedBlock: Codec.encode(priorBlock, Type.Block),
                 signature: priorBlockOriginalSignature as string
             },
             encodedState: priorEncodedState

--- a/src/agreementManager/AgreementManager.ts
+++ b/src/agreementManager/AgreementManager.ts
@@ -7,7 +7,7 @@ import {
     BlockConfirmationStruct,
     DisputeStruct
 } from "@typechain-types/contracts/V1/DisputeTypes";
-import { BlockUtils, EvmUtils } from "@/utils";
+import { BlockUtils, Codec, EvmUtils, Type } from "@/utils";
 import { AgreementFlag } from "@/types";
 import { BlockConfirmation } from "./types";
 import * as SetUtils from "@/utils/set";
@@ -98,7 +98,7 @@ class AgreementManager {
     public getDoubleSignedBlock(
         signedBlock: SignedBlockStruct
     ): SignedBlockStruct | undefined {
-        const block = EvmUtils.decodeBlock(signedBlock.encodedBlock);
+        const block = Codec.decode(signedBlock.encodedBlock, Type.Block);
 
         const agreement = this.forks.agreementByBlock(block);
         if (
@@ -118,7 +118,7 @@ class AgreementManager {
 
         return didSign
             ? {
-                  encodedBlock: EvmUtils.encodeBlock(agreement.block),
+                  encodedBlock: Codec.encode(agreement.block, Type.Block),
                   signature: signature!.toString()
               }
             : undefined;
@@ -297,7 +297,7 @@ class AgreementManager {
 
             virtualVotingBlocks.unshift({
                 signedBlock: {
-                    encodedBlock: EvmUtils.encodeBlock(agreement.block),
+                    encodedBlock: Codec.encode(agreement.block, Type.Block),
                     signature: originalSignature as string
                 },
                 signatures: confirmationSignatures as string[]

--- a/src/agreementManager/BlockValidator.ts
+++ b/src/agreementManager/BlockValidator.ts
@@ -4,7 +4,7 @@ import {
     BlockStruct
 } from "@typechain-types/contracts/V1/DataTypes";
 
-import { BlockUtils, EvmUtils } from "@/utils";
+import { BlockUtils, Codec, EvmUtils, Type } from "@/utils";
 import { AgreementFlag } from "@/types";
 
 import ForkService from "./ForkService";
@@ -47,7 +47,7 @@ export default class BlockValidator {
     }
 
     check(signed: SignedBlockStruct): AgreementFlag {
-        const block = EvmUtils.decodeBlock(signed.encodedBlock);
+        const block = Codec.decode(signed.encodedBlock, Type.Block);
         const { forkCnt, height } = BlockUtils.getCoordinates(block);
         const participant = BlockUtils.getBlockAuthor(block);
 
@@ -86,7 +86,7 @@ export default class BlockValidator {
         const prev = this.forks.blockAt(forkCnt, height - 1);
         if (!prev) return AgreementFlag.NOT_READY;
 
-        const prevBlockHash = ethers.keccak256(EvmUtils.encodeBlock(prev));
+        const prevBlockHash = ethers.keccak256(Codec.encode(prev, Type.Block));
         return prevBlockHash === block.previousBlockHash
             ? AgreementFlag.READY
             : AgreementFlag.INCORRECT_DATA;

--- a/src/agreementManager/OnChainTracker.ts
+++ b/src/agreementManager/OnChainTracker.ts
@@ -3,7 +3,7 @@ import {
     SignedBlockStruct,
     BlockStruct
 } from "@typechain-types/contracts/V1/DataTypes";
-import { BlockUtils, EvmUtils } from "@/utils";
+import { BlockUtils, Codec, EvmUtils, Type } from "@/utils";
 import { AgreementFlag } from "@/types";
 
 import ForkService from "./ForkService";
@@ -31,7 +31,7 @@ export default class OnChainTracker {
             this.queues.queueBlock(signed);
         }
 
-        const blk: BlockStruct = EvmUtils.decodeBlock(signed.encodedBlock);
+        const blk: BlockStruct = Codec.decode(signed.encodedBlock, Type.Block);
         const { forkCnt, height } = BlockUtils.getCoordinates(blk);
         const participant = BlockUtils.getBlockAuthor(blk);
 

--- a/src/agreementManager/QueueService.ts
+++ b/src/agreementManager/QueueService.ts
@@ -3,7 +3,7 @@ import {
     BlockStruct
 } from "@typechain-types/contracts/V1/DataTypes";
 import { BlockConfirmation } from "./types";
-import { BlockUtils, EvmUtils } from "@/utils";
+import { BlockUtils, Codec, EvmUtils, Type } from "@/utils";
 
 type ForkCnt = number;
 type Height = number;
@@ -37,7 +37,7 @@ export default class QueueService {
     /*────────── Block queue ─────────*/
 
     queueBlock(sb: SignedBlockStruct): void {
-        const block = EvmUtils.decodeBlock(sb.encodedBlock);
+        const block = Codec.decode(sb.encodedBlock, Type.Block);
         const { forkCnt, height } = BlockUtils.getCoordinates(block);
         const participant = BlockUtils.getBlockAuthor(block);
         insertNestedMapWithOverwrite(
@@ -65,8 +65,9 @@ export default class QueueService {
     /*──────── Confirmation queue ────────*/
 
     queueConfirmation(blockConfirmation: BlockConfirmation): void {
-        const block = EvmUtils.decodeBlock(
-            blockConfirmation.originalSignedBlock.encodedBlock
+        const block = Codec.decode(
+            blockConfirmation.originalSignedBlock.encodedBlock,
+            Type.Block
         );
         const { forkCnt, height } = BlockUtils.getCoordinates(block);
         const confirmationSigner = EvmUtils.retrieveSignerAddressBlock(
@@ -104,7 +105,7 @@ export default class QueueService {
 
         const stored = this.blockQ.get(forkCnt)?.get(height)?.get(participant);
         return stored
-            ? stored.encodedBlock === EvmUtils.encodeBlock(block)
+            ? stored.encodedBlock === Codec.encode(block, Type.Block)
             : false;
     }
 }

--- a/src/evm/P2pSigner.ts
+++ b/src/evm/P2pSigner.ts
@@ -17,7 +17,7 @@ import {
 import { DisputeStruct } from "@typechain-types/contracts/V1/DataTypes";
 import Clock from "@/Clock";
 import P2PManager from "@/P2PManager";
-import { EvmUtils, Codec, SignatureUtils } from "@/utils";
+import { EvmUtils, Codec, SignatureUtils, Type } from "@/utils";
 
 class P2pSigner implements Signer {
     signer: Signer;
@@ -127,7 +127,7 @@ class P2pSigner implements Signer {
         this.p2pManager.stateManager.setChannelId(channelId);
     }
     public async confirmBlock(signedBlock: SignedBlockStruct) {
-        let block = EvmUtils.decodeBlock(signedBlock.encodedBlock);
+        let block = Codec.decode(signedBlock.encodedBlock, Type.Block);
         let signature = await SignatureUtils.signMsg(
             signedBlock.encodedBlock,
             this.signer
@@ -191,8 +191,10 @@ class P2pSigner implements Signer {
         };
 
         // Encode and sign the request
-        const encodedJoinChannel =
-            EvmUtils.encodeJoinChannel(joinChannelRequest);
+        const encodedJoinChannel = Codec.encode(
+            joinChannelRequest,
+            Type.JoinChannel
+        );
         const signedJoinChannel: SignedJoinChannelStruct = {
             encodedJoinChannel: encodedJoinChannel,
             signature: await this.signMessage(encodedJoinChannel)

--- a/src/rpc/services/JoinChannelService.ts
+++ b/src/rpc/services/JoinChannelService.ts
@@ -7,7 +7,7 @@ import {
     StateSnapshotStruct,
     ExitChannelBlockStruct
 } from "@typechain-types/contracts/V1/DataTypes";
-import { EvmUtils, SignatureCollectionMap } from "@/utils";
+import { Codec, EvmUtils, SignatureCollectionMap, Type } from "@/utils";
 import Clock from "@/Clock";
 import { getActiveParticipants } from "@/utils/participantUtils";
 import { BytesLike } from "ethers";
@@ -32,8 +32,9 @@ class JoinChannelService extends ARpcService {
     ) {
         try {
             const key = signedJoinChannel.encodedJoinChannel.toString();
-            const joinChannel = EvmUtils.decodeJoinChannel(
-                signedJoinChannel.encodedJoinChannel
+            const joinChannel = Codec.decode(
+                signedJoinChannel.encodedJoinChannel,
+                Type.JoinChannel
             );
 
             // Validate request timeframe
@@ -271,8 +272,9 @@ class JoinChannelService extends ARpcService {
     private async processCompletedJoinRequest(
         signedJoinChannel: SignedJoinChannelStruct
     ): Promise<void> {
-        const joinChannel = EvmUtils.decodeJoinChannel(
-            signedJoinChannel.encodedJoinChannel
+        const joinChannel = Codec.decode(
+            signedJoinChannel.encodedJoinChannel,
+            Type.JoinChannel
         );
 
         // 1. Check if we need to submit a state snapshot

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -165,7 +165,7 @@ class StateManager {
             signedBlock,
             Number(timestamp)
         );
-        let block = EvmUtils.decodeBlock(signedBlock.encodedBlock);
+        let block = Codec.decode(signedBlock.encodedBlock, Type.Block);
         let disputeProof: ProofStruct;
         if (flag == AgreementFlag.DOUBLE_SIGN) {
             console.log("StateManager - collectOnChainBlock - double sign");
@@ -263,7 +263,7 @@ class StateManager {
         let finalExecutionFlag: ExecutionFlags = ExecutionFlags.SUCCESS;
         let finalAgreementFlag: AgreementFlag | undefined = undefined;
         const decodedBlock =
-            block ?? EvmUtils.decodeBlock(signedBlock.encodedBlock);
+            block ?? Codec.decode(signedBlock.encodedBlock, Type.Block);
 
         try {
             await this.mutex.lock();
@@ -302,7 +302,7 @@ class StateManager {
     ): Promise<ExecutionFlags> {
         let finalExecutionFlag: ExecutionFlags = ExecutionFlags.SUCCESS; // Default to SUCCESS
         const decodedBlock =
-            block ?? EvmUtils.decodeBlock(signedBlock.encodedBlock);
+            block ?? Codec.decode(signedBlock.encodedBlock, Type.Block);
 
         try {
             const result =
@@ -783,7 +783,7 @@ class StateManager {
 
     // ----- Event handlers -----
     public async onDisputeCommitted(encodedDispute: string, timestamp: number) {
-        const dispute = Codec.decodeDispute(encodedDispute);
+        const dispute = Codec.decode(encodedDispute, Type.Dispute);
 
         // Validate dispute
         const valid = await this.validationService.validateDispute(
@@ -815,7 +815,10 @@ class StateManager {
     public async onDisputeConfirmation(
         signedDispute: SignedDisputeStruct
     ): Promise<ExecutionFlags> {
-        const dispute = Codec.decodeDispute(signedDispute.encodedDispute);
+        const dispute = Codec.decode(
+            signedDispute.encodedDispute,
+            Type.Dispute
+        );
 
         const { success, flag } =
             await this.validationService.validateDisputeConfirmation(

--- a/src/stateManager/ValidationService.ts
+++ b/src/stateManager/ValidationService.ts
@@ -49,7 +49,7 @@ export default class ValidationService {
         signedBlock: SignedBlockStruct,
         block?: BlockStruct
     ): Promise<ValidationResult> {
-        const blk = block ?? EvmUtils.decodeBlock(signedBlock.encodedBlock);
+        const blk = block ?? Codec.decode(signedBlock.encodedBlock, Type.Block);
         const forkCnt = BlockUtils.getFork(blk);
         const height = BlockUtils.getHeight(blk);
 
@@ -122,7 +122,7 @@ export default class ValidationService {
         confirmationSig: BytesLike,
         block?: BlockStruct
     ): Promise<ValidationResult> {
-        const blk = block ?? EvmUtils.decodeBlock(signed.encodedBlock);
+        const blk = block ?? Codec.decode(signed.encodedBlock, Type.Block);
 
         if (!this.isChannelOpen()) return notReady();
         if (!this.isSignedBlockAuthentic(signed, blk, this.getChannelId()))

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -2,6 +2,7 @@ import { BlockStruct } from "@typechain-types/contracts/V1/DataTypes";
 import { EvmUtils } from "./EvmUtils";
 import exp from "constants";
 import { AddressLike, SignatureLike } from "ethers";
+import { Codec, Type } from "./Codec";
 
 export class BlockUtils {
     /**
@@ -44,7 +45,7 @@ export class BlockUtils {
     }
 
     public static areBlocksEqual(b1: BlockStruct, b2: BlockStruct): boolean {
-        return EvmUtils.encodeBlock(b1) === EvmUtils.encodeBlock(b2);
+        return Codec.encode(b1, Type.Block) === Codec.encode(b2, Type.Block);
     }
 
     public static getSignerAddresses(

--- a/src/utils/Codec.ts
+++ b/src/utils/Codec.ts
@@ -23,15 +23,15 @@ type StructType =
 
 // Enum for better autocomplete and type safety
 export enum Type {
-    Block = "Block",
-    JoinChannel = "JoinChannel",
-    Transaction = "Transaction",
-    Dispute = "Dispute",
-    StateSnapshot = "StateSnapshot"
+    Block,
+    JoinChannel,
+    Transaction,
+    Dispute,
+    StateSnapshot
 }
 
 export class Codec {
-    private static readonly structToEthersType = new Map<string, any>([
+    private static readonly structToEthersType = new Map<Type, string>([
         [Type.Block, BlockEthersType],
         [Type.JoinChannel, JoinChannelEthersType],
         [Type.Transaction, TransactionEthersType],
@@ -39,22 +39,37 @@ export class Codec {
         [Type.StateSnapshot, StateSnapshotEthersType]
     ]);
 
-    // Only support explicit type encoding for better reliability
-    public static encode(struct: any, explicitType: Type): string {
-        const ethersType = this.structToEthersType.get(explicitType);
+    public static encode(struct: StructType, type: Type): string {
+        const ethersType = this.structToEthersType.get(type);
         if (!ethersType) {
-            throw new Error(`No ethers type mapping found for ${explicitType}`);
+            throw new Error(`No ethers type mapping found for ${type}`);
         }
         return ethers.AbiCoder.defaultAbiCoder().encode([ethersType], [struct]);
     }
 
+    // Function overloads for type safety
+    public static decode(encoded: BytesLike, type: Type.Block): BlockStruct;
+    public static decode(
+        encoded: BytesLike,
+        type: Type.JoinChannel
+    ): JoinChannelStruct;
+    public static decode(
+        encoded: BytesLike,
+        type: Type.Transaction
+    ): TransactionStruct;
+    public static decode(encoded: BytesLike, type: Type.Dispute): DisputeStruct;
+    public static decode(
+        encoded: BytesLike,
+        type: Type.StateSnapshot
+    ): StateSnapshotStruct;
+
     public static decode<T extends StructType>(
         encoded: BytesLike,
-        structName: string
+        type: Type
     ): T {
-        const ethersType = this.structToEthersType.get(structName);
+        const ethersType = this.structToEthersType.get(type);
         if (!ethersType) {
-            throw new Error(`No ethers type mapping found for ${structName}`);
+            throw new Error(`No ethers type mapping found for ${type}`);
         }
 
         const decoded = ethers.AbiCoder.defaultAbiCoder().decode(
@@ -86,22 +101,5 @@ export class Codec {
             }
         }
         return obj;
-    }
-
-    // Convenience methods with explicit types
-    public static decodeBlock(encoded: BytesLike): BlockStruct {
-        return this.decode(encoded, Type.Block);
-    }
-    public static decodeJoinChannel(encoded: BytesLike): JoinChannelStruct {
-        return this.decode(encoded, Type.JoinChannel);
-    }
-    public static decodeTransaction(encoded: BytesLike): TransactionStruct {
-        return this.decode(encoded, Type.Transaction);
-    }
-    public static decodeDispute(encoded: BytesLike): DisputeStruct {
-        return this.decode(encoded, Type.Dispute);
-    }
-    public static decodeStateSnapshot(encoded: BytesLike): StateSnapshotStruct {
-        return this.decode(encoded, Type.StateSnapshot);
     }
 }

--- a/src/utils/EvmUtils.ts
+++ b/src/utils/EvmUtils.ts
@@ -9,7 +9,6 @@ import {
 } from "@typechain-types/contracts/V1/DataTypes";
 
 import { SignatureUtils } from "./SignatureUtils";
-import { Codec, Type } from "./Codec";
 import { DisputeStruct } from "@typechain-types/contracts/V1/DisputeTypes";
 
 export class EvmUtils {
@@ -22,14 +21,6 @@ export class EvmUtils {
             signer
         );
         return { encodedTransaction: encoded, signature };
-    }
-
-    public static encodeBlock(block: BlockStruct): string {
-        return Codec.encode(block, Type.Block);
-    }
-
-    public static decodeBlock(blockEncoded: BytesLike): BlockStruct {
-        return Codec.decodeBlock(blockEncoded);
     }
 
     public static async signBlock(
@@ -61,12 +52,6 @@ export class EvmUtils {
         return SignatureUtils.getSignerAddressBlock(block, signature);
     }
 
-    public static encodeJoinChannel(jc: JoinChannelStruct): string {
-        return Codec.encode(jc, Type.JoinChannel);
-    }
-    public static decodeJoinChannel(jcEncoded: BytesLike): JoinChannelStruct {
-        return Codec.decodeJoinChannel(jcEncoded);
-    }
     public static async signJoinChannel(
         jc: JoinChannelStruct,
         signer: ethers.Signer
@@ -82,9 +67,5 @@ export class EvmUtils {
         signature: SignatureLike
     ): string {
         return SignatureUtils.getSignerAddressJoinChannel(jc, signature);
-    }
-    //empty arrays '[]' can exist but not empty objects {} - Etheres is really bad for this with the Result object
-    public static ethersResultToObjectRecursive(result: ethers.Result) {
-        return Codec.ethersResultToObjectRecursive(result);
     }
 }

--- a/test/client/DisputeHandler.test.ts
+++ b/test/client/DisputeHandler.test.ts
@@ -8,6 +8,7 @@ import AgreementManager from "@/agreementManager";
 import P2pEventHooks from "@/P2pEventHooks";
 import { EvmUtils } from "@/utils/EvmUtils";
 import * as factory from "../factory";
+import { Codec, Type } from "@/utils";
 
 describe("DisputeHandler", () => {
     let disputeHandler: DisputeHandler;
@@ -66,7 +67,7 @@ describe("DisputeHandler", () => {
                 })
             });
             const signedBlock: SignedBlockStruct = {
-                encodedBlock: EvmUtils.encodeBlock(mockBlock),
+                encodedBlock: Codec.encode(mockBlock, Type.Block),
                 signature: factory.signature()
             };
 
@@ -92,7 +93,7 @@ describe("DisputeHandler", () => {
                 })
             });
             const signedBlock: SignedBlockStruct = {
-                encodedBlock: EvmUtils.encodeBlock(mockBlock),
+                encodedBlock: Codec.encode(mockBlock, Type.Block),
                 signature: factory.signature()
             };
 

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -3,10 +3,12 @@ import {
     BlockStruct,
     TransactionStruct,
     TransactionHeaderStruct,
-    TransactionBodyStruct
+    TransactionBodyStruct,
+    JoinChannelStruct
 } from "@typechain-types/contracts/V1/DataTypes";
 import AgreementManager from "@/agreementManager";
 import { DisputeStruct } from "@typechain-types/contracts/V1/DisputeTypes";
+import { randomInt } from "crypto";
 
 /**
  * Creates a default transaction header
@@ -121,9 +123,7 @@ export function signature(): string {
  * @param overrides Optional override values for the dispute fields
  * @returns A DisputeStruct with default values and any provided overrides
  */
-export function disputeStruct(
-    overrides: Partial<DisputeStruct> = {}
-): DisputeStruct {
+export function dispute(overrides: Partial<DisputeStruct> = {}): DisputeStruct {
     const defaultDispute: DisputeStruct = {
         channelId: ethers.hexlify(ethers.zeroPadBytes("0x00", 32)),
         genesisStateSnapshotHash: ethers.hexlify(ethers.randomBytes(32)),
@@ -156,4 +156,20 @@ export function disputeStruct(
     };
 
     return { ...defaultDispute, ...overrides };
+}
+
+export function joinChannel(
+    overrides: Partial<JoinChannelStruct> = {}
+): JoinChannelStruct {
+    const defaultJoinChannel: JoinChannelStruct = {
+        channelId: ethers.hexlify(ethers.zeroPadBytes("0x00", 32)),
+        participant: ethers.Wallet.createRandom().address,
+        balance: {
+            amount: BigInt(randomInt(1, 100)),
+            data: ethers.hexlify(ethers.randomBytes(32))
+        },
+        deadlineTimestamp: BigInt(randomInt(1, 100))
+    };
+
+    return { ...defaultJoinChannel, ...overrides };
 }

--- a/test/utils/Codec.test.ts
+++ b/test/utils/Codec.test.ts
@@ -1,0 +1,58 @@
+import { expect } from "chai";
+import { Codec, Type } from "@/utils/Codec";
+
+import * as factory from "../factory";
+
+describe("Codec", () => {
+    describe("Round-trip encoding/decoding: decode(encode(T)) === T", () => {
+        it("should encode and decode BlockStruct correctly", () => {
+            const original = factory.block();
+            const encoded = Codec.encode(original, Type.Block);
+            const decoded = Codec.decode(encoded, Type.Block);
+
+            expect(decoded).to.deep.equal(original);
+        });
+
+        it("should encode and decode JoinChannelStruct correctly", () => {
+            const original = factory.joinChannel();
+
+            const encoded = Codec.encode(original, Type.JoinChannel);
+            const decoded = Codec.decode(encoded, Type.JoinChannel);
+
+            expect(decoded).to.deep.equal(original);
+        });
+
+        it("should encode and decode TransactionStruct correctly", () => {
+            const original = factory.transaction();
+
+            const encoded = Codec.encode(original, Type.Transaction);
+            const decoded = Codec.decode(encoded, Type.Transaction);
+
+            expect(decoded).to.deep.equal(original);
+        });
+
+        it("should encode and decode DisputeStruct correctly", () => {
+            const original = factory.dispute();
+
+            const encoded = Codec.encode(original, Type.Dispute);
+            const decoded = Codec.decode(encoded, Type.Dispute);
+
+            expect(decoded).to.deep.equal(original);
+        });
+
+        describe("Error handling", () => {
+            it("should throw error for invalid type in encode", () => {
+                expect(() => {
+                    // @ts-expect-error - testing invalid type
+                    Codec.encode({}, 999 as Type);
+                }).to.throw("No ethers type mapping found");
+            });
+
+            it("should throw error for invalid encoded data", () => {
+                expect(() => {
+                    Codec.decode("0xinvaliddata", Type.Block);
+                }).to.throw();
+            });
+        });
+    });
+});


### PR DESCRIPTION

refactored Codec once again, now offers a symmetric, nice interface, including type safety on the decoded struct

```ts
// this is a string
const encoded = Codec.encode(original, Type.Block); 
// this is a BlockStruct
const decoded = Codec.decode(encoded, Type.Block);
```

removed all use of `EvmUtils` for codec tasks