### PR TITLE
clear yarn compile warnings

### DIFF
--- a/contracts/V1/AStateMachine.sol
+++ b/contracts/V1/AStateMachine.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 import "./DataTypes.sol";
@@ -27,7 +28,7 @@ abstract contract AStateMachine {
 
     // modifies the state to add a new participant to the channel
     function _joinChannel(
-        JoinChannel memory joinChannel
+        JoinChannel memory __joinChannel // use double underscore
     ) internal virtual returns (bool);
 
     // define the logic that punishes a participant for misbehaving (can also remove the participant from the state channel)
@@ -35,7 +36,7 @@ abstract contract AStateMachine {
         address adr
     ) internal virtual returns (bool, ProcessExit memory);
 
-    // similart to _slashParticipant, but doesn't have to punish the player - just removes them from the state channel
+    // similar to _slashParticipant, but doesn't have to punish the player - just removes them from the state channel
     function _removeParticipant(
         address adr
     ) internal virtual returns (bool, ProcessExit memory);
@@ -53,9 +54,9 @@ abstract contract AStateMachine {
     }
 
     function joinChannel(
-        JoinChannel memory joinChannel
+        JoinChannel memory __joinChannel
     ) external _nonReentrant returns (bool) {
-        return _joinChannel(joinChannel);
+        return _joinChannel(__joinChannel);
     }
 
     function slashParticipant(

--- a/contracts/V1/DataTypes.sol
+++ b/contracts/V1/DataTypes.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 //Just so typechain generates types for the structs bellow

--- a/contracts/V1/DisputeTypes.sol
+++ b/contracts/V1/DisputeTypes.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 import "./DataTypes.sol";

--- a/contracts/V1/StateChannelDiamondProxy/AStateChannelManagerProxy.sol
+++ b/contracts/V1/StateChannelDiamondProxy/AStateChannelManagerProxy.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 import "./StateChannelCommon.sol";
@@ -203,7 +204,7 @@ abstract contract AStateChannelManagerProxy is
         address[] memory p = new address[](1);
         p[0] = leaveChannel.participant;
         (
-            bytes memory encodedState,
+            bytes memory _encodedState, //add underscore to this var
             ProcessExit[] memory pe,
             uint successCnt
         ) = removeParticipantsFromStateMachine(encodedState, p);
@@ -219,7 +220,7 @@ abstract contract AStateChannelManagerProxy is
         );
 
         //setState
-        setState(leaveChannel.channelId, encodedState);
+        setState(leaveChannel.channelId, _encodedState);
         //TODO? - what if somone lies and triggeres this later - should not be wated upon and should trigget dispute from others if they play a move -> they're not a particopant anymore
     }
 
@@ -300,14 +301,14 @@ abstract contract AStateChannelManagerProxy is
         bytes memory encodedState,
         JoinChannel[] memory joinCahnnels
     ) internal returns (bytes memory encodedModifiedState, uint successCnt) {
-        uint successCnt = 0;
+       uint _successCntLocal1 = 0;  //change var name
         stateMachineImplementation.setState(encodedState);
         for (uint i = 0; i < joinCahnnels.length; i++) {
             bool success = stateMachineImplementation.joinChannel(
                 joinCahnnels[i]
             );
             // require(success, "JoinChannel failed");
-            if (success) successCnt++;
+            if (success) _successCntLocal1++;
         }
         return (stateMachineImplementation.getState(), successCnt);
     }
@@ -326,14 +327,14 @@ abstract contract AStateChannelManagerProxy is
         ProcessExit[] memory processExits = new ProcessExit[](
             slashedParticipants.length
         );
-        uint successCnt = 0;
+        uint _successCntLocal2 = 0; //change var name
         stateMachineImplementation.setState(encodedState);
         for (uint i = 0; i < slashedParticipants.length; i++) {
             bool success;
-            (success, processExits[successCnt]) = stateMachineImplementation
+            (success, processExits[_successCntLocal2]) = stateMachineImplementation
                 .slashParticipant(slashedParticipants[i]);
             // require(success, "Slash failed");
-            if (success) successCnt++;
+            if (success) _successCntLocal2++;
         }
         return (
             stateMachineImplementation.getState(),
@@ -350,7 +351,7 @@ abstract contract AStateChannelManagerProxy is
         returns (
             bytes memory encodedModifiedState,
             ProcessExit[] memory,
-            uint successCnt
+            uint _successCnt  //add underscore
         )
     {
         ProcessExit[] memory processExits = new ProcessExit[](
@@ -373,13 +374,13 @@ abstract contract AStateChannelManagerProxy is
     }
 
     function executeStateTransitionOnState(
-        bytes32 channelId,
+         bytes32 /* _channelId */, //commened on here "_channelId"
         bytes memory encodedState,
         Transaction memory _tx
     ) public override returns (bool, bytes memory) {
         //channelId not used currenlty since all channels have the same SM - later they can be mapped to different ones
         stateMachineImplementation.setState(encodedState);
-        (bool success, bytes memory encodedReturnValue) = address(
+        (bool success, /*bytes memory encodedReturnValue*/) = address(
             stateMachineImplementation
         ).call(abi.encodeCall(stateMachineImplementation.stateTransition, _tx));
         return (success, stateMachineImplementation.getState());

--- a/contracts/V1/StateChannelDiamondProxy/DisputeErrors.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeErrors.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 error ErrorDisputeInProgrees();

--- a/contracts/V1/StateChannelDiamondProxy/DisputeManagerFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeManagerFacet.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 import "./StateChannelCommon.sol";
@@ -947,7 +948,7 @@ contract DisputeManagerFacet is StateChannelCommon {
     function isGoodTimestampNonDeterministic(
         uint previousCanonicalTimestamp,
         Block memory block2
-    ) internal returns (bool) {
+    ) internal view returns (bool) { //change this funtion to view
         uint timestamp = block2.transaction.header.timestamp;
         uint lastTransactionTimestamp = previousCanonicalTimestamp;
 

--- a/contracts/V1/StateChannelDiamondProxy/StateChannelCommon.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateChannelCommon.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
@@ -22,7 +23,7 @@ contract StateChannelCommon is
     }
 
     function getNextToWrite(
-        bytes32 channelId,
+        bytes32 /* _channelId */, //commened on "/* _channelId */"
         bytes memory encodedState
     ) public virtual returns (address) {
         //channelId not used currenlty since all channels have the same SM - later they can be mapped to different ones

--- a/contracts/V1/StateChannelDiamondProxy/StateChannelManagerStorage.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateChannelManagerStorage.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 import "../DisputeTypes.sol";

--- a/contracts/V1/StateChannelDiamondProxy/StateChannelUtilLibrary.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateChannelUtilLibrary.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";

--- a/contracts/V1/StateChannelManagerEvents.sol
+++ b/contracts/V1/StateChannelManagerEvents.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 import "./DisputeTypes.sol";

--- a/contracts/V1/StateChannelManagerInterface.sol
+++ b/contracts/V1/StateChannelManagerInterface.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 import "./DataTypes.sol";

--- a/contracts/V1/examples/MathStateMachine/MathStateChannelManagerProxy.sol
+++ b/contracts/V1/examples/MathStateMachine/MathStateChannelManagerProxy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 import "../../StateChannelDiamondProxy/AStateChannelManagerProxy.sol";

--- a/contracts/V1/examples/MathStateMachine/MathStateMachine.sol
+++ b/contracts/V1/examples/MathStateMachine/MathStateMachine.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 import "../../AStateMachine.sol";

--- a/contracts/V1/examples/MathStateMachine/Types.sol
+++ b/contracts/V1/examples/MathStateMachine/Types.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 //Just so typechain generates types for the structs bellow

--- a/contracts/V1/helpers/LibraryTestContract.sol
+++ b/contracts/V1/helpers/LibraryTestContract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 //Used only to test the library - other contracts should use the library directly

--- a/contracts/common/DoubleLinkedList.sol
+++ b/contracts/common/DoubleLinkedList.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 // import "hardhat/console.sol";
 

--- a/contracts/test/SimpleNumberStorage.sol
+++ b/contracts/test/SimpleNumberStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.8;
 
 /**


### PR DESCRIPTION
AStateChannelManagerProxy.sol
207.bytes memory _encodedState,            //add underscore to this var
304.uint _successCntLocal1 = 0;              //change var name
330.uint _successCntLocal2 = 0;            //change var name
354.uint _successCnt                            //add underscore
377.bytes32 /* _channelId */,             //commened on here "_channelId"


StateChannelCommon.sol
26.bytes32 /* _channelId */,             //commened on "/* _channelId */"


DisputeManagerFacet.sol
951.) internal view returns (bool) {                   //change this funtion to view

AStateMachine
31. JoinChannel memory __joinChannel          // use double underscore