### PR TITLE
Block storage - options based interface

### DIFF
--- a/src/storage/BlockStorage.ts
+++ b/src/storage/BlockStorage.ts
@@ -7,6 +7,10 @@ import { ethers } from "ethers";
 import { Block, BlockCoordinates } from "@/models";
 
 type CoordinateKey = string;
+type StoreOptions = {
+    hash?: Hash;
+    coordinates?: BlockCoordinates;
+};
 
 export class BlockStorage {
     // ====================================
@@ -27,13 +31,7 @@ export class BlockStorage {
     /*────────────────────────────────────────────────────────────────────────────
       STORE  BLOCK - IMPLEMENTATION
     ────────────────────────────────────────────────────────────────────────────*/
-    storeBlock(
-        signedBlock: SignedBlockStruct,
-        options?: {
-            hash?: Hash;
-            coordinates?: { forkId: ForkId; height: BlockHeight };
-        }
-    ): Hash {
+    storeBlock(signedBlock: SignedBlockStruct, options?: StoreOptions): Hash {
         // Convert SignedBlock to BlockConfirmation (empty signatures)
         const blockConfirmation: BlockConfirmationStruct = {
             signedBlock: signedBlock,
@@ -51,10 +49,7 @@ export class BlockStorage {
     ────────────────────────────────────────────────────────────────────────────*/
     storeBlockConfirmation(
         blockConfirmation: BlockConfirmationStruct,
-        options?: {
-            hash?: Hash;
-            coordinates?: { forkId: ForkId; height: BlockHeight };
-        }
+        options?: StoreOptions
     ): Hash {
         return this._storeBlockConfirmationWithOptions(
             blockConfirmation,
@@ -209,27 +204,9 @@ export class BlockStorage {
         return `${coordinates.forkId}:${coordinates.height}`;
     }
 
-    private _storeBlockConfirmation(
-        blockConfirmation: BlockConfirmationStruct
-    ): Hash {
-        const blockHash = ethers.keccak256(
-            blockConfirmation.signedBlock.encodedBlock
-        );
-        const block = Block.decode(blockConfirmation.signedBlock.encodedBlock);
-
-        return this._storeBlockConfirmationWithKeys(
-            blockConfirmation,
-            blockHash,
-            block.coordinates
-        );
-    }
-
     private _storeBlockConfirmationWithOptions(
         blockConfirmation: BlockConfirmationStruct,
-        options?: {
-            hash?: Hash;
-            coordinates?: { forkId: ForkId; height: BlockHeight };
-        }
+        options?: StoreOptions
     ): Hash {
         // Determine hash - use provided or compute
         const blockHash =
@@ -242,18 +219,7 @@ export class BlockStorage {
             Block.decode(blockConfirmation.signedBlock.encodedBlock)
                 .coordinates;
 
-        return this._storeBlockConfirmationWithKeys(
-            blockConfirmation,
-            blockHash,
-            coordinates
-        );
-    }
-
-    private _storeBlockConfirmationWithKeys(
-        blockConfirmation: BlockConfirmationStruct,
-        blockHash: Hash,
-        coordinates: BlockCoordinates
-    ): Hash {
+        // Store the block confirmation
         const coordinateKey = this.coordinatesToKey(coordinates);
         const existingBlock = this.hashToBlockMap.get(blockHash);
 
@@ -267,8 +233,8 @@ export class BlockStorage {
 
             return blockHash;
         }
-        // If no existing block, store new block
 
+        // If no existing block, store new block
         this.hashToBlockMap.set(blockHash, blockConfirmation);
         this.coordinatesToBlockMap.set(coordinateKey, blockConfirmation);
         return blockHash;

--- a/src/storage/BlockStorage.ts
+++ b/src/storage/BlockStorage.ts
@@ -25,88 +25,41 @@ export class BlockStorage {
     // ====================================
 
     /*────────────────────────────────────────────────────────────────────────────
-      INSERT BLOCK - OVERLOAD SIGNATURES
-    ────────────────────────────────────────────────────────────────────────────*/
-
-    /** Insert signed block with auto-computed keys */
-    storeBlock(signedBlock: SignedBlockStruct): Hash;
-
-    /** Insert signed block with provided keys */
-    storeBlock(
-        signedBlock: SignedBlockStruct,
-        blockHash: Hash,
-        forkId: ForkId,
-        height: BlockHeight
-    ): Hash;
-
-    /*────────────────────────────────────────────────────────────────────────────
       STORE  BLOCK - IMPLEMENTATION
     ────────────────────────────────────────────────────────────────────────────*/
     storeBlock(
         signedBlock: SignedBlockStruct,
-        blockHash?: Hash,
-        forkId?: ForkId,
-        height?: BlockHeight
+        options?: {
+            hash?: Hash;
+            coordinates?: { forkId: ForkId; height: BlockHeight };
+        }
     ): Hash {
-        const hasKeys =
-            blockHash !== undefined &&
-            forkId !== undefined &&
-            height !== undefined;
-
         // Convert SignedBlock to BlockConfirmation (empty signatures)
         const blockConfirmation: BlockConfirmationStruct = {
             signedBlock: signedBlock,
             signatures: [] // Starts empty, ready for peer confirmations
         };
 
-        return hasKeys
-            ? this._storeBlockConfirmationWithKeys(
-                  blockConfirmation,
-                  blockHash,
-                  { forkId, height }
-              )
-            : this._storeBlockConfirmation(blockConfirmation);
+        return this._storeBlockConfirmationWithOptions(
+            blockConfirmation,
+            options
+        );
     }
-
-    /*────────────────────────────────────────────────────────────────────────────
-      STORE BLOCK CONFIRMATION - OVERLOAD SIGNATURES
-    ────────────────────────────────────────────────────────────────────────────*/
-
-    /** Insert block confirmation with auto-computed keys */
-    storeBlockConfirmation(blockConfirmation: BlockConfirmationStruct): Hash;
-
-    /** Insert block confirmation with provided keys */
-    storeBlockConfirmation(
-        blockConfirmation: BlockConfirmationStruct,
-        blockHash: Hash,
-        forkId: ForkId,
-        height: BlockHeight
-    ): Hash;
 
     /*────────────────────────────────────────────────────────────────────────────
       STORE BLOCK CONFIRMATION - IMPLEMENTATION
     ────────────────────────────────────────────────────────────────────────────*/
     storeBlockConfirmation(
         blockConfirmation: BlockConfirmationStruct,
-        blockHash?: Hash,
-        forkId?: ForkId,
-        height?: BlockHeight
+        options?: {
+            hash?: Hash;
+            coordinates?: { forkId: ForkId; height: BlockHeight };
+        }
     ): Hash {
-        const hasKeys =
-            blockHash !== undefined &&
-            forkId !== undefined &&
-            height !== undefined;
-
-        return hasKeys
-            ? this._storeBlockConfirmationWithKeys(
-                  blockConfirmation,
-                  blockHash,
-                  {
-                      forkId,
-                      height
-                  }
-              )
-            : this._storeBlockConfirmation(blockConfirmation);
+        return this._storeBlockConfirmationWithOptions(
+            blockConfirmation,
+            options
+        );
     }
 
     // ====================================
@@ -268,6 +221,31 @@ export class BlockStorage {
             blockConfirmation,
             blockHash,
             block.coordinates
+        );
+    }
+
+    private _storeBlockConfirmationWithOptions(
+        blockConfirmation: BlockConfirmationStruct,
+        options?: {
+            hash?: Hash;
+            coordinates?: { forkId: ForkId; height: BlockHeight };
+        }
+    ): Hash {
+        // Determine hash - use provided or compute
+        const blockHash =
+            options?.hash ??
+            ethers.keccak256(blockConfirmation.signedBlock.encodedBlock);
+
+        // Determine coordinates - use provided or compute
+        const coordinates =
+            options?.coordinates ??
+            Block.decode(blockConfirmation.signedBlock.encodedBlock)
+                .coordinates;
+
+        return this._storeBlockConfirmationWithKeys(
+            blockConfirmation,
+            blockHash,
+            coordinates
         );
     }
 

--- a/test/storage/BlockStorage.test.ts
+++ b/test/storage/BlockStorage.test.ts
@@ -38,12 +38,7 @@ describe("BlockStorage", () => {
 
     describe("CREATE - storeBlock()", () => {
         it("should store SignedBlock and return same hash with empty signatures", () => {
-            const hash = storage.storeBlock(
-                mockSignedBlock,
-                mockBlockHash,
-                mockForkId,
-                mockHeight
-            );
+            const hash = storage.storeBlock(mockSignedBlock);
 
             expect(hash).to.equal(mockBlockHash);
             const stored = storage.getBlockConfirmation(hash);
@@ -66,10 +61,7 @@ describe("BlockStorage", () => {
             };
 
             const hash1 = storage.storeBlockConfirmation(
-                firstBlockConfirmation,
-                mockBlockHash,
-                mockForkId,
-                mockHeight
+                firstBlockConfirmation
             );
 
             // Second block confirmation with same shared signature + different unique signature
@@ -80,9 +72,7 @@ describe("BlockStorage", () => {
 
             const hash2 = storage.storeBlockConfirmation(
                 secondBlockConfirmation,
-                mockBlockHash,
-                mockForkId,
-                mockHeight
+                { hash: mockBlockHash }
             );
 
             // Should return same hash
@@ -111,26 +101,25 @@ describe("BlockStorage", () => {
         });
 
         it("should insert block confirmation with provided keys", () => {
-            const hash = storage.storeBlockConfirmation(
-                mockBlockConfirmation,
-                mockBlockHash,
+            const hash = storage.storeBlockConfirmation(mockBlockConfirmation, {
+                coordinates: { forkId: mockForkId, height: mockHeight }
+            });
+
+            const stored = storage.getBlockConfirmation(hash);
+            const stored_by_coords = storage.getBlockConfirmation(
                 mockForkId,
                 mockHeight
             );
-
-            const stored = storage.getBlockConfirmation(hash);
             expect(stored).to.equal(mockBlockConfirmation);
+            expect(stored_by_coords).to.equal(mockBlockConfirmation);
         });
     });
 
     describe("READ - getBlockConfirmation()", () => {
         beforeEach(() => {
-            storage.storeBlockConfirmation(
-                mockBlockConfirmation,
-                mockBlockHash,
-                mockForkId,
-                mockHeight
-            );
+            storage.storeBlockConfirmation(mockBlockConfirmation, {
+                coordinates: { forkId: mockForkId, height: mockHeight }
+            });
         });
 
         it("should get block by hash", () => {
@@ -165,12 +154,9 @@ describe("BlockStorage", () => {
 
     describe("UPDATE - insertSignature()", () => {
         beforeEach(() => {
-            storage.storeBlockConfirmation(
-                mockBlockConfirmation,
-                mockBlockHash,
-                mockForkId,
-                mockHeight
-            );
+            storage.storeBlockConfirmation(mockBlockConfirmation, {
+                coordinates: { forkId: mockForkId, height: mockHeight }
+            });
         });
 
         it("should insert signature by hash", () => {
@@ -272,12 +258,7 @@ describe("BlockStorage", () => {
 
     describe("DELETE - deleteBlock()", () => {
         beforeEach(() => {
-            storage.storeBlockConfirmation(
-                mockBlockConfirmation,
-                mockBlockHash,
-                mockForkId,
-                mockHeight
-            );
+            storage.storeBlockConfirmation(mockBlockConfirmation);
         });
 
         it("should delete by hash", () => {
@@ -330,9 +311,7 @@ describe("BlockStorage", () => {
             // Store the second blockConfirmation - this should merge signatures in storage
             const hash2 = storageWithProxy.blocks.storeBlockConfirmation(
                 secondBlockConfirmation,
-                hash1,
-                mockForkId,
-                mockHeight
+                { hash: hash1 }
             );
 
             expect(hash1).to.equal(hash2);
@@ -359,9 +338,7 @@ describe("BlockStorage", () => {
 
             storageWithProxy.blocks.storeBlockConfirmation(
                 originalBlockConfirmation,
-                mockBlockHash,
-                mockForkId,
-                mockHeight
+                { hash: mockBlockHash }
             );
 
             // Read the blockConfirmation from storage


### PR DESCRIPTION
Block storage interface is annoying
it is mixing up optional hash with optional coordinates

so if want to provide optional hashkey you also need to provide coordinates and vice-versa
not intuitive and not convenient

this PR offers `options` based interface

i think it's better, easier and clear to use

as side bonus, it cuts down lines of code