### PR TITLE
DisputeAuditingData cleanup

### DIFF
--- a/contracts/V1/StateChannelDiamondProxy/DisputeManagerFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeManagerFacet.sol
@@ -143,14 +143,6 @@ contract DisputeManagerFacet is StateChannelCommon {
         require(_isCorrectAuditingData(dispute, disputeAuditingData), ErrorDisputeWrongAuditingData());
         require(_isCorrectGenesis(dispute), ErrorDisputeGenesisInvalid());
         require(_verifyStateProof(dispute, disputeAuditingData), ErrorDisputeStateProofInvalid());
-        require(
-            _verifyJoinChannelBlocks(
-                disputeAuditingData.latestStateSnapshot.snapshotData.latestJoinChannelBlockHash,
-                dispute.onChainLatestJoinChannelBlockHash,
-                disputeAuditingData.joinChannelBlocks
-            ),
-            ErrorDisputeJoinChannelBlocksInvalid()
-        );
         require(_verifyExitChannelBlocks(dispute, disputeAuditingData), ErrorDisputeExitChannelBlocksInvalid());
 
         FraudProofVerificationContext memory proofContext =
@@ -159,11 +151,13 @@ contract DisputeManagerFacet is StateChannelCommon {
         slashes = StateChannelUtilLibrary.concatAddressArraysNoDuplicates(slashes, dispute.onChainSlashes);
         address[] memory removals = _calculateRemovals(dispute);
 
+        // Disputes don't apply joins directly, just reduce
+        JoinChannelBlock[] memory emptyJoinChannelBlocks = new JoinChannelBlock[](0);
         DisputeOutputState memory disputeOutputState = generateDisputeOutputState(
             disputeAuditingData.latestStateStateMachineState,
             slashes,
             removals,
-            disputeAuditingData.joinChannelBlocks,
+            emptyJoinChannelBlocks,
             disputeAuditingData.latestStateSnapshot
         );
         SnapshotData memory latestSnapshotData = disputeAuditingData.latestStateSnapshot.snapshotData;
@@ -181,7 +175,7 @@ contract DisputeManagerFacet is StateChannelCommon {
         SnapshotData memory outputSnapshotData = SnapshotData({
             stateMachineStateHash: keccak256(disputeOutputState.encodedModifiedState),
             participants: getStatemachineParticipants(disputeOutputState.encodedModifiedState),
-            latestJoinChannelBlockHash: disputeAuditingData.outputStateSnapshot.snapshotData.latestJoinChannelBlockHash, // This has been verified in _verifyJoinChannelBlocks
+            latestJoinChannelBlockHash: disputeAuditingData.genesisStateSnapshot.snapshotData.latestJoinChannelBlockHash, // Joins are not applied in disputes, but in reduce
             latestExitChannelBlockHash: keccak256(abi.encode(disputeOutputState.exitBlock)),
             totalDeposits: disputeOutputState.totalDeposits,
             totalWithdrawals: disputeOutputState.totalWithdrawals
@@ -816,14 +810,6 @@ contract DisputeManagerFacet is StateChannelCommon {
         if (dispute.latestStateSnapshotHash != keccak256(abi.encode(disputeAuditingData.latestStateSnapshot))) {
             return false;
         }
-        //check outputStateSnapshot
-        if (
-            dispute.outputSnapshotDataHash
-                != keccak256(abi.encode(disputeAuditingData.outputStateSnapshot.snapshotData))
-        ) {
-            return false;
-        }
-
         //check latestStateStateMachineState
         if (
             disputeAuditingData.latestStateSnapshot.snapshotData.stateMachineStateHash
@@ -831,18 +817,6 @@ contract DisputeManagerFacet is StateChannelCommon {
         ) {
             return false;
         }
-
-        //check joinChannelBlocks (linked to latestSateSnapshot, chained internally and outputStateSnapshot commits to the head)
-        bytes32 previousJoinChannelBlockHash =
-            disputeAuditingData.latestStateSnapshot.snapshotData.latestJoinChannelBlockHash;
-        for (uint256 i = 0; i < disputeAuditingData.joinChannelBlocks.length; i++) {
-            if (previousJoinChannelBlockHash != disputeAuditingData.joinChannelBlocks[i].previousBlockHash) {
-                return false;
-            }
-            previousJoinChannelBlockHash = keccak256(abi.encode(disputeAuditingData.joinChannelBlocks[i]));
-        }
-        return previousJoinChannelBlockHash
-            == disputeAuditingData.outputStateSnapshot.snapshotData.latestExitChannelBlockHash;
     }
 
     function _commitToDisputeReducedResult(

--- a/contracts/V1/StateChannelManagerEvents.sol
+++ b/contracts/V1/StateChannelManagerEvents.sol
@@ -19,10 +19,6 @@ interface StateChannelManagerEvents {
 
     event StateSnapshotUpdated(bytes32 indexed channelId, StateSnapshot stateSnapshot, uint256 timestamp);
 
-    event OutputStateSnapshotVerified(
-        bytes32 indexed channelId, StateSnapshot stateSnapshot, bytes32 disputeCommitment
-    );
-
     event JoinChannelProcessed(
         bytes32 indexed channelId, JoinChannelBlock joinChannelBlock, uint256 timestamp, Balance totalDeposits
     );

--- a/contracts/V1/types/DisputeTypes.sol
+++ b/contracts/V1/types/DisputeTypes.sol
@@ -33,8 +33,6 @@ struct Dispute {
     FraudProof[] fraudProofs;
     /// @notice participants that were slashed on chain
     address[] onChainSlashes;
-    /// @dev Hash of the latest block (head) of the JoinChannel blockchain present on-chain in dispute on-chain storage.
-    bytes32 onChainLatestJoinChannelBlockHash;
     /// @notice Hash of output state (latest on-chain state)
     /// @dev created after from dispute resolution
     bytes32 outputSnapshotDataHash;
@@ -113,10 +111,8 @@ struct OnChainSlash {
 struct DisputeAuditingData {
     StateSnapshot genesisStateSnapshot;
     StateSnapshot latestStateSnapshot;
-    StateSnapshot outputStateSnapshot;
     StateSnapshot[] milestoneSnapshots; //for K milestones there will be K-1 snapshots, since the first milestone is the genesisSnapshot
     bytes latestStateStateMachineState;
-    JoinChannelBlock[] joinChannelBlocks;
     /// @notice Stores all exits since genesis
     /// @dev the time range of the exit is from genesis to the challenge deadline (new fork)
     ExitChannelBlock[] exitChannelBlocks;

--- a/src/rpc/MainRpcService.ts
+++ b/src/rpc/MainRpcService.ts
@@ -36,7 +36,7 @@ class MainRpcService {
 
     //RPC Services
     initHandshakeService = new InitHandshakeService(this.self);
-    webRTCSetunService = new WebRTCSetupService(this.self);
+    webRTCSetupService = new WebRTCSetupService(this.self);
     stateTransitionService = new StateTransitionService(this.self);
     testJoinChannelService = new TESTJoinChannelService(this.self);
     dhtDiscoveryService = new DHTDiscoveryService(this.self);
@@ -67,15 +67,15 @@ class MainRpcService {
 
     // ********************* WebRTCSetupService *********************
     public async onOfferWebRTC(offer: string) {
-        this.webRTCSetunService.onOfferWebRTC(offer);
+        this.webRTCSetupService.onOfferWebRTC(offer);
     }
 
     public async onAnswerWebRTC(answer: string) {
-        this.webRTCSetunService.onAnswerWebRTC(answer);
+        this.webRTCSetupService.onAnswerWebRTC(answer);
     }
 
     public async onIceCandidate(serializedCandidate: string) {
-        this.webRTCSetunService.onIceCandidate(serializedCandidate);
+        this.webRTCSetupService.onIceCandidate(serializedCandidate);
     }
 
     // ********************* TESTJoinChannelService - TODO! TEST this is only for test *********************

--- a/src/rpc/services/InitHandshakeService.ts
+++ b/src/rpc/services/InitHandshakeService.ts
@@ -137,7 +137,7 @@ class InitHandshakeService extends ARpcService {
             this.mainRpcService.p2pManager.p2pSigner.signerAddress <
                 signerAddress
         ) {
-            this.mainRpcService.webRTCSetunService.initiateWebRTC();
+            this.mainRpcService.webRTCSetupService.initiateWebRTC();
         }
         console.log(`onInitHandshakeRESPONSE - done`);
         //TODO! RESOLVE SUCCESS - set some flag also


### PR DESCRIPTION
Removed `outputStateSnapshot` from `DisputeAuditingData` since the output is generated during auditing. In other words only input data should be part of the auditing data - no `output/posterior` data is needed.
Removed `joinChannelBlocks` from `DisputeAuditingData` since disputes on their own don't apply `joins`, but `reduce` does, which is `stateful`. 

Removed also some logic for checking joins in disputes, since they're not applied there. 

Added a Trello card at the bottom of the `TODO` about `JoinChannel DA - requirement` - read that too 