### PR TITLE
remove `processStateTransition`

### DIFF
--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -277,22 +277,53 @@ class StateManager {
     // Passes the signedBlock through a verification pipeline and returns an execution flag based on the outcome
     public async onSignedBlock(
         signedBlock: SignedBlockStruct,
-        block?: Block
+        blk?: Block
     ): Promise<ExecutionFlags> {
         // Default everything to SUCCESS + no AgreementFlag
         let finalExecutionFlag: ExecutionFlags = ExecutionFlags.SUCCESS;
         let finalAgreementFlag: AgreementFlag | undefined = undefined;
-        const decodedBlock = block ?? Block.decode(signedBlock.encodedBlock);
+        const block = blk ?? Block.decode(signedBlock.encodedBlock);
 
         try {
             await this.mutex.lock();
             const result = await this.validationService.validateSignedBlock(
                 signedBlock,
-                decodedBlock
+                block
             );
 
             finalExecutionFlag = result.flag;
             finalAgreementFlag = result.agreementFlag;
+
+            // If validation passed, apply the transaction
+            if (result.success && result.flag === ExecutionFlags.SUCCESS) {
+                const applyResult = await this.applyTransaction(
+                    block.transaction
+                );
+                if (!applyResult.success) {
+                    finalExecutionFlag = ExecutionFlags.DISPUTE;
+                    finalAgreementFlag = AgreementFlag.INCORRECT_DATA;
+                } else {
+                    // store exit block, exit points, state snapshot and the block
+                    this.storeExitChannelBlock(
+                        applyResult.exitChannels,
+                        block.coordinates
+                    );
+
+                    this.handleStateSnapshotStorage(
+                        applyResult.encodedState,
+                        block.forkId
+                    );
+
+                    this.storage.blocks.storeBlock(signedBlock);
+
+                    // Schedule the success callback
+                    scheduleTask(
+                        applyResult.successCallback,
+                        0,
+                        "stateTransitionSuccessCallback"
+                    );
+                }
+            }
 
             return finalExecutionFlag;
         } finally {
@@ -363,22 +394,9 @@ class StateManager {
         exitChannels: ExitChannelStruct[];
     }> {
         const previousStateHash = await this.getEncodedStateKecak256();
-        let { success, successCallback, exitChannels } =
+        const { success, successCallback, exitChannels } =
             await this.stateMachine.stateTransition(transaction);
         const encodedState = await this.stateMachine.getState();
-
-        //This is done before the state snapshot is created
-        //This is because the exit channels need to be taken into account when creating the state snapshot
-        const coordinates: BlockCoordinates = {
-            forkId: transaction.header.forkId,
-            height: Number(transaction.header.transactionCnt)
-        };
-        this.storeExitChannelBlock(exitChannels, coordinates);
-
-        this.handleStateSnapshotStorage(
-            encodedState,
-            Number(transaction.header.forkCnt)
-        );
 
         return {
             success,
@@ -637,19 +655,21 @@ class StateManager {
             exitChannelBlock,
             totalWithdrawals
         );
+        this.storage.exitPoints.storeExitPoint(
+            coordinates.forkId,
+            coordinates.height
+        );
     }
 
-    //TODO: check that these storage typings are the best ones to use here
-    // needs to check if its ok to store a number or a BigNumberish
     private async handleStateSnapshotStorage(
-        encodedState: string,
-        forkCnt: number
+        encodedState: Bytes,
+        forkId: ForkId
     ) {
         const stateSnapshot = await this.createStateSnapshot(
             encodedState,
-            forkCnt
+            forkId
         );
-        this.storageModule.storeStateSnapshot(stateSnapshot);
+        this.storage.stateSnapshots.storeStateSnapshot(stateSnapshot);
     }
 
     // Tries to timeout a participant by checking did the participant fail to transition the state within time - if successful -> creates a dispute

--- a/src/stateManager/ValidationService.ts
+++ b/src/stateManager/ValidationService.ts
@@ -6,7 +6,6 @@ import DisputeHandler from "@/DisputeHandler";
 import { ethers } from "ethers";
 import { AStateChannelManagerProxy } from "@typechain-types/contracts/V1/StateChannelDiamondProxy";
 import {
-    scheduleTask,
     subjectiveTimingFlag,
     SignatureUtils,
     getActiveParticipants,
@@ -110,8 +109,8 @@ export default class ValidationService {
         if (blk.author !== nextToWrite)
             return dispute(AgreementFlag.INCORRECT_DATA);
 
-        // Process state transition
-        return this.processStateTransition(blk, signedBlock);
+        // All validation passed - return success
+        return success();
     }
 
     public async validateBlockConfirmation(
@@ -232,40 +231,6 @@ export default class ValidationService {
     }
 
     /*────────────────────── PRIVATE HELPERS ─────────────────────*/
-
-    private async processStateTransition(
-        block: Block,
-        signed: SignedBlockStruct
-    ): Promise<ValidationResult> {
-        const previousStateHash = await this.stateMachine
-            .getState()
-            .then(ethers.keccak256);
-        let {
-            success: txOK,
-            successCallback,
-            exitChannels: _
-        } = await this.stateMachine.stateTransition(block.transaction);
-
-        const encodedState = await this.stateMachine.getState();
-        const stateHash = ethers.keccak256(encodedState);
-
-        // TODO: get current state snapshot and previous block hash
-        // const currentStateSnapshotHash = "";
-        // const previousBlockHash = "";
-
-        // const hashOK =
-        //     currentStateSnapshotHash === block.stateSnapshotHash &&
-        //     previousBlockHash === block.previousBlockHash;
-
-        // TEMPORARY
-        const hashOK = true;
-
-        if (!txOK || !hashOK) return dispute(AgreementFlag.INCORRECT_DATA);
-
-        this.agreementManager.addBlock(block, signed.signature, encodedState);
-        scheduleTask(successCallback, 0, "stateTransitionSuccessCallback");
-        return success();
-    }
 
     /* subjective time window */
     private async isEnoughTimeSubjective(


### PR DESCRIPTION

## 📋 Description


#### Problem

`processStateTransition` is misleading to be in `ValidationService`

Also it is plain wrong
transaction is applied once "to validate"
and second time (on already transitioned state)
to "actaully apply"

#### Solution

- Removed `processStateTransition` , apply transaction once, in `StateManager`
- moved storage ops out of `applyTransaction` and into `onSignedBlock`