### PR TITLE
Sender transport - Idea

### DIFF
--- a/src/P2PManager.ts
+++ b/src/P2PManager.ts
@@ -49,7 +49,7 @@ class P2PManager implements IOnMessage {
             transport.send(serializedRPC);
         }
     }
-    public onRpc(serializedRpc: string) {
+    public onRpc(serializedRpc: string, senderTransport?: ATransport) {
         try {
             let rpc = deserializeRpc(serializedRpc);
             if (!rpc) {
@@ -60,8 +60,23 @@ class P2PManager implements IOnMessage {
                 //TODO!Disconnect
                 return;
             }
-            //TODO! set context - calling socket/profile (ATransport)!
-            this.localRpcService[rpc.method](...rpc.params);
+
+            // Execute RPC with transport context - transport is required
+            if (senderTransport) {
+                this.localRpcService.executeWithTransport(
+                    senderTransport,
+                    () => {
+                        (this.localRpcService as any)[rpc.method](
+                            ...rpc.params
+                        );
+                    }
+                );
+            } else {
+                // Error: RPC execution requires a sender transport
+                throw new Error(
+                    `RPC execution failed: no sender transport provided for method '${rpc.method}'`
+                );
+            }
         } catch (e) {
             //TODO - disconnect from peer
             console.error(e);

--- a/src/rpc/ARpcService.ts
+++ b/src/rpc/ARpcService.ts
@@ -1,10 +1,18 @@
 import { MainRpcService } from "@/rpc";
+import ATransport from "@/transport/ATransport";
 
 abstract class ARpcService {
     mainRpcService: MainRpcService;
 
     constructor(mainRpcService: MainRpcService) {
         this.mainRpcService = mainRpcService;
+    }
+
+    /**
+     * Get the current sender transport from the execution context
+     */
+    protected getCurrentSenderTransport(): ATransport | undefined {
+        return this.mainRpcService.getCurrentSenderTransport();
     }
 }
 

--- a/src/rpc/MainRpcService.ts
+++ b/src/rpc/MainRpcService.ts
@@ -31,8 +31,8 @@ class MainRpcService {
     p2pManager: P2PManager;
     rpcProxy = RpcProxy.createProxy(this);
 
-    //execution context
-    senderTransport: ATransport | undefined; //TODO! set this
+    //execution context - using context approach instead of shared variable
+    private currentTransport: ATransport | undefined;
     self = DEBUG_RPC ? DebugProxy.createProxy(this) : this;
 
     //RPC Services
@@ -46,6 +46,26 @@ class MainRpcService {
     constructor(p2pManager: P2PManager) {
         this.p2pManager = p2pManager;
         return this.self;
+    }
+
+    /**
+     * Execute an RPC method with transport context
+     */
+    public executeWithTransport<T>(transport: ATransport, fn: () => T): T {
+        const previousTransport = this.currentTransport;
+        this.currentTransport = transport;
+        try {
+            return fn();
+        } finally {
+            this.currentTransport = previousTransport;
+        }
+    }
+
+    /**
+     * Get the current sender transport from context
+     */
+    public getCurrentSenderTransport(): ATransport | undefined {
+        return this.currentTransport;
     }
 
     // ********************* InitHandskaheService *********************

--- a/src/rpc/services/InitHandshakeService.ts
+++ b/src/rpc/services/InitHandshakeService.ts
@@ -58,13 +58,16 @@ class InitHandshakeService extends ARpcService {
                 challengeHashBytes
             );
         console.log(`onInitHandshakeRequest - done`);
-        this.mainRpcService.rpcProxy
-            .onInitHandshakeResponse(
-                signature,
-                localTime,
-                this.mainRpcService.p2pManager.preferredTransport
-            )
-            .sendOne(this.mainRpcService.senderTransport!);
+        let senderTransport = this.getCurrentSenderTransport();
+        if (senderTransport) {
+            this.mainRpcService.rpcProxy
+                .onInitHandshakeResponse(
+                    signature,
+                    localTime,
+                    this.mainRpcService.p2pManager.preferredTransport
+                )
+                .sendOne(senderTransport);
+        }
     }
 
     public async onInitHandshakeResponse(
@@ -73,7 +76,7 @@ class InitHandshakeService extends ARpcService {
         preferredTransport: TransportType
     ) {
         console.log(`onInitHandshakeRESPONSE - start`);
-        let senderTransport = this.mainRpcService.senderTransport;
+        let senderTransport = this.getCurrentSenderTransport();
         if (!senderTransport) throw new Error("senderTransport is undefined");
         let challenge = this.getChallenge(senderTransport);
         if (!challenge) {

--- a/src/rpc/services/StateTransitionService.ts
+++ b/src/rpc/services/StateTransitionService.ts
@@ -16,7 +16,7 @@ class StateTransitionService extends ARpcService {
             );
         if (!keepConnection) {
             // Disconnect from peer and blacklist them
-            const senderTransport = this.mainRpcService.senderTransport;
+            const senderTransport = this.getCurrentSenderTransport();
             if (senderTransport) {
                 this.mainRpcService.p2pManager.disconnectAndBlacklistPeer(
                     senderTransport

--- a/src/rpc/services/WebRTCSetupService.ts
+++ b/src/rpc/services/WebRTCSetupService.ts
@@ -22,29 +22,31 @@ class WebRTCSetupService extends ARpcService {
                 this.mainRpcService.p2pManager
             );
 
+            let senderTransport = this.getCurrentSenderTransport();
+            if (!senderTransport)
+                return console.log("initiateWebRTC - no sender transport");
+
             // Handle ICE candidates
             connection.onicecandidate = (event: any) => {
                 if (event.candidate) {
                     let serializedCandidate = JSON.stringify(event.candidate);
                     this.mainRpcService.rpcProxy
                         .onIceCandidate(serializedCandidate)
-                        .sendOne(this.mainRpcService.senderTransport!);
+                        .sendOne(senderTransport);
                 }
             };
-
-            let senderTransport = this.mainRpcService.senderTransport; // catch it here since async call below
             let offer = await connection.createOffer();
             connection.setLocalDescription(offer);
             let adr =
                 this.mainRpcService.p2pManager.profileManager.getProfileByTransport(
-                    senderTransport!
+                    senderTransport
                 )?.evmAddress;
             if (!adr) return console.log("initiateWebRTC - no EVM address");
             this.connectionMap.set(adr.toString(), connection);
             let serializedOffer = JSON.stringify(offer);
             this.mainRpcService.rpcProxy
                 .onOfferWebRTC(serializedOffer)
-                .sendOne(senderTransport!);
+                .sendOne(senderTransport);
         } catch (e) {
             console.log("initiateWebRTC - error", e);
         }
@@ -54,13 +56,17 @@ class WebRTCSetupService extends ARpcService {
     public async onOfferWebRTC(serializedOffer: string) {
         try {
             let connection = new RTCPeerConnection();
+            let senderTransport = this.getCurrentSenderTransport();
+            if (!senderTransport)
+                return console.log("onOfferWebRTC - no sender transport");
+
             // Handle ICE candidates
             connection.onicecandidate = (event: any) => {
                 if (event.candidate) {
                     let serializedCandidate = JSON.stringify(event.candidate);
                     this.mainRpcService.rpcProxy
                         .onIceCandidate(serializedCandidate)
-                        .sendOne(this.mainRpcService.senderTransport!);
+                        .sendOne(senderTransport);
                 }
             };
             connection.ondatachannel = (event: any) => {
@@ -70,12 +76,11 @@ class WebRTCSetupService extends ARpcService {
                     this.mainRpcService.p2pManager
                 );
             };
-            let senderTransport = this.mainRpcService.senderTransport; // catch it here since async call below
             let adr =
                 this.mainRpcService.p2pManager.profileManager.getProfileByTransport(
-                    senderTransport!
+                    senderTransport
                 )?.evmAddress;
-            if (!adr) return console.log("initiateWebRTC - no EVM address");
+            if (!adr) return console.log("onOfferWebRTC - no EVM address");
             this.connectionMap.set(adr.toString(), connection);
             let offer = JSON.parse(serializedOffer);
             console.log("onOfferWebRTC - offer", offer);
@@ -85,7 +90,7 @@ class WebRTCSetupService extends ARpcService {
             let serializedAnswer = JSON.stringify(answer);
             this.mainRpcService.rpcProxy
                 .onAnswerWebRTC(serializedAnswer)
-                .sendOne(senderTransport!);
+                .sendOne(senderTransport);
         } catch (e) {
             console.log("onOfferWebRTC - error", e);
         }
@@ -94,9 +99,13 @@ class WebRTCSetupService extends ARpcService {
     //Ran by the peer who initiated the connection - this completes the handshake (negoation)
     public async onAnswerWebRTC(serializedAnswer: string) {
         try {
+            let senderTransport = this.getCurrentSenderTransport();
+            if (!senderTransport)
+                return console.log("onAnswerWebRTC - no sender transport");
+
             let adr =
                 this.mainRpcService.p2pManager.profileManager.getProfileByTransport(
-                    this.mainRpcService.senderTransport!
+                    senderTransport
                 )?.evmAddress;
             if (!adr) return console.log("onAnswerWebRTC - no EVM address");
             let connection = this.connectionMap.get(adr.toString());
@@ -116,9 +125,14 @@ class WebRTCSetupService extends ARpcService {
             let candidate = new RTCIceCandidate(
                 JSON.parse(serializedCandidate)
             );
+
+            let senderTransport = this.getCurrentSenderTransport();
+            if (!senderTransport)
+                return console.log("onIceCandidate - no sender transport");
+
             let adr =
                 this.mainRpcService.p2pManager.profileManager.getProfileByTransport(
-                    this.mainRpcService.senderTransport!
+                    senderTransport
                 )?.evmAddress;
             if (!adr) return console.log("onIceCandidate - no EVM address");
 

--- a/src/transport/HolepunchTransport.ts
+++ b/src/transport/HolepunchTransport.ts
@@ -34,10 +34,9 @@ class HolepunchTransport extends ATransport {
         this.holepunchSocket.write(serializedRPC);
     }
     onMessage(data: any): void {
-        this.p2pManager.localRpcService.senderTransport = this;
         const serializedRPC = data.toString();
         console.log("RECEIVED RPC", serializedRPC);
-        this.p2pManager.onRpc(serializedRPC);
+        this.p2pManager.onRpc(serializedRPC, this);
     }
     _close(): void {
         console.log("closing holepunch socket");

--- a/src/transport/LocalTransport.ts
+++ b/src/transport/LocalTransport.ts
@@ -18,9 +18,8 @@ class LocalTransport extends ATransport {
         this.ws.send(serializedRPC);
     }
     onMessage(data: any): void {
-        this.p2pManager.localRpcService.senderTransport = this;
         const serializedRPC = data.toString();
-        this.p2pManager.onRpc(serializedRPC);
+        this.p2pManager.onRpc(serializedRPC, this);
     }
     _close(): void {
         if (this.ws && this.ws.readyState === this.ws.OPEN) {

--- a/src/transport/WebRTCTransport.ts
+++ b/src/transport/WebRTCTransport.ts
@@ -28,12 +28,11 @@ class WebRTCTransport extends ATransport {
         this.webRTCChannel.send(serializedRPC);
     }
     onMessage(data: any): void {
-        this.p2pManager.localRpcService.senderTransport = this;
         if (data instanceof Uint8Array) data = Buffer.from(data);
         if (data instanceof Buffer) data = data.toString();
         const serializedRPC = data;
         console.log("WebRTC - onMessage", serializedRPC);
-        this.p2pManager.onRpc(serializedRPC);
+        this.p2pManager.onRpc(serializedRPC, this);
     }
     _close(): void {
         console.log("closing webRTC channel");


### PR DESCRIPTION


- P2PManager receives RPC with optional senderTransport parameter
- executeWithTransport() sets the transport in context before RPC execution
- RPC methods use getCurrentSenderTransport() to access the transport
- Context is automatically cleaned up after RPC execution 