### PR TITLE
Fix killdispute

### DIFF
--- a/contracts/V1/StateChannelDiamondProxy/DisputeVerificationFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeVerificationFacet.sol
@@ -535,7 +535,7 @@ contract DisputeVerificationFacet is StateChannelCommon {
         // require that the dispute window exists and is not expired
         require(
             disputeWindow.evidence.creationTimestamp != 0
-                && block.timestamp < disputeWindow.evidence.creationTimestamp + getEvidenceTime(),
+                && block.timestamp < disputeWindow.evidence.creationTimestamp + getKillTime(),
             ErrorDisputeExpired()
         );
 


### PR DESCRIPTION
Quick fix so `killDispute` uses `killTime` to check is the `DisputeWindow expired` instead of `evidenceTime` - I'll create a PR for the dispute part of the diagrams these days when it's all done, but there's enough to take a look already (diagrams branch). 