### PR TITLE
Disputes CRDT - PR 7

### DIFF
--- a/contracts/V1/StateChannelDiamondProxy/AStateChannelManagerProxy.sol
+++ b/contracts/V1/StateChannelDiamondProxy/AStateChannelManagerProxy.sol
@@ -1,13 +1,13 @@
 pragma solidity ^0.8.8;
 
 import "./StateChannelCommon.sol";
+import "../StateChannelManagerInterface.sol";
+import "./StateChannelUtilLibrary.sol";
+
 import "./DisputeManagerFacet.sol";
 import "./FraudProofFacet.sol";
 import "./DisputeFraudProofFacet.sol";
-
-import "./StateChannelUtilLibrary.sol";
 import "./StateSnapshotFacet.sol";
-import "../StateChannelManagerInterface.sol";
 import "./JoinChannelFacet.sol";
 
 abstract contract AStateChannelManagerProxy is StateChannelManagerInterface, StateChannelCommon {
@@ -38,107 +38,7 @@ abstract contract AStateChannelManagerProxy is StateChannelManagerInterface, Sta
         killTime = 60;
     }
 
-    function _addParticipantComposable(JoinChannel memory joinChannel) internal virtual returns (bool);
-
-    function _removeParticipantComposable(bytes32 channelId, ExitChannel memory exitChannel)
-        internal
-        virtual
-        returns (bool);
-
-    function addParticipantComposable(JoinChannel memory joinChannel) public onlySelf returns (bool) {
-        return _addParticipantComposable(joinChannel);
-    }
-
-    function removeParticipantComposable(bytes32 channelId, ExitChannel memory exitChannel)
-        public
-        onlySelf
-        returns (bool)
-    {
-        return _removeParticipantComposable(channelId, exitChannel);
-    }
-
-    function applyJoinChannelToStateMachine(bytes memory encodedState, JoinChannel[] memory joinCahnnels)
-        public
-        override
-        onlySelf
-        returns (bytes memory encodedModifiedState)
-    {
-        return _applyJoinChannelToStateMachine(encodedState, joinCahnnels);
-    }
-
-    function applySlashesToStateMachine(bytes memory encodedState, address[] memory slashedParticipants)
-        public
-        onlySelf
-        returns (bytes memory encodedModifiedState, ExitChannel[] memory)
-    {
-        return _applySlashesToStateMachine(encodedState, slashedParticipants);
-    }
-
-    function removeParticipantsFromStateMachine(bytes memory encodedState, address[] memory participants)
-        public
-        onlySelf
-        returns (bytes memory encodedModifiedState, ExitChannel[] memory)
-    {
-        return _removeParticipantsFromStateMachine(encodedState, participants);
-    }
-
-    function _applyJoinChannelToStateMachine(bytes memory encodedState, JoinChannel[] memory joinCahnnels)
-        internal
-        returns (bytes memory encodedModifiedState)
-    {
-        stateMachineImplementation.setState(encodedState);
-        for (uint256 i = 0; i < joinCahnnels.length; i++) {
-            bool success = stateMachineImplementation.joinChannel(joinCahnnels[i]);
-            // require(success, "Slash failed");
-            require(success, ErrorDisputeStateMachineJoiningFailed());
-        }
-        return (stateMachineImplementation.getState());
-    }
-
-    function _applySlashesToStateMachine(bytes memory encodedState, address[] memory slashedParticipants)
-        internal
-        override
-        returns (bytes memory encodedModifiedState, ExitChannel[] memory exitChannels)
-    {
-        exitChannels = new ExitChannel[](slashedParticipants.length);
-        stateMachineImplementation.setState(encodedState);
-        for (uint256 i = 0; i < slashedParticipants.length; i++) {
-            bool success;
-            (success, exitChannels[i]) = stateMachineImplementation.slashParticipant(slashedParticipants[i]);
-            // require(success, "Slash failed");
-            require(success, ErrorDisputeStateMachineSlashingFailed());
-        }
-        return (stateMachineImplementation.getState(), exitChannels);
-    }
-
-    function _removeParticipantsFromStateMachine(bytes memory encodedState, address[] memory participants)
-        internal
-        override
-        returns (bytes memory encodedModifiedState, ExitChannel[] memory)
-    {
-        ExitChannel[] memory exitChannels = new ExitChannel[](participants.length);
-        stateMachineImplementation.setState(encodedState);
-        for (uint256 i = 0; i < participants.length; i++) {
-            bool success;
-            (success, exitChannels[i]) = stateMachineImplementation.removeParticipant(participants[i]);
-            // require(success, "Remove failed");
-            require(success, ErrorDisputeStateMachineRemovingFailed());
-        }
-        return (stateMachineImplementation.getState(), exitChannels);
-    }
-
-    function executeStateTransitionOnState(bytes32 channelId, bytes memory encodedState, Transaction memory _tx)
-        public
-        override
-        returns (bool, bytes memory)
-    {
-        //channelId not used currenlty since all channels have the same SM - later they can be mapped to different ones
-        stateMachineImplementation.setState(encodedState);
-        (bool success,) =
-            address(stateMachineImplementation).call(abi.encodeCall(stateMachineImplementation.stateTransition, _tx));
-        return (success, stateMachineImplementation.getState());
-        // return (success, abi.decode(encodedReturnValue, (bytes)));
-    }
+    // ********** public/external functions **********
 
     /**
      * Posting calldata is lightweight, since it persists a signle hash/commitment.
@@ -170,20 +70,6 @@ abstract contract AStateChannelManagerProxy is StateChannelManagerInterface, Sta
         emit BlockCalldataPosted(_block.transaction.header.channelId, msg.sender, signedBlock, block.timestamp);
     }
 
-    function _delegatecall(address target, bytes memory data) internal returns (bytes memory) {
-        (bool success, bytes memory result) = target.delegatecall(data);
-        if (!success) {
-            if (result.length == 0) {
-                revert("AStateChannelManagerProxy - Delegatecall failed");
-            }
-            assembly ("memory-safe") {
-                let returndata_size := mload(result)
-                revert(add(32, result), returndata_size)
-            }
-        }
-        return result;
-    }
-
     function uploadDispute(DisputeConfirmation memory disputeConfirmation) public override {
         _delegatecall(
             address(disputeManagerFacet), abi.encodeCall(disputeManagerFacet.uploadDispute, (disputeConfirmation))
@@ -210,6 +96,16 @@ abstract contract AStateChannelManagerProxy is StateChannelManagerInterface, Sta
         return slashedParticipants;
     }
 
+    function uploadDisputeWithCalldata(
+        DisputeConfirmation memory disputeConfirmation,
+        DisputeAuditingData memory disputeAuditingData
+    ) public override {
+        _delegatecall(
+            address(disputeManagerFacet),
+            abi.encodeCall(disputeManagerFacet.uploadDisputeWithCalldata, (disputeConfirmation, disputeAuditingData))
+        );
+    }
+
     function uploadDisputeAndAudit(
         DisputeConfirmation memory disputeConfirmation,
         DisputeAuditingData memory disputeAuditingData
@@ -225,6 +121,84 @@ abstract contract AStateChannelManagerProxy is StateChannelManagerInterface, Sta
             address(disputeManagerFacet),
             abi.encodeCall(disputeManagerFacet.challengeDispute, (dispute, disputeAuditingData))
         );
+    }
+
+    function applyDisputeFraudProofs(DisputeFraudProof[] memory proofs) public override {
+        _delegatecall(
+            address(disputeManagerFacet), abi.encodeCall(disputeManagerFacet.applyDisputeFraudProofs, (proofs))
+        );
+    }
+
+    function updateStateSnapshotFork(
+        bytes32 channelId,
+        StateSnapshot memory newStateSnapshot,
+        ExitChannelBlock[] memory exitChannelBlocks
+    ) public override {
+        _delegatecall(
+            address(stateSnapshotFacet),
+            abi.encodeCall(stateSnapshotFacet.updateStateSnapshotFork, (channelId, newStateSnapshot, exitChannelBlocks))
+        );
+    }
+
+    function updateStateSnapshotSameFork(
+        bytes32 channelId,
+        MilestoneProof[] memory milestoneProofs,
+        StateSnapshot[] memory milestoneSnapshots,
+        ExitChannelBlock[] memory exitChannelBlocks
+    ) public override {
+        _delegatecall(
+            address(stateSnapshotFacet),
+            abi.encodeCall(
+                stateSnapshotFacet.updateStateSnapshotSameFork,
+                (channelId, milestoneProofs, milestoneSnapshots, exitChannelBlocks)
+            )
+        );
+    }
+
+    function joinChannel(JoinChannelConfirmation memory joinChannelConfirmations) public override {
+        _delegatecall(
+            address(joinChannelFacet), abi.encodeCall(joinChannelFacet.joinChannel, (joinChannelConfirmations))
+        );
+    }
+
+    // ********** public/external DIAMOND functions **********
+
+    /// @dev Callable only by diamond facets - performs the deposit of the specific assets by interpeting `joinChannel` - returns bool success
+    function depositAssetsComposable(JoinChannel memory joinChannel) public onlySelf returns (bool) {
+        return _depositAssetsComposable(joinChannel);
+    }
+
+    /// @dev Callable only by diamond facets - performs the withdrawal of the specific assets by interpeting `exitChannel` - returns bool success
+    function withdrawAssetsComposable(ExitChannel memory exitChannel) public onlySelf returns (bool) {
+        return _withdrawAssetsComposable(exitChannel);
+    }
+
+    function applySlashesToStateMachine(bytes memory encodedState, address[] memory slashedParticipants)
+        public
+        onlySelf
+        returns (bytes memory encodedModifiedState, ExitChannel[] memory)
+    {
+        return _applySlashesToStateMachine(encodedState, slashedParticipants);
+    }
+
+    function removeParticipantsFromStateMachine(bytes memory encodedState, address[] memory participants)
+        public
+        onlySelf
+        returns (bytes memory encodedModifiedState, ExitChannel[] memory)
+    {
+        return _removeParticipantsFromStateMachine(encodedState, participants);
+    }
+
+    function executeStateTransition(bytes32 channelId, bytes memory encodedState, Transaction memory _tx)
+        public
+        override
+        returns (bool, bytes memory encodedModifiedState)
+    {
+        //channelId not used currenlty since all channels have the same SM - later they can be mapped to different ones
+        stateMachineImplementation.setState(encodedState);
+        (bool success,) =
+            address(stateMachineImplementation).call(abi.encodeCall(stateMachineImplementation.stateTransition, _tx));
+        return (success, stateMachineImplementation.getState());
     }
 
     function verifyFraudProofs(
@@ -256,14 +230,6 @@ abstract contract AStateChannelManagerProxy is StateChannelManagerInterface, Sta
         returns (address[] memory)
     {
         return getSnapshotParticipants(channelId);
-    }
-
-    function getNextToWrite(bytes32 channelId, bytes memory encodedState)
-        public
-        override(StateChannelCommon, StateChannelManagerInterface)
-        returns (address)
-    {
-        return StateChannelCommon.getNextToWrite(channelId, encodedState);
     }
 
     function getP2pTime() public view override(StateChannelCommon, StateChannelManagerInterface) returns (uint256) {
@@ -328,32 +294,6 @@ abstract contract AStateChannelManagerProxy is StateChannelManagerInterface, Sta
         return StateChannelCommon.isChannelOpen(channelId);
     }
 
-    function updateStateSnapshotFork(
-        bytes32 channelId,
-        StateSnapshot memory newStateSnapshot,
-        ExitChannelBlock[] memory exitChannelBlocks
-    ) public override {
-        _delegatecall(
-            address(stateSnapshotFacet),
-            abi.encodeCall(stateSnapshotFacet.updateStateSnapshotFork, (channelId, newStateSnapshot, exitChannelBlocks))
-        );
-    }
-
-    function updateStateSnapshotSameFork(
-        bytes32 channelId,
-        MilestoneProof[] memory milestoneProofs,
-        StateSnapshot[] memory milestoneSnapshots,
-        ExitChannelBlock[] memory exitChannelBlocks
-    ) public override {
-        _delegatecall(
-            address(stateSnapshotFacet),
-            abi.encodeCall(
-                stateSnapshotFacet.updateStateSnapshotSameFork,
-                (channelId, milestoneProofs, milestoneSnapshots, exitChannelBlocks)
-            )
-        );
-    }
-
     function verifyMilestones(
         MilestoneProof[] memory milestoneProofs,
         StateSnapshot[] memory milestoneSnapshots,
@@ -364,12 +304,6 @@ abstract contract AStateChannelManagerProxy is StateChannelManagerInterface, Sta
             abi.encodeCall(disputeManagerFacet.verifyMilestones, (milestoneProofs, milestoneSnapshots, genesisSnapshot))
         );
         return abi.decode(result, (bool, bytes));
-    }
-
-    function joinChannel(JoinChannelConfirmation memory joinChannelConfirmations) public override {
-        _delegatecall(
-            address(joinChannelFacet), abi.encodeCall(joinChannelFacet.joinChannel, (joinChannelConfirmations))
-        );
     }
 
     function multicall(bytes[] calldata calls) external override returns (bytes[] memory results) {
@@ -384,5 +318,56 @@ abstract contract AStateChannelManagerProxy is StateChannelManagerInterface, Sta
             }
             results[i] = result;
         }
+    }
+
+    // ********** private/internal functions **********
+
+    function _depositAssetsComposable(JoinChannel memory joinChannel) internal virtual returns (bool);
+
+    function _withdrawAssetsComposable(ExitChannel memory exitChannel) internal virtual returns (bool);
+
+    function _applySlashesToStateMachine(bytes memory encodedState, address[] memory slashedParticipants)
+        internal
+        override
+        returns (bytes memory encodedModifiedState, ExitChannel[] memory exitChannels)
+    {
+        exitChannels = new ExitChannel[](slashedParticipants.length);
+        stateMachineImplementation.setState(encodedState);
+        for (uint256 i = 0; i < slashedParticipants.length; i++) {
+            bool success;
+            (success, exitChannels[i]) = stateMachineImplementation.slashParticipant(slashedParticipants[i]);
+            require(success, ErrorDisputeStateMachineSlashingFailed());
+        }
+        return (stateMachineImplementation.getState(), exitChannels);
+    }
+
+    function _removeParticipantsFromStateMachine(bytes memory encodedState, address[] memory participants)
+        internal
+        override
+        returns (bytes memory encodedModifiedState, ExitChannel[] memory)
+    {
+        ExitChannel[] memory exitChannels = new ExitChannel[](participants.length);
+        stateMachineImplementation.setState(encodedState);
+        for (uint256 i = 0; i < participants.length; i++) {
+            bool success;
+            (success, exitChannels[i]) = stateMachineImplementation.removeParticipant(participants[i]);
+            // require(success, "Remove failed");
+            require(success, ErrorDisputeStateMachineRemovingFailed());
+        }
+        return (stateMachineImplementation.getState(), exitChannels);
+    }
+
+    function _delegatecall(address target, bytes memory data) internal returns (bytes memory) {
+        (bool success, bytes memory result) = target.delegatecall(data);
+        if (!success) {
+            if (result.length == 0) {
+                revert("AStateChannelManagerProxy - Delegatecall failed");
+            }
+            assembly ("memory-safe") {
+                let returndata_size := mload(result)
+                revert(add(32, result), returndata_size)
+            }
+        }
+        return result;
     }
 }

--- a/contracts/V1/StateChannelDiamondProxy/AStateChannelManagerProxy.sol
+++ b/contracts/V1/StateChannelDiamondProxy/AStateChannelManagerProxy.sol
@@ -8,25 +8,29 @@ import "./DisputeFraudProofFacet.sol";
 import "./StateChannelUtilLibrary.sol";
 import "./StateSnapshotFacet.sol";
 import "../StateChannelManagerInterface.sol";
+import "./JoinChannelFacet.sol";
 
 abstract contract AStateChannelManagerProxy is StateChannelManagerInterface, StateChannelCommon {
     DisputeManagerFacet disputeManagerFacet;
     FraudProofFacet fraudProofFacet;
     DisputeFraudProofFacet disputeFraudProofFacet;
     StateSnapshotFacet stateSnapshotFacet;
+    JoinChannelFacet joinChannelFacet;
 
     constructor(
         address _stateMachineImplementation,
         address _disputeManagerFacet,
         address _fraudProofFacet,
         address _disputeFraudProofFacet,
-        address _stateSnapshotFacet
+        address _stateSnapshotFacet,
+        address _joinChannelFacet
     ) {
         stateMachineImplementation = AStateMachine(_stateMachineImplementation);
         disputeManagerFacet = DisputeManagerFacet(_disputeManagerFacet);
         fraudProofFacet = FraudProofFacet(_fraudProofFacet);
         disputeFraudProofFacet = DisputeFraudProofFacet(_disputeFraudProofFacet);
         stateSnapshotFacet = StateSnapshotFacet(_stateSnapshotFacet);
+        joinChannelFacet = JoinChannelFacet(_joinChannelFacet);
         p2pTime = 15;
         agreementTime = 5;
         chainFallbackTime = 30;
@@ -360,5 +364,25 @@ abstract contract AStateChannelManagerProxy is StateChannelManagerInterface, Sta
             abi.encodeCall(disputeManagerFacet.verifyMilestones, (milestoneProofs, milestoneSnapshots, genesisSnapshot))
         );
         return abi.decode(result, (bool, bytes));
+    }
+
+    function joinChannel(JoinChannelConfirmation memory joinChannelConfirmations) public override {
+        _delegatecall(
+            address(joinChannelFacet), abi.encodeCall(joinChannelFacet.joinChannel, (joinChannelConfirmations))
+        );
+    }
+
+    function multicall(bytes[] calldata calls) external override returns (bytes[] memory results) {
+        results = new bytes[](calls.length);
+        for (uint256 i = 0; i < calls.length; i++) {
+            (bool success, bytes memory result) = address(this).delegatecall(calls[i]);
+            if (!success) {
+                // Bubble up the revert reason
+                assembly {
+                    revert(add(result, 32), mload(result))
+                }
+            }
+            results[i] = result;
+        }
     }
 }

--- a/contracts/V1/StateChannelDiamondProxy/DisputeFraudProofFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeFraudProofFacet.sol
@@ -5,6 +5,7 @@ import "./AStateChannelManagerProxy.sol";
 import "./StateChannelUtilLibrary.sol";
 import "./Errors.sol";
 import "../types/DisputeFraudProofTypes.sol";
+import "./utils/DisputeUtils.sol";
 
 contract DisputeFraudProofFacet is StateChannelCommon {
     mapping(
@@ -15,8 +16,17 @@ contract DisputeFraudProofFacet is StateChannelCommon {
     constructor() {
         //If we endup having too many fraud proofs, we'll refactor them into a seperate 'facet' (ERC-2535)
         proofHandlers[DisputeFraudProofType.TimeoutThreshold] = _handleTimeoutThreshold;
-        proofHandlers[DisputeFraudProofType.TimeoutPriorInvalid] = _handleTimeoutPriorInvalid;
+        proofHandlers[DisputeFraudProofType.TimeoutCalldataPosted] = _handleTimeoutCalldataPosted;
+        proofHandlers[DisputeFraudProofType.TimeoutParticipantNotNext] = _handleTimeoutParticipantNotNext;
+        proofHandlers[DisputeFraudProofType.TimeoutTooEarly] = _handleTimeoutTooEarly;
+        proofHandlers[DisputeFraudProofType.DisputeNotLatestState] = _handleDisputeNotLatestState;
+        proofHandlers[DisputeFraudProofType.DisputeInvalid] = _handleDisputeInvalid;
+        proofHandlers[DisputeFraudProofType.DisputeInvalidRecursive] = _handleDisputeInvalidRecursive;
+        proofHandlers[DisputeFraudProofType.DisputeOutOfGas] = _handleDisputeOutOfGas;
+        proofHandlers[DisputeFraudProofType.DisputeInvalidOutputState] = _handleDisputeInvalidOutputState;
+        proofHandlers[DisputeFraudProofType.DisputeInvalidStateProof] = _handleDisputeInvalidStateProof;
         proofHandlers[DisputeFraudProofType.DisputeInvalidPreviousRecursive] = _handleDisputeInvalidPreviousRecursive;
+        proofHandlers[DisputeFraudProofType.DisputeInvalidExitChannelBlocks] = _handleDisputeInvalidExitChannelBlocks;
     }
 
     //This is a bit inefficient, since public/external functions always do a deep copy unlike internal/private that pas by reference, but this shares the context
@@ -51,11 +61,155 @@ contract DisputeFraudProofFacet is StateChannelCommon {
         view
         returns (address)
     {
+        TimeoutThresholdProof memory timeoutThresholdProof = abi.decode(encodedFraudProof, (TimeoutThresholdProof));
+        SignedBlock memory signedBlock = timeoutThresholdProof.thresholdBlock.signedBlock;
+        bytes memory encodedBlock = signedBlock.encodedBlock;
+        Block memory thresholdBlock = abi.decode(encodedBlock, (Block));
+
+        // Check channelId
+        if (!_areDisputeAndBlockSameChannel(dispute, thresholdBlock)) revert();
+
+        // Check forkId
+        if (!_areDisputeAndBlockSameFork(dispute, thresholdBlock)) revert();
+
+        // Check timeout == thresholdBlock
+        if (dispute.timeout.blockHeight != _getBlockHeight(thresholdBlock)) revert();
+
+        //check correct snapshot
+        if (!_doesBlockCommitToSnapshot(thresholdBlock, timeoutThresholdProof.latestStateSnapshot)) revert();
+
+        //check threshold
+        address[] memory thresholdParticipants = timeoutThresholdProof.latestStateSnapshot.snapshotData.participants;
+        bytes[] memory signatures = StateChannelUtilLibrary.insertBytesInByteArray(
+            signedBlock.signature, timeoutThresholdProof.thresholdBlock.signatures
+        );
+        (bool isValid,) = StateChannelUtilLibrary.verifyThresholdSigned(thresholdParticipants, encodedBlock, signatures);
+        if (!isValid) revert();
+
+        return dispute.disputer;
+    }
+
+    function _handleTimeoutCalldataPosted(bytes memory encodedFraudProof, Dispute memory dispute)
+        internal
+        view
+        returns (address)
+    {
+        TimeoutCalldataPostedProof memory timeoutCalldataPostedProof =
+            abi.decode(encodedFraudProof, (TimeoutCalldataPostedProof));
+        Block memory postedBlock = timeoutCalldataPostedProof.postedBlock;
+
+        // Check channelId
+        if (!_areDisputeAndBlockSameChannel(dispute, postedBlock)) revert();
+
+        // Check forkId
+        if (!_areDisputeAndBlockSameFork(dispute, postedBlock)) revert();
+
+        // Check timeout == postedBlock
+        if (dispute.timeout.blockHeight != _getBlockHeight(postedBlock)) revert();
+
+        // Check timeout participant == block author
+        if (dispute.timeout.participant != _getBlockAuthor(postedBlock)) revert();
+
+        // Check block calldata posted
+        (bool isFound,) = getBlockCallDataCommitment(
+            _getDisputeChannel(dispute),
+            _getDisputeFork(dispute),
+            dispute.timeout.blockHeight,
+            dispute.timeout.participant
+        );
+        if (!isFound) revert();
+
+        return dispute.disputer;
+    }
+
+    function _handleTimeoutParticipantNotNext(bytes memory encodedFraudProof, Dispute memory dispute)
+        internal
+        view
+        returns (address)
+    {
+        //Can be part of auditing instead of doing it here
+        Block memory latestBlock = _getLatestBlock(dispute.stateProof);
+        if (_getBlockAuthor(latestBlock) == dispute.timeout.participant) revert();
+
+        return dispute.disputer;
+    }
+
+    function _handleTimeoutTooEarly(bytes memory encodedFraudProof, Dispute memory dispute)
+        internal
+        view
+        returns (address)
+    {
         //TODO
         return dispute.disputer;
     }
 
-    function _handleTimeoutPriorInvalid(bytes memory encodedFraudProof, Dispute memory dispute)
+    function _handleDisputeNotLatestState(bytes memory encodedFraudProof, Dispute memory dispute)
+        internal
+        view
+        returns (address)
+    {
+        DisputeNotLatestStateProof memory disputeNotLatestStateProof =
+            abi.decode(encodedFraudProof, (DisputeNotLatestStateProof));
+        Block memory newerBlock = abi.decode(disputeNotLatestStateProof.encodedBlock, (Block));
+        Block memory latestBlock = _getLatestBlock(dispute.stateProof);
+
+        // Check channelId
+        if (!_areDisputeAndBlockSameChannel(dispute, newerBlock) || !_areBlocksSameChannel(newerBlock, latestBlock)) {
+            revert();
+        }
+
+        // Check forkId
+        if (!_areDisputeAndBlockSameFork(dispute, newerBlock) || !_areBlocksSameFork(newerBlock, latestBlock)) revert();
+
+        // Check is block newer
+        if (_getBlockHeight(newerBlock) <= _getBlockHeight(latestBlock)) revert();
+
+        // Check siganture
+        address retrivedAddress = StateChannelUtilLibrary.retriveSignerAddress(
+            disputeNotLatestStateProof.encodedBlock, disputeNotLatestStateProof.signature
+        );
+        if (retrivedAddress != dispute.disputer) revert();
+
+        return dispute.disputer;
+    }
+
+    function _handleDisputeInvalid(bytes memory encodedFraudProof, Dispute memory dispute)
+        internal
+        view
+        returns (address)
+    {
+        //TODO
+        return dispute.disputer;
+    }
+
+    function _handleDisputeInvalidRecursive(bytes memory encodedFraudProof, Dispute memory dispute)
+        internal
+        view
+        returns (address)
+    {
+        //TODO
+        return dispute.disputer;
+    }
+
+    function _handleDisputeOutOfGas(bytes memory encodedFraudProof, Dispute memory dispute)
+        internal
+        view
+        returns (address)
+    {
+        //TODO
+        return dispute.disputer;
+    }
+
+    function _handleDisputeInvalidOutputState(bytes memory encodedFraudProof, Dispute memory dispute)
+        internal
+        view
+        returns (address)
+    {
+        //TODO
+        return dispute.disputer;
+    }
+
+    function _handleDisputeInvalidStateProof(bytes memory encodedFraudProof, Dispute memory dispute)
         internal
         view
         returns (address)
@@ -65,6 +219,15 @@ contract DisputeFraudProofFacet is StateChannelCommon {
     }
 
     function _handleDisputeInvalidPreviousRecursive(bytes memory encodedFraudProof, Dispute memory dispute)
+        internal
+        view
+        returns (address)
+    {
+        //TODO
+        return dispute.disputer;
+    }
+
+    function _handleDisputeInvalidExitChannelBlocks(bytes memory encodedFraudProof, Dispute memory dispute)
         internal
         view
         returns (address)
@@ -123,54 +286,6 @@ contract DisputeFraudProofFacet is StateChannelCommon {
     //     }
     //     // If calldata check also fails, return false with the last error message
     //     return originalTimedOutDispute.disputer;
-    // }
-
-    // function _handleTimeoutPriorInvalid(
-    //     bytes memory encodedProof,
-    //     FraudProofVerificationContext memory fraudProofVerificationContext
-    // ) internal view returns (address) {
-    //     TimeoutPriorInvalidProof memory timeoutPriorInvalidProof = abi.decode(encodedProof, (TimeoutPriorInvalidProof));
-    //     Dispute memory originalDispute = timeoutPriorInvalidProof.originalDispute;
-    //     Dispute memory recursiveDispute = timeoutPriorInvalidProof.recursiveDispute;
-
-    //     if (
-    //         recursiveDispute.channelId != originalDispute.channelId
-    //             && recursiveDispute.channelId != fraudProofVerificationContext.channelId
-    //     ) {
-    //         revert ErrorNotSameChannelId();
-    //     }
-    //     // check if the recursive dispute is available
-    //     bytes32 recursiveDisputeCommitment =
-    //         keccak256(abi.encode(recursiveDispute, timeoutPriorInvalidProof.recursiveDisputeTimestamp));
-    //     bytes32 originalDisputeCommitment =
-    //         keccak256(abi.encode(originalDispute, timeoutPriorInvalidProof.originalDisputeTimestamp));
-
-    //     (bool isAvailable, bytes32 commitment) =
-    //         getDisputeCommitment(fraudProofVerificationContext.channelId, recursiveDispute.disputeIndex);
-
-    //     if (!isAvailable && commitment != recursiveDisputeCommitment) {
-    //         revert ErrorDisputeCommitmentNotAvailable();
-    //     }
-    //     if (
-    //         recursiveDispute.previousRecursiveDisputeIndex == type(uint256).max
-    //             || recursiveDispute.previousRecursiveDisputeIndex == originalDispute.disputeIndex
-    //     ) {
-    //         revert ErrorDisputeCommitmentNotAvailable();
-    //     }
-
-    //     // check if the previous recursive dispute is available
-    //     (bool isOriginalDisputeAvailable, bytes32 originalCommitment) =
-    //         getDisputeCommitment(fraudProofVerificationContext.channelId, originalDispute.disputeIndex);
-    //     if (!isOriginalDisputeAvailable && originalCommitment != originalDisputeCommitment) {
-    //         revert ErrorDisputeCommitmentNotAvailable();
-    //     }
-
-    //     // check if the original timeout is greater than the recursive timeout
-    //     if (originalDispute.timeout.blockHeight <= recursiveDispute.timeout.blockHeight) {
-    //         revert ErrorInvalidBlock();
-    //     }
-
-    //     return recursiveDispute.disputer;
     // }
 
     // ------------------------------------ Dispute Fraud Proofs ------------------------------------

--- a/contracts/V1/StateChannelDiamondProxy/DisputeManagerFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeManagerFacet.sol
@@ -4,53 +4,23 @@ import "./StateChannelCommon.sol";
 import "./AStateChannelManagerProxy.sol";
 import "./StateChannelUtilLibrary.sol";
 import "./Errors.sol";
+import "./utils/DisputeUtils.sol";
 
 contract DisputeManagerFacet is StateChannelCommon {
     function uploadDispute(DisputeConfirmation memory disputeConfirmation) public {
+        _uploadDispute(disputeConfirmation, false);
+    }
+
+    function uploadDisputeWithCalldata(
+        DisputeConfirmation memory disputeConfirmation,
+        DisputeAuditingData memory disputeAuditingData
+    ) public {
         Dispute memory dispute = abi.decode(disputeConfirmation.signedDispute.encodedDispute, (Dispute));
-        require(msg.sender == dispute.disputer, ErrorDisputerNotMsgSender());
-        require(_canParticipateInDisputes(dispute.channelId, msg.sender), ErrorCantParticipateInDispute());
-
-        // race condition checks
-        _disputeRaceConditionCheck(dispute);
-
-        DisputeData storage disputeData = disputeData[dispute.channelId];
-        mapping(bytes32 forkId => DisputeWindow) storage disputeWindowMap = disputeData.disputeWindowMap;
-        bytes32 forkId = dispute.genesisSnapshotDataHash;
-        DisputeWindow storage disputeWindow = disputeWindowMap[forkId];
-        bool isThresholdFinal = _isDisputeThresholdFinal(disputeConfirmation);
-        bool isAuditingRequired;
-        if (!isThresholdFinal) {
-            require(!_isAuditingRequired(disputeConfirmation), ErrorDisputeAuditingRequired());
-        }
-
-        //check if dispute window is created/opened for the disputed fork, otherwise create/open it
-        if (disputeWindow.evidence.creationTimestamp == 0) {
-            //create the dispute window
-            disputeWindow.forkId = forkId;
-            disputeWindow.evidence.creationTimestamp = block.timestamp; //challenge period started
-        } else {
-            require(
-                block.timestamp <= disputeWindow.evidence.creationTimestamp + getEvidenceTime(),
-                ErrorDisputeChallengePeriodExpired()
-            );
-            require(!disputeWindow.evidence.hasPosted[dispute.disputer], ErrorDisputeAlreadyPosted());
-        }
-
-        if (isThresholdFinal) {
-            //finalize the dispute windown by making the kill period expired
-            disputeWindow.evidence.creationTimestamp = block.timestamp - getKillTime() - 1;
-            //delete all previous commitments - free up storage (gas refund)
-            delete disputeWindow.evidence.disputeCommitments;
-            //The reduced result is this dispute output. Finalize it by making it expired.
-            _commitToDisputeReducedResult(
-                disputeWindow, dispute.outputSnapshotDataHash, block.timestamp - getEvidenceTime() - 1, block.timestamp
-            );
-        }
-        disputeWindow.evidence.disputeCommitments.push(keccak256(abi.encode(dispute)));
-        disputeWindow.evidence.hasPosted[dispute.disputer] = true; //disputer has posted the dispute
-        emit DisputeCommited(
-            dispute.channelId, dispute, block.timestamp, isThresholdFinal, disputeWindow.evidence.creationTimestamp
+        bytes32 disputeAuditingDataHash = keccak256(abi.encode(disputeAuditingData));
+        require(dispute.disputeAuditingDataHash == disputeAuditingDataHash, ErrorAuditingDataHashMismatch());
+        _uploadDispute(disputeConfirmation, true);
+        emit DisputeAuditingDataPosted(
+            dispute.channelId, keccak256(disputeConfirmation.signedDispute.encodedDispute), disputeAuditingData
         );
     }
 
@@ -64,20 +34,10 @@ contract DisputeManagerFacet is StateChannelCommon {
         for (uint256 i = 0; i < slashes.length; i++) {
             addOnChainSlashedParticipant(dispute.channelId, slashes[i]);
         }
-        uploadDispute(disputeConfirmation);
-    }
-
-    function commitToReducedResult(
-        bytes32 channelId,
-        bytes32 disputedForkId,
-        bytes32 reducedForkId,
-        uint256 reducedForkGenesisTimestamps
-    ) public {
-        DisputeData storage disputeData = disputeData[channelId];
-        DisputeWindow storage disputeWindow = disputeData.disputeWindowMap[disputedForkId];
-        require(_canParticipateInDisputes(channelId, msg.sender), ErrorCantParticipateInDispute());
-        _commitToDisputeReducedResult(disputeWindow, reducedForkId, block.timestamp, reducedForkGenesisTimestamps);
-        //TODO - emit event
+        _uploadDispute(disputeConfirmation, true);
+        emit DisputeAuditingDataPosted(
+            dispute.channelId, keccak256(disputeConfirmation.signedDispute.encodedDispute), disputeAuditingData
+        );
     }
 
     function reduce(Dispute[] memory disputes, uint256 disputeWindowCreationTimestamp)
@@ -115,12 +75,12 @@ contract DisputeManagerFacet is StateChannelCommon {
                     }
                 }
                 // ***** reducedOutput.latestJoinChannelBlockHash *****
-                for (uint256 j = 0; j < disputeData.onChainJoinChannels.length; j++) {
-                    if (disputeData.onChainJoinChannels[j].timestamp <= disputeWindowExpirationTimestamp) {
-                        reducedOutput.latestJoinChannelBlockHash =
-                            disputeData.onChainJoinChannels[j].joinChannelBlockHash;
-                    }
+                ChannelBalance storage cb = channelBalances[dispute.channelId];
+                bytes32 jcbHash = cb.latestJoinChannelBlockHash;
+                while (cb.onChainJoinChannelMap[jcbHash].timestamp > disputeWindowExpirationTimestamp) {
+                    jcbHash = cb.onChainJoinChannelMap[jcbHash].prebiousJoinChannelBlockHash;
                 }
+                reducedOutput.latestJoinChannelBlockHash = jcbHash;
             }
 
             // ***** reducedOutput.latestBlock *****
@@ -175,50 +135,6 @@ contract DisputeManagerFacet is StateChannelCommon {
         }
     }
 
-    function reduceOutputToSnapshotData(
-        ReduceOutput memory reducedOutput,
-        StateSnapshot memory stateSnapshot,
-        bytes memory encodedStateMachineState,
-        JoinChannelBlock[] memory joinChannelBlocks
-    ) public returns (SnapshotData memory outputSnapshotData) {
-        //verify snapshot linked to reducedOutput.latestBlock
-        Block memory latestBlock = reducedOutput.latestBlock;
-        require(latestBlock.stateSnapshotHash == keccak256(abi.encode(stateSnapshot)), ErrorInvalidStateSnapshot());
-        //verify encodedStateMachineState linked to snapshot
-        require(
-            stateSnapshot.snapshotData.stateMachineStateHash == keccak256(encodedStateMachineState),
-            ErrorInvalidLatestState()
-        );
-        //verify JoinChannelBlocks
-        require(
-            _verifyJoinChannelBlocks(
-                stateSnapshot.snapshotData.latestJoinChannelBlockHash,
-                reducedOutput.latestJoinChannelBlockHash,
-                joinChannelBlocks
-            ),
-            ErrorDisputeJoinChannelBlocksInvalid()
-        );
-
-        address[] memory removals = reducedOutput.selfRemovals;
-        if (reducedOutput.timeout.participant != address(0) && reducedOutput.slashedParticipants.length == 0) {
-            removals =
-                StateChannelUtilLibrary.insertIntoAddressArrayNoDuplicates(removals, reducedOutput.timeout.participant);
-        }
-
-        DisputeOutputState memory outputState = generateDisputeOutputState(
-            encodedStateMachineState, reducedOutput.slashedParticipants, removals, joinChannelBlocks, stateSnapshot
-        );
-
-        return SnapshotData({
-            stateMachineStateHash: keccak256(outputState.encodedModifiedState),
-            participants: getStatemachineParticipants(outputState.encodedModifiedState),
-            latestJoinChannelBlockHash: reducedOutput.latestJoinChannelBlockHash, // This has been verified in _verifyJoinChannelBlocks
-            latestExitChannelBlockHash: keccak256(abi.encode(outputState.exitBlock)),
-            totalDeposits: outputState.totalDeposits,
-            totalWithdrawals: outputState.totalWithdrawals
-        });
-    }
-
     function auditDispute(Dispute memory dispute, DisputeAuditingData memory disputeAuditingData)
         external
         onlySelf
@@ -250,9 +166,13 @@ contract DisputeManagerFacet is StateChannelCommon {
             disputeAuditingData.joinChannelBlocks,
             disputeAuditingData.latestStateSnapshot
         );
+        SnapshotData memory latestSnapshotData = disputeAuditingData.latestStateSnapshot.snapshotData;
         require(
             _verifyBalanceInvariantCheck(
-                dispute.channelId, disputeOutputState.totalDeposits, disputeOutputState.totalWithdrawals
+                dispute.channelId,
+                latestSnapshotData.totalDeposits,
+                latestSnapshotData.totalWithdrawals,
+                latestSnapshotData.latestJoinChannelBlockHash
             ),
             ErrorDisputeBalanceInvariantInvalid()
         );
@@ -290,19 +210,25 @@ contract DisputeManagerFacet is StateChannelCommon {
         }
     }
 
-    function applyDisputeFraudProofs(DisputeFraudProof[] memory proofs) public {
-        Dispute[] memory maliciousDisputes = _verifyDisputeFraudProofs(proofs);
-        for (uint256 i = 0; i < maliciousDisputes.length; i++) {
-            _killDispute(maliciousDisputes[i]);
-        }
+    function commitToReducedResult(
+        bytes32 channelId,
+        bytes32 disputedForkId,
+        bytes32 reducedForkId,
+        uint256 reducedForkGenesisTimestamps
+    ) public {
+        DisputeData storage disputeData = disputeData[channelId];
+        DisputeWindow storage disputeWindow = disputeData.disputeWindowMap[disputedForkId];
+        require(_canParticipateInDisputes(channelId, msg.sender), ErrorCantParticipateInDispute());
+        _commitToDisputeReducedResult(disputeWindow, reducedForkId, block.timestamp, reducedForkGenesisTimestamps);
+        //TODO - emit event
     }
+
     /**
      * @notice Challenges a dispute reduction by providing disputes and verification data
      * @dev IMPORTANT: The disputes array must be provided in the same order as they were committed
      *      to the dispute window. The off-chain client is responsible for ensuring disputes are
      *      ordered correctly to save on gas during verification.
      */
-
     function challengeDisputeReduction(
         Dispute[] memory disputes,
         uint256 disputeWindowCreationTimestamp,
@@ -343,6 +269,63 @@ contract DisputeManagerFacet is StateChannelCommon {
         }
     }
 
+    function applyDisputeFraudProofs(DisputeFraudProof[] memory proofs) public {
+        Dispute[] memory maliciousDisputes = _verifyDisputeFraudProofs(proofs);
+        for (uint256 i = 0; i < maliciousDisputes.length; i++) {
+            _killDispute(maliciousDisputes[i]);
+        }
+    }
+
+    function reduceOutputToSnapshotData(
+        ReduceOutput memory reducedOutput,
+        StateSnapshot memory latestStateSnapshot,
+        bytes memory encodedStateMachineState,
+        JoinChannelBlock[] memory joinChannelBlocks
+    ) public returns (SnapshotData memory outputSnapshotData) {
+        //verify snapshot linked to reducedOutput.latestBlock
+        Block memory latestBlock = reducedOutput.latestBlock;
+        require(
+            latestBlock.stateSnapshotHash == keccak256(abi.encode(latestStateSnapshot)), ErrorInvalidStateSnapshot()
+        );
+        //verify encodedStateMachineState linked to snapshot
+        require(
+            latestStateSnapshot.snapshotData.stateMachineStateHash == keccak256(encodedStateMachineState),
+            ErrorInvalidLatestState()
+        );
+        //verify JoinChannelBlocks
+        require(
+            _verifyJoinChannelBlocks(
+                latestStateSnapshot.snapshotData.latestJoinChannelBlockHash,
+                reducedOutput.latestJoinChannelBlockHash,
+                joinChannelBlocks
+            ),
+            ErrorDisputeJoinChannelBlocksInvalid()
+        );
+
+        address[] memory removals = reducedOutput.selfRemovals;
+        if (reducedOutput.timeout.participant != address(0) && reducedOutput.slashedParticipants.length == 0) {
+            removals =
+                StateChannelUtilLibrary.insertIntoAddressArrayNoDuplicates(removals, reducedOutput.timeout.participant);
+        }
+
+        DisputeOutputState memory outputState = generateDisputeOutputState(
+            encodedStateMachineState,
+            reducedOutput.slashedParticipants,
+            removals,
+            joinChannelBlocks,
+            latestStateSnapshot
+        );
+
+        return SnapshotData({
+            stateMachineStateHash: keccak256(outputState.encodedModifiedState),
+            participants: getStatemachineParticipants(outputState.encodedModifiedState),
+            latestJoinChannelBlockHash: reducedOutput.latestJoinChannelBlockHash, // This has been verified in _verifyJoinChannelBlocks
+            latestExitChannelBlockHash: keccak256(abi.encode(outputState.exitBlock)),
+            totalDeposits: outputState.totalDeposits,
+            totalWithdrawals: outputState.totalWithdrawals
+        });
+    }
+
     // Doesn't do any checks and just applies all slashes, removals and joins to a specific stateMachineState and generates the outputStateMachineState - similar logic to playTransaction in the typescript code - this is done to help the backer generate a correct output state while forging the dispute
     function generateDisputeOutputState(
         bytes memory encodedStateMachineState,
@@ -379,9 +362,58 @@ contract DisputeManagerFacet is StateChannelCommon {
         return outputState;
     }
 
+    // ********************** Internal/private functions
+
+    function _uploadDispute(DisputeConfirmation memory disputeConfirmation, bool isAuditingCalldataProvided) internal {
+        Dispute memory dispute = abi.decode(disputeConfirmation.signedDispute.encodedDispute, (Dispute));
+        require(msg.sender == dispute.disputer, ErrorDisputerNotMsgSender());
+        require(_canParticipateInDisputes(dispute.channelId, msg.sender), ErrorCantParticipateInDispute());
+
+        // race condition checks
+        _disputeRaceConditionCheck(dispute);
+
+        DisputeData storage disputeData = disputeData[dispute.channelId];
+        mapping(bytes32 forkId => DisputeWindow) storage disputeWindowMap = disputeData.disputeWindowMap;
+        bytes32 forkId = _getDisputeFork(dispute);
+        DisputeWindow storage disputeWindow = disputeWindowMap[forkId];
+        bool isThresholdFinal = _isDisputeThresholdFinal(disputeConfirmation);
+        if (!isAuditingCalldataProvided && !isThresholdFinal) {
+            require(!_isAuditingCalldataRequired(disputeConfirmation), ErrorDisputeAuditingRequired());
+        }
+
+        //check if dispute window is created/opened for the disputed fork, otherwise create/open it
+        if (disputeWindow.evidence.creationTimestamp == 0) {
+            //create the dispute window
+            disputeWindow.forkId = forkId;
+            disputeWindow.evidence.creationTimestamp = block.timestamp; //challenge period started
+        } else {
+            require(
+                block.timestamp <= disputeWindow.evidence.creationTimestamp + getEvidenceTime(),
+                ErrorDisputeChallengePeriodExpired()
+            );
+            require(!disputeWindow.evidence.hasPosted[dispute.disputer], ErrorDisputeAlreadyPosted());
+        }
+
+        if (isThresholdFinal) {
+            //finalize the dispute windown by making the kill period expired
+            disputeWindow.evidence.creationTimestamp = block.timestamp - getKillTime() - 1;
+            //delete all previous commitments - free up storage (gas refund)
+            delete disputeWindow.evidence.disputeCommitments;
+            //The reduced result is this dispute output. Finalize it by making it expired.
+            _commitToDisputeReducedResult(
+                disputeWindow, dispute.outputSnapshotDataHash, block.timestamp - getEvidenceTime() - 1, block.timestamp
+            );
+        }
+        disputeWindow.evidence.disputeCommitments.push(keccak256(abi.encode(dispute)));
+        disputeWindow.evidence.hasPosted[dispute.disputer] = true; //disputer has posted the dispute
+        emit DisputeCommited(
+            dispute.channelId, dispute, block.timestamp, isThresholdFinal, disputeWindow.evidence.creationTimestamp
+        );
+    }
+
     function _killDispute(Dispute memory dispute) internal {
         DisputeData storage disputeData = disputeData[dispute.channelId];
-        DisputeWindow storage disputeWindow = disputeData.disputeWindowMap[dispute.genesisSnapshotDataHash];
+        DisputeWindow storage disputeWindow = disputeData.disputeWindowMap[_getDisputeFork(dispute)];
 
         // require that the dispute window exists and is not expired
         require(
@@ -413,10 +445,10 @@ contract DisputeManagerFacet is StateChannelCommon {
 
         //if dispute window is empty, delete it
         if (disputeWindow.evidence.disputeCommitments.length == 0) {
-            delete disputeData.disputeWindowMap[dispute.genesisSnapshotDataHash];
+            delete disputeData.disputeWindowMap[_getDisputeFork(dispute)];
 
             for (uint256 i = 0; i < disputeData.disputedForks.length; i++) {
-                if (disputeData.disputedForks[i] == dispute.genesisSnapshotDataHash) {
+                if (disputeData.disputedForks[i] == _getDisputeFork(dispute)) {
                     //remove disputed fork from the list
                     disputeData.disputedForks[i] = disputeData.disputedForks[disputeData.disputedForks.length - 1];
                     disputeData.disputedForks.pop();
@@ -433,6 +465,9 @@ contract DisputeManagerFacet is StateChannelCommon {
     {
         //This runs after verifying auditingData and genesisStateSnapshot => we can skip those checks here
 
+        bytes32 latestSnapshotDataHash = keccak256(abi.encode(disputeAuditingData.latestStateSnapshot.snapshotData));
+        bytes32 latestSnanpshotHash = keccak256(abi.encode(disputeAuditingData.latestStateSnapshot));
+
         // Milestone checking
         (bool isValid, bytes memory lastBlockEncoded) = verifyMilestones(
             dispute.stateProof.milestones,
@@ -446,7 +481,10 @@ contract DisputeManagerFacet is StateChannelCommon {
         if (lastBlockEncoded.length == 0) {
             if (dispute.stateProof.signedBlocks.length == 0) {
                 //no blocks at all => genesis == latest
-                if (dispute.genesisSnapshotDataHash != dispute.latestStateSnapshotHash) return false;
+                if (
+                    dispute.genesisSnapshotDataHash != latestSnapshotDataHash
+                        || dispute.latestStateSnapshotHash != latestSnanpshotHash
+                ) return false;
             } else {
                 //check if signedBlocks are linked, signed and build on genesis
                 if (
@@ -488,11 +526,13 @@ contract DisputeManagerFacet is StateChannelCommon {
         return true;
     }
 
-    function _isMilestoneFinal(
-        MilestoneProof memory milestone,
-        address[] memory expectedParticipants,
-        bytes32 genesisSnapshotHash
-    ) internal pure returns (bool isFinal, bytes32 finalizedSnapshotHash) {
+    function _isMilestoneFinal(StateSnapshot memory genesisSnapshot, MilestoneProof memory milestone)
+        internal
+        pure
+        returns (bool isFinal, bytes32 finalizedSnapshotHash)
+    {
+        bytes32 genesisForkId = genesisSnapshot.forkId;
+        address[] memory expectedParticipants = genesisSnapshot.snapshotData.participants;
         address[] memory thresholdSet = new address[](expectedParticipants.length);
         uint256 thresholdCount = 0;
         bytes memory previousEncodedBlock;
@@ -505,6 +545,7 @@ contract DisputeManagerFacet is StateChannelCommon {
         for (uint256 i = 0; i < milestone.blockConfirmations.length; i++) {
             currentBlockConfirmation = milestone.blockConfirmations[i];
             currentBlock = abi.decode(currentBlockConfirmation.signedBlock.encodedBlock, (Block));
+            if (currentBlock.transaction.header.forkId != genesisForkId) return (false, bytes32(0));
             //check linked
             if (i != 0) {
                 if (currentBlock.previousBlockHash != keccak256(previousEncodedBlock)) {
@@ -543,7 +584,6 @@ contract DisputeManagerFacet is StateChannelCommon {
         StateSnapshot[] memory milestoneSnapshots,
         StateSnapshot memory genesisSnapshot
     ) public returns (bool isValid, bytes memory lastBlockEncoded) {
-        address[] memory participants = genesisSnapshot.snapshotData.participants;
         StateSnapshot memory snapshot = genesisSnapshot;
         lastBlockEncoded = "";
 
@@ -554,8 +594,7 @@ contract DisputeManagerFacet is StateChannelCommon {
 
         for (uint256 i = 0; i < milestoneProofs.length; i++) {
             MilestoneProof memory milestone = milestoneProofs[i];
-            (bool isFinal, bytes32 finalizedSnapshotHash) =
-                _isMilestoneFinal(milestone, participants, snapshot.snapshotData.stateMachineStateHash);
+            (bool isFinal, bytes32 finalizedSnapshotHash) = _isMilestoneFinal(snapshot, milestone);
             if (!isFinal) {
                 return (false, "");
             }
@@ -563,8 +602,6 @@ contract DisputeManagerFacet is StateChannelCommon {
                 return (false, "");
             }
             snapshot = milestoneSnapshots[i];
-            participants = milestoneSnapshots[i].snapshotData.participants;
-
             if (i == milestoneProofs.length - 1 && milestone.blockConfirmations.length > 0) {
                 lastBlockEncoded =
                     milestone.blockConfirmations[milestone.blockConfirmations.length - 1].signedBlock.encodedBlock;
@@ -573,20 +610,8 @@ contract DisputeManagerFacet is StateChannelCommon {
         return (true, lastBlockEncoded);
     }
 
-    function _getLatestBlock(StateProof memory stateProof) internal pure returns (Block memory) {
-        return stateProof.signedBlocks.length > 0
-            ? abi.decode(stateProof.signedBlocks[stateProof.signedBlocks.length - 1].encodedBlock, (Block))
-            : abi.decode(
-                stateProof.milestones[stateProof.milestones.length - 1].blockConfirmations[stateProof.milestones[stateProof
-                    .milestones
-                    .length - 1].blockConfirmations.length - 1].signedBlock.encodedBlock,
-                (Block)
-            );
-    }
-
     function _isCorrectGenesis(Dispute memory dispute) internal view returns (bool) {
-        Block memory latestBlock = _getLatestBlock(dispute.stateProof);
-        return latestBlock.transaction.header.forkId == dispute.genesisSnapshotDataHash;
+        return _areDisputeAndBlockSameFork(dispute, _getLatestBlock(dispute.stateProof));
     }
 
     function _verifyJoinChannelBlocks(
@@ -621,16 +646,19 @@ contract DisputeManagerFacet is StateChannelCommon {
             == disputeAuditingData.latestStateSnapshot.snapshotData.latestExitChannelBlockHash;
     }
 
+    /// @dev Verify latestState balance invariant - output state is calculated with correct state transition that's audited -> if input is ok -> output is ok
     function _verifyBalanceInvariantCheck(
         bytes32 channelId,
         Balance memory totalDeposits,
-        Balance memory totalWithdrawals
+        Balance memory totalWithdrawals,
+        bytes32 latestJoinChannelBlockHash
     ) internal view returns (bool) {
-        Balance memory onChainDeposits = totalOnChainProcessedDeposits[channelId];
-        Balance memory onChainWithdrawals = totalOnChainProcessedWithdrawals[channelId];
-        //on-chain deposits have to match outputState deposits since deposits only happen on-chain
+        ChannelBalance storage channelBalance = channelBalances[channelId];
+        Balance memory onChainDeposits = channelBalance.onChainJoinChannelMap[latestJoinChannelBlockHash].totalDeposits;
+        Balance memory onChainWithdrawals = channelBalance.totalOnChainWithdrawals;
+        //on-chain deposits have to match latestState deposits since deposits only happen on-chain
         if (!stateMachineImplementation.areBalancesEqual(totalDeposits, onChainDeposits)) return false;
-        //total withdrawals can not be less than on-chain withdrawals since on-chain withdrawals are already processed
+        //total withdrawals >= on-chain withdrawals since on-chain withdrawals are already processed
         if (stateMachineImplementation.isBalanceLesserThan(totalWithdrawals, onChainWithdrawals)) return false;
         Balance memory stateMachineBalance = stateMachineImplementation.getTotalStateBalance(); // The state is already set
         // totalDeposits == totalWithdrawals + stateMachineBalance
@@ -675,14 +703,11 @@ contract DisputeManagerFacet is StateChannelCommon {
     }
 
     function _disputeRaceConditionCheck(Dispute memory dispute) internal view {
-        StateSnapshot storage stateSnapshot = stateSnapshots[dispute.channelId];
-        DisputeData storage _disputeData = disputeData[dispute.channelId];
-
         // *********** 1. Timeout *************
         if (dispute.timeout.participant != address(0) && !dispute.timeout.isForced) {
             //check if participant posted calldata commitment
             (bool found, bytes32 blockCalldataCommitment) = getBlockCallDataCommitment(
-                dispute.channelId, dispute.timeout.forkId, dispute.timeout.blockHeight, dispute.timeout.participant
+                dispute.channelId, _getDisputeFork(dispute), dispute.timeout.blockHeight, dispute.timeout.participant
             );
             if (found) {
                 revert ErrorDisputeTimeoutCalldataPosted();
@@ -690,9 +715,9 @@ contract DisputeManagerFacet is StateChannelCommon {
 
             //check if previous block producer posted blockCalldata and if the expectation matches
             if (dispute.timeout.previousBlockProducer != address(0)) {
-                (bool found, bytes32 blockCalldataCommitment) = getBlockCallDataCommitment(
+                (found, blockCalldataCommitment) = getBlockCallDataCommitment(
                     dispute.channelId,
-                    dispute.timeout.forkId,
+                    _getDisputeFork(dispute),
                     dispute.timeout.blockHeight - 1,
                     dispute.timeout.previousBlockProducer
                 );
@@ -731,15 +756,13 @@ contract DisputeManagerFacet is StateChannelCommon {
         return isThresholdFinal;
     }
 
-    function _isAuditingRequired(DisputeConfirmation memory disputeConfirmation)
+    function _isAuditingCalldataRequired(DisputeConfirmation memory disputeConfirmation)
         internal
         view
         returns (bool isRequired)
     {
         Dispute memory dispute = abi.decode(disputeConfirmation.signedDispute.encodedDispute, (Dispute));
         DisputeData storage disputeData = disputeData[dispute.channelId];
-        SnapshotData storage snapshotData = stateSnapshots[dispute.channelId].snapshotData;
-        uint256 thresholdCount = disputeData.pendingParticipants.length;
         if (disputeConfirmation.signatures.length < disputeData.pendingParticipants.length) return true;
 
         (bool isThresholdFinal,) = StateChannelUtilLibrary.verifyThresholdSigned(
@@ -751,7 +774,7 @@ contract DisputeManagerFacet is StateChannelCommon {
     }
 
     function _calculateRemovals(Dispute memory dispute) internal view returns (address[] memory removals) {
-        //Try and combine timeout and selfRemova -> max 2 removals per dispute
+        //Try and combine timeout and selfRemoval -> max 2 removals per dispute
         uint256 removalCount = 0;
         address[] memory _removals = new address[](2);
         // Always apply selfRemoval if set

--- a/contracts/V1/StateChannelDiamondProxy/DisputeManagerFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeManagerFacet.sol
@@ -108,14 +108,19 @@ contract DisputeManagerFacet is StateChannelCommon {
                 for (uint256 j = 0; j < disputeData.onChainSlashes.length; j++) {
                     if (disputeData.onChainSlashes[j].timestamp <= disputeWindowExpirationTimestamp) {
                         slashParticipants[slashCount++] = disputeData.onChainSlashes[j].participant;
+                        //if on-chain slash happened after evidnece period expired (during the kill period), take that timestamp as genesis
                         if (disputeData.onChainSlashes[j].timestamp > reducedOutput.forkGenesisTimestamp) {
                             reducedOutput.forkGenesisTimestamp = disputeData.onChainSlashes[j].timestamp;
                         }
                     }
                 }
                 // ***** reducedOutput.latestJoinChannelBlockHash *****
-                // All disputes have the same latestJoinChannelBlockHash - enforced by the chain at creation
-                reducedOutput.latestJoinChannelBlockHash = disputeData.latestJoinChannelBlockHash;
+                for (uint256 j = 0; j < disputeData.onChainJoinChannels.length; j++) {
+                    if (disputeData.onChainJoinChannels[j].timestamp <= disputeWindowExpirationTimestamp) {
+                        reducedOutput.latestJoinChannelBlockHash =
+                            disputeData.onChainJoinChannels[j].joinChannelBlockHash;
+                    }
+                }
             }
 
             // ***** reducedOutput.latestBlock *****
@@ -699,12 +704,6 @@ contract DisputeManagerFacet is StateChannelCommon {
                 revert ErrorDisputeTimeoutNotMinTimestamp();
             }
         }
-
-        // *********** 2. onChainLatestJoinChannelBlockHash should match *************
-        require(
-            dispute.onChainLatestJoinChannelBlockHash == _disputeData.latestJoinChannelBlockHash,
-            ErrorDisputeOnChainLatestJoinChannelBlockHashMismatch()
-        );
     }
 
     function _isDisputeThresholdFinal(DisputeConfirmation memory disputeConfirmation)

--- a/contracts/V1/StateChannelDiamondProxy/Errors.sol
+++ b/contracts/V1/StateChannelDiamondProxy/Errors.sol
@@ -104,6 +104,7 @@ error ErrorJoinChannelNotMyTurn();
 error ErrorJoinChannelAlreadyInChannel();
 error ErrorJoinChannelExpired();
 error ErrorJoinChannelAlreadyAdded();
+error ErrorJoinChannelInvalidSignature();
 
 // ========================== DisputeManagerFacet ==========================
 

--- a/contracts/V1/StateChannelDiamondProxy/Errors.sol
+++ b/contracts/V1/StateChannelDiamondProxy/Errors.sol
@@ -1,40 +1,44 @@
 pragma solidity ^0.8.8;
 
-error ErrorDisputeInProgrees();
+//Calldata errors
+error ErrorBlockCalldataTimestampTooLate();
+error ErrorBlockCalldataAlreadyPosted();
+
+//StateSnapshot errors
+error ErrorStateSnapshotNotValid();
+error ErrorInvalidStateProof();
+error ErrorFirstExitChannelBlockInvalid();
+error ErrorExitChannelBlocksNotLinked();
+error ErrorLastSnapshotInvalid();
+error ErrorLastSnapshotDoesNotMatchGenesis();
+error ErrorSnapshotsNotProvided();
+error ErrorStanpshotForkMismatch();
+
+//Join channel
+error ErrorJoinChannelExpired();
+error ErrorJoinChannelInvalidSignature();
+
+//Exit channel
+error ErrorWithdrawalFailed();
+error CantWithdrawMoreThanDeposits();
+
+//Dispute errors
 error ErrorDisputerNotMsgSender();
-error ErrorDisputeForkMismatch();
-error ErrorNotParticipant();
-error ErrorLatestFinalizedBlock();
 error ErrorTimeoutNotLinkedToPreviousBlock();
-error ErrorTimeoutParticipantNotNextToWrite();
-error ErrorTimeoutInvalid();
-error ErrorTimeoutSelf();
 error ErrorLinkingPreviousBlock();
-error ErrorDisputeInvalid();
-error ErrorDisputeDoesntExist();
-error ErrorDisputeChallengeMismatch();
-// error ErrorDisputeExpired();
-error ErrorParticipantAlredySlashed();
-error ErrorChallengeNewFinalizedBeforeOldFinalized();
 error ErrorJoinChannelFailed();
-error ErrorSlashedParticipantCantDispute();
-error ErrorChannelIdMismatch();
-error ErrorTransactionCountMismatch();
-error ErrorSignatureInvalid();
 error ErrorDisputeChallengePeriodExpired();
 error ErrorDisputeAlreadyPosted();
-//Can participate in dispute
 error ErrorCantParticipateInDispute();
+error ErrorAuditingDataHashMismatch();
 
 //Reduce errors
 error ErrorNoDisputesProvided();
-error ErrorDisputesLenghtMismatch();
 error ErrorDisputeKillPeriodNotExpired();
 error ErrorDisputeAlreadyReduced();
 
 //Auditing errors
 error ErrorDisputeAuditingRequired();
-error ErrorDisputeWrongCommitment();
 error ErrorDisputeWrongAuditingData();
 error ErrorDisputeCommitmentNotAvailable();
 error ErrorDisputeExpired();
@@ -47,103 +51,26 @@ error ErrorDisputeOutputStateSnapshotInvalid();
 error ErrorDisputeJoinChannelBlocksInvalid();
 error ErrorDisputeExitChannelBlocksInvalid();
 error ErrorDisputeBalanceInvariantInvalid();
-error ErrorWithinChallengePeriod();
-error ErrorInvalidSignedBlocks();
 error ErrorInvalidLatestState();
-error ErrorInvalidDisputeOutputState();
-error ErrorRecursiveDisputeNotExtendingSlashes();
+
 //Race conditions
-error ErrorDisputeShouldUseSnapshotAsGenesisState();
-error ErrorDisputeOnChainSlashedParticipantsMismatch();
-error ErrorDisputeNotExpectedIndex();
 error ErrorDisputeTimeoutCalldataPosted();
 error ErrorDisputeTimeoutPreviousBlockProducerPostedCalldataMismatch();
 error ErrorDisputeTimeoutNotMinTimestamp();
-error ErrorDisputeOnChainLatestJoinChannelBlockHashMismatch();
-
-//Finalized and latest
-error ErrorFinalizedAndLatestNotSignedByParticipant();
-error ErrorFinalizedAndLatestFirstBlockNotVotingForFinalizedState();
-error ErrorFinalizedAndLatestSecondBlocksNotLinked();
-error ErrorFinalizedAndLatestLastBlockNotVoringForLatestState();
 
 //FraudProofs
 error ErrorInvalidFraudProof();
 
 //Double sign
 error ErrorDoubleSignBlocksNotSame();
-error ErrorDoubleSignSignersNotSame();
 error ErrorNotEmptyBlockFraud();
 error ErrorNotSameChannelId();
-error ErrorInvalidBlockStateTransition();
-error ErrorValidBlockStateTransition();
-error ErrorInvalidBlockState();
 error ErrorInvalidStateSnapshot();
 error ErrorInvalidBlock();
 error ErrorInvalidStateSnapshotHash();
 error ErrorValidStateTransition();
+
 //Incorrect data
-error ErrorIncorrectDataStateHashNotLinkedToBlock(uint256 blockNumber);
-error ErrorIncorrectDataBlocksNotLinked();
 error ErrorIncorrectLatestStateSnapshot();
 
-//Newer state
-error ErrorNewerStateConfirmationInvalid();
-
-//Timeout prior
-error ErrorTimeoutPriorBlockNotInVirtualVotes();
-error ErrorTimeoutPriorBlockNotPrior();
-error ErrorTimeoutPriorCalldataExists();
-error ErrorInvalidTimeoutParticipant();
-
-//Block to far in the future
-error ErrorBlockToFarInTheFutureActuallyNotInTheFuture();
-
-//Join channel
-error ErrorJoinChannelNotMyTurn();
-error ErrorJoinChannelAlreadyInChannel();
-error ErrorJoinChannelExpired();
-error ErrorJoinChannelAlreadyAdded();
-error ErrorJoinChannelInvalidSignature();
-
 // ========================== DisputeManagerFacet ==========================
-
-error CreateDisputeInvalidOnChainSlashedParticipants();
-error CreateDisputeInvalidSignature();
-
-error AuditMissingDisputeCommitment();
-error AuditInvalidStateProof();
-error AuditInvalidMilestone();
-error AuditInvalidFraudProof();
-error AuditInvalidOutputState();
-
-error BlockInvalidConfirmation();
-error BlockInvalidSignature();
-error BlockInvalidChannelId();
-error BlockInvalidTransactionCount();
-error BlockInvalidStateSnapshotHash();
-error BlockInvalidLink();
-error BlockInvalidStateTransition();
-error BlockOutOfGas();
-error BlockNotLatestState();
-
-error DisputeInvalidRecursive();
-error DisputeInvalidPreviousRecursive();
-error DisputeInvalidExitChannelBlocks();
-
-//Posting block calldata
-error ErrorBlockCalldataTimestampTooLate();
-error ErrorBlockCalldataAlreadyPosted();
-
-//StateSnapshot errors
-error ErrorDisputeProofRequired();
-error ErrorDisputeProofNotValid();
-error ErrorDisputeNotFinalized();
-error ErrorStateSnapshotNotValid();
-error ErrorInvalidStateProof();
-error ErrorFirstExitChannelBlockInvalid();
-error ErrorExitChannelBlocksNotLinked();
-error ErrorLastSnapshotInvalid();
-error ErrorLastSnapshotDoesNotMatchGenesis();
-error ErrorSnapshotsNotProvided();
-error ErrorStanpshotForkMismatch();

--- a/contracts/V1/StateChannelDiamondProxy/FraudProofFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/FraudProofFacet.sol
@@ -147,7 +147,7 @@ contract FraudProofFacet is StateChannelCommon {
         }
 
         (bool isSuccess, bytes memory encodedModifiedState) = AStateChannelManagerProxy(address(this))
-            .executeStateTransitionOnState(
+            .executeStateTransition(
             fraudProofVerificationContext.channelId, previousStateStateMachineState, fraudBlock.transaction
         );
         if (!isSuccess) {

--- a/contracts/V1/StateChannelDiamondProxy/JoinChannelFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/JoinChannelFacet.sol
@@ -37,12 +37,6 @@ contract JoinChannelFacet is StateChannelCommon {
         // Deposit funds
         isValid = _processJoinChannelDeposits(jc);
         require(isValid, ErrorJoinChannelFailed());
-
-        // Create and apply JoinChannelBlock
-        _insertJoinChannelBlock(jc);
-
-        // Uupdate pendingParticipants
-        _updatePendingParticipants(jc);
     }
 
     // ############### Processing Functions ###############
@@ -54,40 +48,50 @@ contract JoinChannelFacet is StateChannelCommon {
         bytes32 channelId = jc.channelId;
 
         // Process the deposit for the specific StateChannelManager
-        success = AStateChannelManagerProxy(address(this)).addParticipantComposable(jc);
+        success = AStateChannelManagerProxy(address(this)).depositAssetsComposable(jc);
+        if (!success) return false;
 
-        // Update on-chain total deposits
-        if (success) {
-            totalOnChainProcessedDeposits[channelId] =
-                stateMachineImplementation.addBalance(totalOnChainProcessedDeposits[channelId], jc.balance);
-        }
-        return success;
+        // Create JoinChannelBlock
+        JoinChannelBlock memory jcb = _createJoinChannelBlock(jc);
+        bytes32 blockHash = keccak256(abi.encode(jcb));
+
+        // Update on-chain balance
+        ChannelBalance storage channelBalance = channelBalances[channelId];
+        // Get previous total deposits
+        Balance memory previousTotalDeposits =
+            channelBalance.onChainJoinChannelMap[channelBalance.latestJoinChannelBlockHash].totalDeposits;
+        // Calculate new totalDeposits
+        Balance memory newTotalDeposits = stateMachineImplementation.addBalance(previousTotalDeposits, jc.balance);
+
+        // Persist the onChainJoinChannel in the map
+        channelBalance.onChainJoinChannelMap[blockHash] = OnChainJoinChannel({
+            prebiousJoinChannelBlockHash: channelBalance.latestJoinChannelBlockHash,
+            timestamp: block.timestamp,
+            totalDeposits: newTotalDeposits
+        });
+        // Update the latestJoinChannelBlockHash;
+        channelBalance.latestJoinChannelBlockHash = blockHash;
+
+        // Update pending participants
+        _updatePendingParticipants(jc);
+
+        // Emit the event
+        emit JoinChannelProcessed(channelId, jcb, block.timestamp);
+        return true;
     }
 
     function _updatePendingParticipants(JoinChannel memory jc) internal {
         disputeData[jc.channelId].pendingParticipants.push(jc.participant);
     }
 
-    function _insertJoinChannelBlock(JoinChannel memory jc) internal {
-        bytes32 channelId = jc.channelId;
+    function _createJoinChannelBlock(JoinChannel memory jc) internal returns (JoinChannelBlock memory) {
         JoinChannel[] memory jcs = new JoinChannel[](1);
+        ChannelBalance storage channelBalance = channelBalances[jc.channelId];
         jcs[0] = jc;
-        JoinChannelBlock memory joinChannelBlock = JoinChannelBlock({
-            previousBlockHash: disputeData[jc.channelId].latestJoinChannelBlockHash,
-            joinChannels: jcs
-        });
-
-        bytes32 blockHash = keccak256(abi.encode(joinChannelBlock));
-
-        disputeData[jc.channelId].latestJoinChannelBlockHash = blockHash;
-        disputeData[jc.channelId].onChainJoinChannels.push(
-            OnChainJoinChannel({joinChannelBlockHash: blockHash, timestamp: block.timestamp})
-        );
-
-        emit JoinChannelProcessed(channelId, joinChannelBlock, block.timestamp);
+        bytes32 latestBlockHash = channelBalance.latestJoinChannelBlockHash;
+        bytes32 previousBlockHash = channelBalance.onChainJoinChannelMap[latestBlockHash].prebiousJoinChannelBlockHash;
+        JoinChannelBlock memory joinChannelBlock =
+            JoinChannelBlock({previousBlockHash: previousBlockHash, joinChannels: jcs});
+        return joinChannelBlock;
     }
-
-    // ############### Events ###############
-
-    event JoinChannelProcessed(bytes32 indexed channelId, JoinChannelBlock joinChannelBlock, uint256 timestamp);
 }

--- a/contracts/V1/StateChannelDiamondProxy/JoinChannelFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/JoinChannelFacet.sol
@@ -1,0 +1,93 @@
+pragma solidity ^0.8.8;
+
+import "./StateChannelCommon.sol";
+import "./AStateChannelManagerProxy.sol";
+import "./StateChannelUtilLibrary.sol";
+import "./Errors.sol";
+
+contract JoinChannelFacet is StateChannelCommon {
+    /**
+     * @notice Joins participants to the channel by submitting a complete join channel request
+     *
+     * @param joinChannelConfirmation Array of join channel confirmations to process
+     */
+    function joinChannel(JoinChannelConfirmation memory joinChannelConfirmation) external {
+        SignedJoinChannel memory sjc = joinChannelConfirmation.signedJoinChannel;
+        JoinChannel memory jc = abi.decode(sjc.encodedJoinChannel, (JoinChannel));
+        bytes32 channelId = jc.channelId;
+
+        // Check deadline
+        require(jc.deadlineTimestamp <= block.timestamp, ErrorJoinChannelExpired());
+
+        //verify original siganture
+        require(
+            jc.participant == StateChannelUtilLibrary.retriveSignerAddress(sjc.encodedJoinChannel, sjc.signature),
+            ErrorJoinChannelInvalidSignature()
+        );
+
+        // Check threshold from existing participant set
+        address[] memory thresholdParticipants = StateChannelUtilLibrary.concatAddressArraysNoDuplicates(
+            getSnapshotParticipants(channelId), getPendingParticipants(channelId)
+        );
+        (bool isValid,) = StateChannelUtilLibrary.verifyThresholdSigned(
+            thresholdParticipants, sjc.encodedJoinChannel, joinChannelConfirmation.signatures
+        );
+        require(isValid, ErrorJoinChannelInvalidSignature());
+
+        // Deposit funds
+        isValid = _processJoinChannelDeposits(jc);
+        require(isValid, ErrorJoinChannelFailed());
+
+        // Create and apply JoinChannelBlock
+        _insertJoinChannelBlock(jc);
+
+        // Uupdate pendingParticipants
+        _updatePendingParticipants(jc);
+    }
+
+    // ############### Processing Functions ###############
+
+    /**
+     * @dev Processes the JoinChannel for the specific StateChannelManager
+     */
+    function _processJoinChannelDeposits(JoinChannel memory jc) internal returns (bool success) {
+        bytes32 channelId = jc.channelId;
+
+        // Process the deposit for the specific StateChannelManager
+        success = AStateChannelManagerProxy(address(this)).addParticipantComposable(jc);
+
+        // Update on-chain total deposits
+        if (success) {
+            totalOnChainProcessedDeposits[channelId] =
+                stateMachineImplementation.addBalance(totalOnChainProcessedDeposits[channelId], jc.balance);
+        }
+        return success;
+    }
+
+    function _updatePendingParticipants(JoinChannel memory jc) internal {
+        disputeData[jc.channelId].pendingParticipants.push(jc.participant);
+    }
+
+    function _insertJoinChannelBlock(JoinChannel memory jc) internal {
+        bytes32 channelId = jc.channelId;
+        JoinChannel[] memory jcs = new JoinChannel[](1);
+        jcs[0] = jc;
+        JoinChannelBlock memory joinChannelBlock = JoinChannelBlock({
+            previousBlockHash: disputeData[jc.channelId].latestJoinChannelBlockHash,
+            joinChannels: jcs
+        });
+
+        bytes32 blockHash = keccak256(abi.encode(joinChannelBlock));
+
+        disputeData[jc.channelId].latestJoinChannelBlockHash = blockHash;
+        disputeData[jc.channelId].onChainJoinChannels.push(
+            OnChainJoinChannel({joinChannelBlockHash: blockHash, timestamp: block.timestamp})
+        );
+
+        emit JoinChannelProcessed(channelId, joinChannelBlock, block.timestamp);
+    }
+
+    // ############### Events ###############
+
+    event JoinChannelProcessed(bytes32 indexed channelId, JoinChannelBlock joinChannelBlock, uint256 timestamp);
+}

--- a/contracts/V1/StateChannelDiamondProxy/StateChannelCommon.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateChannelCommon.sol
@@ -5,6 +5,8 @@ import "./StateChannelManagerStorage.sol";
 import "../StateChannelManagerEvents.sol";
 import "./StateChannelUtilLibrary.sol";
 import "./AStateChannelManagerProxy.sol";
+import "./Errors.sol";
+import "./utils/DisputeUtils.sol";
 
 contract StateChannelCommon is StateChannelManagerStorage, StateChannelManagerEvents {
     function getOnChainSlashes(bytes32 channelId) public view virtual returns (OnChainSlash[] memory) {
@@ -24,8 +26,6 @@ contract StateChannelCommon is StateChannelManagerStorage, StateChannelManagerEv
     }
 
     function getOnChainThresholdSet(bytes32 channelId) public view virtual returns (address[] memory) {
-        SnapshotData storage snapshotData = stateSnapshots[channelId].snapshotData;
-        DisputeData storage _disputeData = disputeData[channelId];
         return StateChannelUtilLibrary.subtractAddressArrays(
             StateChannelUtilLibrary.concatAddressArrays(
                 getSnapshotParticipants(channelId), getPendingParticipants(channelId)
@@ -90,7 +90,7 @@ contract StateChannelCommon is StateChannelManagerStorage, StateChannelManagerEv
     }
 
     function _isReduceChallengePeriodExpired(DisputeWindow storage disputeWindow) internal view returns (bool) {
-        return block.timestamp > disputeWindow.reducedResult.timestamp + getEvidenceTime();
+        return block.timestamp > disputeWindow.reducedResult.timestamp + evidenceTime;
     }
 
     function getBlockCallDataCommitment(bytes32 channelId, bytes32 forkId, uint256 blockHeight, address participant)
@@ -209,15 +209,21 @@ contract StateChannelCommon is StateChannelManagerStorage, StateChannelManagerEv
         return ExitChannelBlock({exitChannels: exitChannels, previousBlockHash: previousBlockHash});
     }
 
+    /// @dev Callable only by diamond facets - applies the join to the given state of the state machine and returns the modified state
     function applyJoinChannelToStateMachine(bytes memory encodedState, JoinChannel[] memory joinCahnnels)
         public
-        virtual
+        onlySelf
         returns (bytes memory encodedModifiedState)
     {
-        return AStateChannelManagerProxy(address(this)).applyJoinChannelToStateMachine(encodedState, joinCahnnels);
+        stateMachineImplementation.setState(encodedState);
+        for (uint256 i = 0; i < joinCahnnels.length; i++) {
+            bool success = stateMachineImplementation.joinChannel(joinCahnnels[i]);
+            require(success, ErrorDisputeStateMachineJoiningFailed());
+        }
+        return (stateMachineImplementation.getState());
     }
-
     //stateless
+
     function _applySlashesToStateMachine(bytes memory encodedState, address[] memory slashedParticipants)
         internal
         virtual
@@ -229,11 +235,11 @@ contract StateChannelCommon is StateChannelManagerStorage, StateChannelManagerEv
     function isDisputeCommitted(Dispute memory dispute) internal view returns (bool) {
         bytes32 channelId = dispute.channelId;
         DisputeData storage disputeData = disputeData[channelId];
-        DisputeWindow storage disputeWindow = disputeData.disputeWindowMap[dispute.genesisSnapshotDataHash];
+        DisputeWindow storage disputeWindow = disputeData.disputeWindowMap[_getDisputeFork(dispute)];
         bytes32 commitment = keccak256(abi.encode(dispute));
 
         for (uint256 i = 0; i < disputeWindow.evidence.disputeCommitments.length; i++) {
-            if (disputeWindow.evidence.disputeCommitments[i] != commitment) {
+            if (disputeWindow.evidence.disputeCommitments[i] == commitment) {
                 return true;
             }
         }

--- a/contracts/V1/StateChannelDiamondProxy/StateChannelManagerStorage.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateChannelManagerStorage.sol
@@ -11,17 +11,15 @@ contract StateChannelManagerStorage {
     uint256 public chainFallbackTime;
     // Time within more dispute can be submitted during the challenge period
     uint256 public evidenceTime;
-    /// @dev Time within the dispute cam be killed during the challenge period
+    /// @dev Time within the dispute can be killed during the challenge period (killTime > evidenceTime)
     uint256 public killTime;
     uint256 public gasLimit;
 
     AStateMachine stateMachineImplementation;
 
     // =================== State on chain storage ==================
-    /// @dev Total on-chain processed deposits
-    mapping(bytes32 channelId => Balance) totalOnChainProcessedDeposits;
-    /// @dev Total on-chain processed withdraws
-    mapping(bytes32 channelId => Balance) totalOnChainProcessedWithdrawals;
+    /// @dev Channel balance tracker
+    mapping(bytes32 channelId => ChannelBalance) channelBalances;
 
     /// @dev stateSnapshot Data
     mapping(bytes32 channelId => StateSnapshot) stateSnapshots;

--- a/contracts/V1/StateChannelDiamondProxy/StateSnapshotFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateSnapshotFacet.sol
@@ -59,14 +59,14 @@ contract StateSnapshotFacet is StateChannelCommon {
         ExitChannelBlock[] memory exitChannelBlocks
     ) internal {
         _validateExitChannelBlocks(exitChannelBlocks, currentOnChainSnapshot, newSnapshot);
-        _applyExitChannelBlocks(channelId, exitChannelBlocks);
+        _applyExitChannelBlocks(channelId, exitChannelBlocks, newSnapshot.snapshotData.latestJoinChannelBlockHash);
 
         // Update the state snapshot
         stateSnapshots[channelId] = newSnapshot;
 
-        //check if last fork -> clearDisputeData
+        //check if last fork -> clearStorage
         if (disputeData[channelId].disputeWindowMap[newSnapshot.forkId].evidence.creationTimestamp == 0) {
-            _clearDisputeData(channelId);
+            _clearStorage(channelId, newSnapshot.snapshotData.latestJoinChannelBlockHash);
         }
         emit StateSnapshotUpdated(channelId, newSnapshot, block.timestamp);
     }
@@ -119,26 +119,58 @@ contract StateSnapshotFacet is StateChannelCommon {
         }
     }
 
-    function _applyExitChannelBlocks(bytes32 channelId, ExitChannelBlock[] memory exitChannelBlocks) internal {
+    function _applyExitChannelBlocks(
+        bytes32 channelId,
+        ExitChannelBlock[] memory exitChannelBlocks,
+        bytes32 joinChannelBlockHash
+    ) internal {
+        ChannelBalance storage cb = channelBalances[channelId];
+        Balance memory totalDeposits = cb.onChainJoinChannelMap[joinChannelBlockHash].totalDeposits;
+        Balance memory totalWithdrawals = cb.totalOnChainWithdrawals;
         for (uint256 i = 0; i < exitChannelBlocks.length; i++) {
             for (uint256 j = 0; j < exitChannelBlocks[i].exitChannels.length; j++) {
-                AStateChannelManagerProxy(address(this)).processExitChannel(
-                    channelId, exitChannelBlocks[i].exitChannels[j]
+                bool success = AStateChannelManagerProxy(address(this)).withdrawAssetsComposable(
+                    exitChannelBlocks[i].exitChannels[j]
                 );
+                require(success, ErrorWithdrawalFailed());
+
+                totalWithdrawals = stateMachineImplementation.addBalance(
+                    totalWithdrawals, exitChannelBlocks[i].exitChannels[j].balance
+                );
+                //require withdrawals <= deposits
+                bool isLessThan = stateMachineImplementation.isBalanceLesserThan(totalWithdrawals, totalDeposits);
+                bool isEqual = stateMachineImplementation.areBalancesEqual(totalWithdrawals, totalDeposits);
+                require(isLessThan || isEqual, CantWithdrawMoreThanDeposits());
             }
         }
+        cb.totalOnChainWithdrawals = totalWithdrawals;
+    }
+
+    function _clearStorage(bytes32 channelId, bytes32 snapshotLatestJoinChannelBlockHash) internal {
+        _clearDisputeData(channelId);
+        _clearOldJoinChannels(channelId, snapshotLatestJoinChannelBlockHash);
     }
 
     function _clearDisputeData(bytes32 channelId) internal {
         DisputeData storage disputeData = disputeData[channelId];
         delete disputeData.onChainSlashes; //TODO! Check should we clear this since things happen in 'parallel' now
-        delete disputeData.onChainJoinChannels;
         delete disputeData.pendingParticipants;
         mapping(bytes32 => DisputeWindow) storage disputeWindowMap = disputeData.disputeWindowMap;
         for (uint256 i = 0; i < disputeData.disputedForks.length; i++) {
             delete disputeWindowMap[disputeData.disputedForks[i]];
         }
         delete disputeData.disputedForks;
-        // delete disputeData.latestJoinChannelBlockHash; // safe to delete this, since snapshot contains the same, but for convinience we don't delete it so we can continue 'chaining'/buidling on top with a clean interface
+    }
+
+    function _clearOldJoinChannels(bytes32 channelId, bytes32 snapshotLatestJoinChannelBlockHash) internal {
+        ChannelBalance storage cb = channelBalances[channelId];
+        //start from the previous block hash (keep the current blockHash in storage for easy access even though it's in the snapshot)
+        bytes32 keyToDelete = cb.onChainJoinChannelMap[snapshotLatestJoinChannelBlockHash].prebiousJoinChannelBlockHash;
+        bytes32 prev;
+        while (keyToDelete != bytes32(0)) {
+            prev = cb.onChainJoinChannelMap[keyToDelete].prebiousJoinChannelBlockHash;
+            delete cb.onChainJoinChannelMap[keyToDelete];
+            keyToDelete = prev;
+        }
     }
 }

--- a/contracts/V1/StateChannelDiamondProxy/StateSnapshotFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateSnapshotFacet.sol
@@ -139,6 +139,6 @@ contract StateSnapshotFacet is StateChannelCommon {
             delete disputeWindowMap[disputeData.disputedForks[i]];
         }
         delete disputeData.disputedForks;
-        // delete disputeData.latestJoinChannelBlockHash; // safe to delete this, since snapshot contains the same, but for convinience we don't delete it so we can continue 'chaining'/buidling on top with a clean itnerface
+        // delete disputeData.latestJoinChannelBlockHash; // safe to delete this, since snapshot contains the same, but for convinience we don't delete it so we can continue 'chaining'/buidling on top with a clean interface
     }
 }

--- a/contracts/V1/StateChannelDiamondProxy/StateSnapshotFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateSnapshotFacet.sol
@@ -132,12 +132,13 @@ contract StateSnapshotFacet is StateChannelCommon {
     function _clearDisputeData(bytes32 channelId) internal {
         DisputeData storage disputeData = disputeData[channelId];
         delete disputeData.onChainSlashes; //TODO! Check should we clear this since things happen in 'parallel' now
+        delete disputeData.onChainJoinChannels;
         delete disputeData.pendingParticipants;
         mapping(bytes32 => DisputeWindow) storage disputeWindowMap = disputeData.disputeWindowMap;
         for (uint256 i = 0; i < disputeData.disputedForks.length; i++) {
             delete disputeWindowMap[disputeData.disputedForks[i]];
         }
         delete disputeData.disputedForks;
-        delete disputeData.latestJoinChannelBlockHash;
+        // delete disputeData.latestJoinChannelBlockHash; // safe to delete this, since snapshot contains the same, but for convinience we don't delete it so we can continue 'chaining'/buidling on top with a clean itnerface
     }
 }

--- a/contracts/V1/StateChannelDiamondProxy/utils/BlockUtils.sol
+++ b/contracts/V1/StateChannelDiamondProxy/utils/BlockUtils.sol
@@ -1,0 +1,31 @@
+pragma solidity ^0.8.8;
+
+import "../../types/DisputeTypes.sol";
+
+function _getBlockHeight(Block memory _block) pure returns (uint256) {
+    return _block.transaction.header.transactionCnt;
+}
+
+function _getBlockChannel(Block memory _block) pure returns (bytes32) {
+    return _block.transaction.header.channelId;
+}
+
+function _getBlockFork(Block memory _block) pure returns (bytes32) {
+    return _block.transaction.header.forkId;
+}
+
+function _getBlockAuthor(Block memory _block) pure returns (address) {
+    return _block.transaction.header.participant;
+}
+
+function _areBlocksSameFork(Block memory _block1, Block memory _block2) pure returns (bool) {
+    return _getBlockFork(_block1) == _getBlockFork(_block2);
+}
+
+function _areBlocksSameChannel(Block memory _block1, Block memory _block2) pure returns (bool) {
+    return _getBlockChannel(_block1) == _getBlockChannel(_block2);
+}
+
+function _doesBlockCommitToSnapshot(Block memory _block, StateSnapshot memory snapshot) pure returns (bool) {
+    return _block.stateSnapshotHash == keccak256(abi.encode(snapshot));
+}

--- a/contracts/V1/StateChannelDiamondProxy/utils/DisputeUtils.sol
+++ b/contracts/V1/StateChannelDiamondProxy/utils/DisputeUtils.sol
@@ -1,0 +1,31 @@
+pragma solidity ^0.8.8;
+
+import "../../types/DisputeTypes.sol";
+import "./BlockUtils.sol";
+
+function _getDisputeChannel(Dispute memory dispute) pure returns (bytes32) {
+    return dispute.channelId;
+}
+
+function _getDisputeFork(Dispute memory dispute) pure returns (bytes32) {
+    return dispute.genesisSnapshotDataHash;
+}
+
+function _areDisputeAndBlockSameFork(Dispute memory dispute, Block memory _block) pure returns (bool) {
+    return _getBlockFork(_block) == _getDisputeFork(dispute);
+}
+
+function _areDisputeAndBlockSameChannel(Dispute memory dispute, Block memory _block) pure returns (bool) {
+    return _getBlockChannel(_block) == _getDisputeChannel(dispute);
+}
+
+function _getLatestBlock(StateProof memory stateProof) pure returns (Block memory) {
+    return stateProof.signedBlocks.length > 0
+        ? abi.decode(stateProof.signedBlocks[stateProof.signedBlocks.length - 1].encodedBlock, (Block))
+        : abi.decode(
+            stateProof.milestones[stateProof.milestones.length - 1].blockConfirmations[stateProof.milestones[stateProof
+                .milestones
+                .length - 1].blockConfirmations.length - 1].signedBlock.encodedBlock,
+            (Block)
+        );
+}

--- a/contracts/V1/StateChannelManagerEvents.sol
+++ b/contracts/V1/StateChannelManagerEvents.sol
@@ -13,10 +13,15 @@ interface StateChannelManagerEvents {
         bool isFinal,
         uint256 windowCreationTimestamp
     );
+    event DisputeAuditingDataPosted(
+        bytes32 indexed channelId, bytes32 disputeHash, DisputeAuditingData disputeAuditingData
+    );
 
     event StateSnapshotUpdated(bytes32 indexed channelId, StateSnapshot stateSnapshot, uint256 timestamp);
 
     event OutputStateSnapshotVerified(
         bytes32 indexed channelId, StateSnapshot stateSnapshot, bytes32 disputeCommitment
     );
+
+    event JoinChannelProcessed(bytes32 indexed channelId, JoinChannelBlock joinChannelBlock, uint256 timestamp);
 }

--- a/contracts/V1/StateChannelManagerInterface.sol
+++ b/contracts/V1/StateChannelManagerInterface.sol
@@ -16,8 +16,6 @@ abstract contract StateChannelManagerInterface {
         public
         virtual;
 
-    function processExitChannel(bytes32 channelId, ExitChannel calldata exitChannel) public virtual;
-
     function addParticipant(bytes32 channelId, bytes[] calldata removeParticipantData, bytes[] calldata signatures)
         public
         virtual;
@@ -25,8 +23,6 @@ abstract contract StateChannelManagerInterface {
     function isChannelOpen(bytes32 channelId) public view virtual returns (bool);
 
     function getParticipants(bytes32 channelId) public virtual returns (address[] memory);
-
-    function getNextToWrite(bytes32 channelId, bytes memory encodedState) public virtual returns (address);
 
     function getP2pTime() public view virtual returns (uint256);
 
@@ -40,7 +36,7 @@ abstract contract StateChannelManagerInterface {
 
     function getAllTimes() public view virtual returns (uint256, uint256, uint256, uint256, uint256);
 
-    function executeStateTransitionOnState(bytes32 channelId, bytes memory encodedState, Transaction memory _tx)
+    function executeStateTransition(bytes32 channelId, bytes memory encodedState, Transaction memory _tx)
         public
         virtual
         returns (bool, bytes memory);
@@ -55,6 +51,11 @@ abstract contract StateChannelManagerInterface {
 
     function uploadDispute(DisputeConfirmation memory disputeConfirmation) public virtual;
 
+    function uploadDisputeWithCalldata(
+        DisputeConfirmation memory disputeConfirmation,
+        DisputeAuditingData memory disputeAuditingData
+    ) public virtual;
+
     function auditDispute(Dispute memory dispute, DisputeAuditingData memory disputeAuditingData)
         public
         virtual
@@ -66,6 +67,8 @@ abstract contract StateChannelManagerInterface {
     ) public virtual;
 
     function challengeDispute(Dispute memory dispute, DisputeAuditingData memory disputeAuditingData) public virtual;
+
+    function applyDisputeFraudProofs(DisputeFraudProof[] memory proofs) public virtual;
 
     function updateStateSnapshotFork(
         bytes32 channelId,

--- a/contracts/V1/StateChannelManagerInterface.sol
+++ b/contracts/V1/StateChannelManagerInterface.sol
@@ -79,4 +79,8 @@ abstract contract StateChannelManagerInterface {
         StateSnapshot[] memory milestoneSnapshots,
         ExitChannelBlock[] memory exitChannelBlocks
     ) public virtual;
+
+    function joinChannel(JoinChannelConfirmation memory joinChannelConfirmations) public virtual;
+
+    function multicall(bytes[] calldata calls) external virtual returns (bytes[] memory results);
 }

--- a/contracts/V1/examples/MathStateMachine/MathStateChannelManagerProxy.sol
+++ b/contracts/V1/examples/MathStateMachine/MathStateChannelManagerProxy.sol
@@ -108,20 +108,13 @@ contract MathStateChannelManagerProxy is AStateChannelManagerProxy {
         override
     {}
 
-    function processExitChannel(bytes32 channelId, ExitChannel calldata exitChannel) public virtual override {}
-
     function addParticipant(bytes32 channelId, bytes[] calldata removeParticipantData, bytes[] calldata signatures)
         public
         virtual
         override
     {}
 
-    function _addParticipantComposable(JoinChannel memory joinChannel) internal virtual override returns (bool) {}
+    function _depositAssetsComposable(JoinChannel memory joinChannel) internal virtual override returns (bool) {}
 
-    function _removeParticipantComposable(bytes32 channelId, ExitChannel memory exitChannel)
-        internal
-        virtual
-        override
-        returns (bool)
-    {}
+    function _withdrawAssetsComposable(ExitChannel memory exitChannel) internal virtual override returns (bool) {}
 }

--- a/contracts/V1/examples/MathStateMachine/MathStateChannelManagerProxy.sol
+++ b/contracts/V1/examples/MathStateMachine/MathStateChannelManagerProxy.sol
@@ -15,14 +15,16 @@ contract MathStateChannelManagerProxy is AStateChannelManagerProxy {
         address disputeManagerFacet,
         address fraudProofFacet,
         address disputeFraudProofFacet,
-        address stateSnapshotFacet
+        address stateSnapshotFacet,
+        address joinChannelFacet
     )
         AStateChannelManagerProxy(
             aStateMachineAddress,
             disputeManagerFacet,
             fraudProofFacet,
             disputeFraudProofFacet,
-            stateSnapshotFacet
+            stateSnapshotFacet,
+            joinChannelFacet
         )
     {
         p2pTime = 5;

--- a/contracts/V1/types/DataTypes.sol
+++ b/contracts/V1/types/DataTypes.sol
@@ -116,3 +116,15 @@ struct SnapshotData {
     /// @dev sum of all the amounts in the exitChannel blockchain
     Balance totalWithdrawals;
 }
+
+struct OnChainJoinChannel {
+    bytes32 prebiousJoinChannelBlockHash;
+    Balance totalDeposits;
+    uint256 timestamp;
+}
+
+struct ChannelBalance {
+    mapping(bytes32 joinChannelBlockHash => OnChainJoinChannel) onChainJoinChannelMap;
+    bytes32 latestJoinChannelBlockHash;
+    Balance totalOnChainWithdrawals;
+}

--- a/contracts/V1/types/DisputeFraudProofTypes.sol
+++ b/contracts/V1/types/DisputeFraudProofTypes.sol
@@ -3,10 +3,11 @@ pragma solidity ^0.8.8;
 import "./DataTypes.sol";
 
 // ========================== Dispute related fraud proofs ==========================
+// This is sematically equivalent to SignedBlock, but logically it's any signature not only from the original block author
+
 struct DisputeNotLatestStateProof {
-    BlockConfirmation newerBlock;
-    Dispute originalDispute;
-    uint256 originalDisputeTimestamp;
+    bytes encodedBlock;
+    bytes signature;
 }
 
 struct DisputeOutOfGasProof {
@@ -37,13 +38,15 @@ struct DisputeInvalidExitChannelBlocksProof {
 // ========================== Timeout related fraud proofs ==========================
 
 struct TimeoutThresholdProof {
-    BlockConfirmation thresholdBlock;
-    Dispute timedOutDispute;
-    uint256 timedOutDisputeTimestamp;
-    bytes latestStateSnapshot;
+    BlockConfirmation thresholdBlock; // only N/N on single block - no virtual voting
+    StateSnapshot latestStateSnapshot;
 }
 
-struct TimeoutPriorInvalidProof {
+struct TimeoutCalldataPostedProof {
+    Block postedBlock;
+}
+
+struct TimeoutParticipantNotNextProof {
     Dispute originalDispute;
     Dispute recursiveDispute;
     uint256 originalDisputeTimestamp;

--- a/contracts/V1/types/DisputeTypes.sol
+++ b/contracts/V1/types/DisputeTypes.sol
@@ -99,7 +99,12 @@ struct OnChainSlash {
     uint256 timestamp;
 }
 
+struct OnChainJoinChannel {
+    bytes32 joinChannelBlockHash;
+    uint256 timestamp;
+}
 /// @dev data for dispute auditing
+
 struct DisputeAuditingData {
     StateSnapshot genesisStateSnapshot;
     StateSnapshot latestStateSnapshot;
@@ -114,6 +119,7 @@ struct DisputeAuditingData {
 
 struct DisputeData {
     OnChainSlash[] onChainSlashes;
+    OnChainJoinChannel[] onChainJoinChannels;
     address[] pendingParticipants;
     bytes32 latestJoinChannelBlockHash;
     mapping(bytes32 forkId => DisputeWindow) disputeWindowMap;

--- a/contracts/V1/types/DisputeTypes.sol
+++ b/contracts/V1/types/DisputeTypes.sol
@@ -55,8 +55,6 @@ struct Timeout {
     uint256 blockHeight;
     /// @dev minimum timestamp where this timeout is valid
     uint256 minTimeStamp;
-    /// @dev the forkId at which the participant is timed out
-    bytes32 forkId;
     /// @dev True if timeout checks should ignore race condition checks on-chain - usefull when the participant being tiemdout committed to a wrong block (is not linked to the latestState), but we can't prove deviation - explained more in the docs
     bool isForced;
     // ================== optional ==================
@@ -99,10 +97,6 @@ struct OnChainSlash {
     uint256 timestamp;
 }
 
-struct OnChainJoinChannel {
-    bytes32 joinChannelBlockHash;
-    uint256 timestamp;
-}
 /// @dev data for dispute auditing
 
 struct DisputeAuditingData {
@@ -119,9 +113,7 @@ struct DisputeAuditingData {
 
 struct DisputeData {
     OnChainSlash[] onChainSlashes;
-    OnChainJoinChannel[] onChainJoinChannels;
     address[] pendingParticipants;
-    bytes32 latestJoinChannelBlockHash;
     mapping(bytes32 forkId => DisputeWindow) disputeWindowMap;
     bytes32[] disputedForks;
 }

--- a/contracts/V1/types/ProofTypes.sol
+++ b/contracts/V1/types/ProofTypes.sol
@@ -41,8 +41,9 @@ struct DisputeFraudProof {
 enum DisputeFraudProofType {
     // Timeout related fraud proofs
     TimeoutThreshold,
-    TimeoutPriorInvalid,
-    TimeoutParticipantNoNext,
+    TimeoutCalldataPosted, //usefull when force timeout is used maliciously
+    TimeoutParticipantNotNext, // this can also be done in auditing instead
+    TimeoutTooEarly,
     // Dispute fraud proofs
     DisputeNotLatestState,
     DisputeInvalid,

--- a/examples/TicTacToe/contracts/TicTacToe/TicTacToeStateChannelManagerProxy.sol
+++ b/examples/TicTacToe/contracts/TicTacToe/TicTacToeStateChannelManagerProxy.sol
@@ -9,76 +9,59 @@ import "./TicTacToeStateMachine.sol";
 // import "hardhat/console.sol";
 
 contract TicTacToeStateChannelManagerProxy is AStateChannelManagerProxy {
-    uint public totalChannelsOpened;
+    uint256 public totalChannelsOpened;
 
-    constructor(
-        address aStateMaachineAddress,
-        address disputeManagerFacet
-    ) AStateChannelManagerProxy(aStateMaachineAddress, disputeManagerFacet) {
+    constructor(address aStateMaachineAddress, address disputeManagerFacet)
+        AStateChannelManagerProxy(aStateMaachineAddress, disputeManagerFacet)
+    {
         p2pTime = 5;
         agreementTime = 5;
         chainFallbackTime = 5;
         challengeTime = 5;
     }
 
-    function openChannel(
-        bytes32 channelId,
-        bytes[] calldata openChannelData,
-        bytes[] calldata signatures
-    ) public virtual override {
+    function openChannel(bytes32 channelId, bytes[] calldata openChannelData, bytes[] calldata signatures)
+        public
+        virtual
+        override
+    {
         require(
-            openChannelData.length > 0 &&
-                openChannelData.length == signatures.length,
+            openChannelData.length > 0 && openChannelData.length == signatures.length,
             "TicTacToeStateChannelManager: openChannel (openChannel <> signatures) incorect length"
         );
 
-        JoinChannel[] memory joinChannels = new JoinChannel[](
-            openChannelData.length
-        );
-        for (uint i = 0; i < openChannelData.length; i++) {
+        JoinChannel[] memory joinChannels = new JoinChannel[](openChannelData.length);
+        for (uint256 i = 0; i < openChannelData.length; i++) {
             joinChannels[i] = abi.decode(openChannelData[i], (JoinChannel));
         }
 
         bool isValid = true;
-        for (uint i = 0; i < openChannelData.length; i++) {
+        for (uint256 i = 0; i < openChannelData.length; i++) {
             address[] memory addressesInThreshold = new address[](1);
             addressesInThreshold[0] = joinChannels[i].participant;
             bytes[] memory signature = new bytes[](1);
             signature[0] = signatures[i];
-            (bool succeeds, ) = StateChannelUtilLibrary.verifyThresholdSigned(
-                addressesInThreshold,
-                openChannelData[i],
-                signatures
-            );
+            (bool succeeds,) =
+                StateChannelUtilLibrary.verifyThresholdSigned(addressesInThreshold, openChannelData[i], signatures);
             if (!succeeds) {
                 isValid = false;
                 break;
             }
         }
 
-        require(
-            isValid,
-            "TicTacToeStateChannelManager: openChannel (openChannel <> signatures) singatures don't match"
-        );
+        require(isValid, "TicTacToeStateChannelManager: openChannel (openChannel <> signatures) singatures don't match");
 
-        require(
-            channelId != bytes32(0),
-            "TicTacToeStateChannelManager: openChannel channelId cannot be 0x0"
-        );
+        require(channelId != bytes32(0), "TicTacToeStateChannelManager: openChannel channelId cannot be 0x0");
 
-        require(
-            !isChannelOpen(channelId),
-            "TicTacToeStateChannelManager: openChannel - channel already open"
-        );
-        for (uint i = 0; i < joinChannels.length; i++) {
+        require(!isChannelOpen(channelId), "TicTacToeStateChannelManager: openChannel - channel already open");
+        for (uint256 i = 0; i < joinChannels.length; i++) {
             require(
                 channelId == joinChannels[i].channelId,
                 "TicTacToeStateChannelManager: openChannel channelId doesn't match"
             );
 
             require(
-                joinChannels[i].amount > 0,
-                "TicTacToeStateChannelManager: openChannel amount must be greater than 0"
+                joinChannels[i].amount > 0, "TicTacToeStateChannelManager: openChannel amount must be greater than 0"
             );
             //TODO process deposits (this is composable with the global state (other contracts))
 
@@ -92,7 +75,7 @@ contract TicTacToeStateChannelManagerProxy is AStateChannelManagerProxy {
         genesisState.gameActive = true;
         genesisState.participants = new address[](joinChannels.length);
         genesisState.balances = new uint256[](joinChannels.length);
-        for (uint i = 0; i < joinChannels.length; i++) {
+        for (uint256 i = 0; i < joinChannels.length; i++) {
             genesisState.participants[i] = joinChannels[i].participant;
             genesisState.balances[i] = joinChannels[i].amount;
         }
@@ -105,30 +88,25 @@ contract TicTacToeStateChannelManagerProxy is AStateChannelManagerProxy {
         emit SetState(channelId, genesisStateEcoded, 0, block.timestamp);
     }
 
-    function closeChannel(
-        bytes32 channelId,
-        bytes[] calldata closeChannelData,
-        bytes[] calldata signatures
-    ) public virtual override {}
+    function closeChannel(bytes32 channelId, bytes[] calldata closeChannelData, bytes[] calldata signatures)
+        public
+        virtual
+        override
+    {}
 
-    function removeParticipant(
-        bytes32 channelId,
-        bytes[] calldata removeParticipantData,
-        bytes[] calldata signatures
-    ) public virtual override {}
+    function removeParticipant(bytes32 channelId, bytes[] calldata removeParticipantData, bytes[] calldata signatures)
+        public
+        virtual
+        override
+    {}
 
-    function addParticipant(
-        bytes32 channelId,
-        bytes[] calldata removeParticipantData,
-        bytes[] calldata signatures
-    ) public virtual override {}
+    function addParticipant(bytes32 channelId, bytes[] calldata removeParticipantData, bytes[] calldata signatures)
+        public
+        virtual
+        override
+    {}
 
-    function _addParticipantComposable(
-        JoinChannel memory joinChannel
-    ) internal virtual override returns (bool) {}
+    function _depositAssetsComposable(JoinChannel memory joinChannel) internal virtual override returns (bool) {}
 
-    function _removeParticipantComposable(
-        bytes32 channelId,
-        ProcessExit memory processExit
-    ) internal virtual override returns (bool) {}
+    function _withdrawAssetsComposable(ProcessExit memory processExit) internal virtual override returns (bool) {}
 }

--- a/src/types/disputes.ts
+++ b/src/types/disputes.ts
@@ -15,7 +15,7 @@ export enum FraudProofType {
     // Timeout related fraud proofs
     TimeoutThreshold = 5,
     TimeoutPriorInvalid = 6,
-    TimeoutParticipantNoNext = 7,
+    TimeoutParticipantNotNext = 7,
     // Dispute fraud proofs
     DisputeNotLatestState = 8,
     DisputeInvalid = 9,


### PR DESCRIPTION
Simplified `JoinChannel` logic. Hopefully this concludes all architectural stuff behind the CRDT implementation and now only some cleanup/refactor and fraud proof population is left and typescript can advance in parallel.

JoinChannel flow/logic explanation: 

1) The new participant connects to any/all participant(s).
2) At least 1 existing participant, shares all the required state data / makes it available to the `joining participant` over the p2p network (RPC). Essentially the joining peer connects as a `spectator` - If the data does not become available/shared, the joining peer `aborts`. 
3) The joining peer validates that data and `syncs` - here it can subjectively perform the `invariant check` and decide does it want to join the channel. It continues replicating state as the new state transitions are shared with it. It also cosigns and gossips blocks like it was already part of the channel - indicating cooperation. The peer can `abort` at any step at its own discretion without affecting any existing peers. 
4) If the peer wants to join, it sends a `JoinChannel` request over the p2p network (RPC) indicating it wants to join the channel.
5) Existing peers analyze the request and if they agree with it (want to allow the peer to join), they cosign it and gossip it over the p2p network. All of the signing is done async in parallel without affecting other existing operations (e.g. their state replication/progression). If for any reason the joining is `aborted` the existing peers remain unaffected like it never was initiated.
6) When/If a N/N threshold is reached on the `JoinChannel` the joining peer can at its own discretion initiate the joining `on-chain` by calling `StateChannelManagerProxy.joinChannel` and providing the `JoinChannelConfirmation` proving that existing peers agreed to let the new peer in. This performs all the lockups and deposits of funds. If it fails, the joining is aborted without affecting other peers. At its own discretion the peer has a `multicall` endpoint that allows it to `update the snapshot (optional)` if needed prior (only useful to reduce the participant set for the N/N is some cases, since the peer at this point has all the data, otherwise it wouldn't be at this step, so it's not needed for security) and `upload a dispute (optional)` that triggers its joining immediately in the `StateMachine` - this is optional since any future dispute will trigger the join through `reduce` and it will be accounted for in the state machine. In most cases peers will upload a dispute immediately and not delay their own joining.
7) Uploading the dispute creates the `dispute window` for submitting more evidence and `playing out the dispute game` - this is the trigger for other peers that the join operation happened successfully on-chain (N/N and deposits) and that it `can't be aborted` anymore. Peers, like with other disputes, stop their state progression for the disputed `forkId` and try and submit the latest `evidence` in most cases they just submit the latest state, so the final `reduction` accounts for the latest state when applying the join.
8) The resulting fork contains the joining peers as participants.

`Game Theory` behind this design: 
Up until the last point the joining operation can abort randomly without affecting any peers. It's in everyone's best interest to cooperate or abort early. The original peers should share the full/latest state data with all joining peers, so when the joining peer actually performs the join operation and creates the `dispute` it uses the `latest state` which will save the existing peers gas fees, by potentially not having to upload more `evidence` during the `dispute window`. Since the cost of joining are always passed on to the joining peer, its not in their interest to perform double spend on their deposits, since their transactions will fail and they'll just pay gas fees on-chain without affecting the existing participant set.  

Continuation on point 7) above - Existing peer can during the `dispute window` submit more `evidence` in most cases used to push the state to the `latest` and they will try to get signatures from all pending participants, but in the case that they don't get those signatures they're forced to either accept the older state or upload the `AuditingData` as calldata so it's verifiable. Joining peers may not be synced to what's actually the `latest state` since existing peers can withhold that data, but in such cases they gain no advantage since they'll be forced to pay gas fees on-chain and the data will eventually be provided and made available or forfeited - so it's better for them to do it for free over the p2p network than on-chain through calldata where fees have to be paid. The joining peer, since it also cosigns blocks even when `spectating` (`step 3`) (otherwise other peers don't cosign its `JoinChannel` request (`step 5`)) it is also forced to use `the latest state provided to it` during the initial `dispute` or like other peers a `dispute fraud proof` for enforcing `latest signed state` will slash the joining peer and kill the dispute. 
