### PR TITLE
[Ignore] Solidity compiler error - yul stack too deep

### DIFF
--- a/contracts/V1/StateChannelDiamondProxy/AConsumerFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/AConsumerFacet.sol
@@ -4,23 +4,9 @@ import "../types/DataTypes.sol";
 import "../StateChannelManagerInterface.sol";
 
 abstract contract AConsumerFacet {
-    function openChannel(bytes32 channelId, bytes[] calldata openChannelData, bytes[] calldata signatures)
-        external
-        virtual;
+    // function openChannelGenesis(JoinChannel[] memory successfulJoinChannels, bytes memory optionalOpeningData) external pure virtual returns (bytes memory encodedGenesisState, address[] memory participants);
 
-    function closeChannel(bytes32 channelId, bytes[] calldata closeChannelData, bytes[] calldata signatures)
-        external
-        virtual;
+    function deposit(JoinChannel memory joinChannel) external virtual returns (bool);
 
-    function removeParticipant(bytes32 channelId, bytes[] calldata removeParticipantData, bytes[] calldata signatures)
-        external
-        virtual;
-
-    function addParticipant(bytes32 channelId, bytes[] calldata addParticipantData, bytes[] calldata signatures)
-        external
-        virtual;
-
-    function depositAssetsComposable(JoinChannel memory joinChannel) external virtual returns (bool);
-
-    function withdrawAssetsComposable(ExitChannel memory exitChannel) external virtual returns (bool);
+    function withdraw(ExitChannel memory exitChannel) external virtual returns (bool);
 }

--- a/contracts/V1/StateChannelDiamondProxy/DisputeVerificationFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeVerificationFacet.sol
@@ -8,32 +8,6 @@ import "./utils/DisputeUtils.sol";
 import "./utils/BlockUtils.sol";
 
 contract DisputeVerificationFacet is StateChannelCommon {
-    function auditDispute(Dispute memory dispute, DisputeAuditingData memory disputeAuditingData)
-        external
-        onlySelf
-        returns (address[] memory slashParticipants)
-    {
-        require(isCorrectAuditingData(dispute, disputeAuditingData), ErrorDisputeWrongAuditingData());
-        require(_isCorrectGenesis(dispute), ErrorDisputeGenesisInvalid());
-        require(verifyStateProof(dispute, disputeAuditingData, true), ErrorDisputeStateProofInvalid());
-        require(_verifyDisputeExitChannelBlocks(dispute, disputeAuditingData), ErrorDisputeExitChannelBlocksInvalid());
-
-        // ***************** Generate output snapshot ***************
-        (SnapshotData memory outputSnapshotData, address[] memory slashes) = computeDisputeOutputSnapshotData(
-            dispute.input,
-            disputeAuditingData.latestStateSnapshot,
-            disputeAuditingData.latestStateStateMachineState,
-            disputeAuditingData.genesisStateSnapshotData.latestJoinChannelBlockHash
-        );
-
-        //verify outputStateSnapshot commitment
-        if (keccak256(abi.encode(outputSnapshotData)) != dispute.outputSnapshotDataHash) {
-            revert ErrorDisputeOutputStateSnapshotInvalid();
-        }
-
-        return slashes;
-    }
-
     function computeDisputeOutputSnapshotData(
         DisputeInput memory disputeInput,
         StateSnapshot memory latestStateSnapshot,
@@ -58,21 +32,6 @@ contract DisputeVerificationFacet is StateChannelCommon {
             totalDeposits: disputeOutputState.totalDeposits,
             totalWithdrawals: disputeOutputState.totalWithdrawals
         });
-    }
-
-    function challengeDispute(Dispute memory dispute, DisputeAuditingData memory disputeAuditingData) public {
-        uint256 gasLimit = getGasLimit();
-        bytes memory data = abi.encodeCall(DisputeVerificationFacet.auditDispute, (dispute, disputeAuditingData));
-        (bool success, bytes memory returnData) = address(this).call{gas: gasLimit}(data);
-        if (success) {
-            // auditing passed - dispute is correct, slash the challenger
-            if (_canParticipateInDisputes(dispute.input.channelId, msg.sender)) {
-                addOnChainSlashedParticipant(dispute.input.channelId, msg.sender);
-            }
-        } else {
-            // auditing failed - dispute is invalid, kill it
-            _killDispute(dispute);
-        }
     }
 
     function reduce(Dispute[] memory disputes) public view returns (ReduceOutput memory reducedOutput) {
@@ -326,13 +285,11 @@ contract DisputeVerificationFacet is StateChannelCommon {
 
         // Apply slashes
         ExitChannel[] memory slashExitChannels;
-        (outputState.encodedModifiedState, slashExitChannels) = StateChannelManagerProxy(address(this))
-            .applySlashesToStateMachine(outputState.encodedModifiedState, slashParticipants);
+        // (outputState.encodedModifiedState, slashExitChannels) = _applySlashesToStateMachine(outputState.encodedModifiedState, slashParticipants);
 
         // Apply removals
         ExitChannel[] memory removalExitChannels;
-        (outputState.encodedModifiedState, removalExitChannels) = StateChannelManagerProxy(address(this))
-            .removeParticipantsFromStateMachine(outputState.encodedModifiedState, removeParticipants);
+        // (outputState.encodedModifiedState, removalExitChannels) = _removeParticipantsFromStateMachine(outputState.encodedModifiedState, removeParticipants);
 
         // Combine exit channels and calculate totals
         ExitChannel[] memory allExitChannels =
@@ -757,4 +714,33 @@ contract DisputeVerificationFacet is StateChannelCommon {
         //verify outputStateSnapshot commitment
         return (keccak256(abi.encode(outputSnapshotData)) == dispute.outputSnapshotDataHash);
     }
+
+    // function _removeParticipantsFromStateMachine(bytes memory encodedState, address[] memory participants)
+    //     internal
+    //     returns (bytes memory encodedModifiedState, ExitChannel[] memory)
+    // {
+    //     ExitChannel[] memory exitChannels = new ExitChannel[](participants.length);
+    //     stateMachineImplementation.setState(encodedState);
+    //     for (uint256 i = 0; i < participants.length; i++) {
+    //         bool success;
+    //         (success, exitChannels[i]) = stateMachineImplementation.removeParticipant(participants[i]);
+    //         // require(success, "Remove failed");
+    //         require(success, ErrorDisputeStateMachineRemovingFailed());
+    //     }
+    //     return (stateMachineImplementation.getState(), exitChannels);
+    // }
+
+    // function _applySlashesToStateMachine(bytes memory encodedState, address[] memory slashedParticipants)
+    //     internal
+    //     returns (bytes memory encodedModifiedState, ExitChannel[] memory exitChannels)
+    // {
+    //     exitChannels = new ExitChannel[](slashedParticipants.length);
+    //     stateMachineImplementation.setState(encodedState);
+    //     for (uint256 i = 0; i < slashedParticipants.length; i++) {
+    //         bool success;
+    //         (success, exitChannels[i]) = stateMachineImplementation.slashParticipant(slashedParticipants[i]);
+    //         require(success, ErrorDisputeStateMachineSlashingFailed());
+    //     }
+    //     return (stateMachineImplementation.getState(), exitChannels);
+    // }
 }

--- a/contracts/V1/StateChannelDiamondProxy/Errors.sol
+++ b/contracts/V1/StateChannelDiamondProxy/Errors.sol
@@ -1,5 +1,9 @@
 pragma solidity ^0.8.8;
 
+//Channel Open
+// error ErrorChannelAlreadyOpen();
+// error ErrorAtLeastTwoParticipantsRequired();
+
 //Calldata errors
 error ErrorBlockCalldataTimestampTooLate();
 error ErrorBlockCalldataAlreadyPosted();
@@ -20,6 +24,9 @@ error ErrorNotGenesisSnapshot();
 //Join channel
 error ErrorJoinChannelExpired();
 error ErrorJoinChannelInvalidSignature();
+// error ErrorNoJoinChannelProvided();
+// error ErrorNoSuccessfulJoinChannel();
+// error ErrorJoinChannelAtomicFailure();
 
 //Exit channel
 error ErrorWithdrawalFailed();

--- a/contracts/V1/StateChannelDiamondProxy/JoinChannelFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/JoinChannelFacet.sol
@@ -35,58 +35,9 @@ contract JoinChannelFacet is StateChannelCommon {
         require(isValid, ErrorJoinChannelInvalidSignature());
 
         // Deposit funds
-        isValid = _processJoinChannelDeposits(jc);
-        require(isValid, ErrorJoinChannelFailed());
-    }
-
-    // ############### Processing Functions ###############
-
-    /**
-     * @dev Processes the JoinChannel for the specific StateChannelManager
-     */
-    function _processJoinChannelDeposits(JoinChannel memory jc) internal returns (bool success) {
-        bytes32 channelId = jc.channelId;
-
-        // Process the deposit for the specific StateChannelManager
-        success = StateChannelManagerProxy(address(this)).depositAssetsComposable(jc);
-        if (!success) return false;
-
-        // Create JoinChannelBlock
-        JoinChannelBlock memory jcb = _createJoinChannelBlock(jc);
-        bytes32 blockHash = keccak256(abi.encode(jcb));
-
-        // Update on-chain balance
-        ChannelBalance storage channelBalance = channelBalances[channelId];
-        // Get previous total deposits
-        Balance memory previousTotalDeposits =
-            channelBalance.onChainJoinChannelMap[channelBalance.latestJoinChannelBlockHash].totalDeposits;
-        // Calculate new totalDeposits
-        Balance memory newTotalDeposits = stateMachineImplementation.addBalance(previousTotalDeposits, jc.balance);
-
-        // Persist the onChainJoinChannel in the map
-        channelBalance.onChainJoinChannelMap[blockHash] = OnChainJoinChannel({
-            previousJoinChannelBlockHash: channelBalance.latestJoinChannelBlockHash,
-            timestamp: block.timestamp,
-            totalDeposits: newTotalDeposits
-        });
-        // Update the latestJoinChannelBlockHash;
-        channelBalance.latestJoinChannelBlockHash = blockHash;
-
-        // Update pending participants
-        disputeData[channelId].pendingParticipants.push(jc.participant);
-
-        emit JoinChannelProcessed(channelId, jcb, block.timestamp, newTotalDeposits);
-        return true;
-    }
-
-    function _createJoinChannelBlock(JoinChannel memory jc) internal view returns (JoinChannelBlock memory) {
-        JoinChannel[] memory jcs = new JoinChannel[](1);
-        ChannelBalance storage channelBalance = channelBalances[jc.channelId];
-        jcs[0] = jc;
-        bytes32 latestBlockHash = channelBalance.latestJoinChannelBlockHash;
-        bytes32 previousBlockHash = channelBalance.onChainJoinChannelMap[latestBlockHash].previousJoinChannelBlockHash;
-        JoinChannelBlock memory joinChannelBlock =
-            JoinChannelBlock({previousBlockHash: previousBlockHash, joinChannels: jcs});
-        return joinChannelBlock;
+        // JoinChannel[] memory jcs = new JoinChannel[](1);
+        // jcs[0] = jc;
+        // (JoinChannelBlock memory jcb, Balance memory newTotalDeposits) = StateChannelManagerProxy(address(this)).depositAssetsComposable(jcs, true);
+        // emit JoinChannelProcessed(channelId, jcb, block.timestamp, newTotalDeposits);
     }
 }

--- a/contracts/V1/StateChannelDiamondProxy/StateChannelManagerProxy.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateChannelManagerProxy.sol
@@ -74,63 +74,69 @@ contract StateChannelManagerProxy is StateChannelManagerInterface, StateChannelC
 
     // ********** Consumer Facet Delegation Functions **********
 
-    function openChannel(bytes32 channelId, bytes[] calldata openChannelData, bytes[] calldata signatures)
-        public
-        virtual
-        override
-    {
-        require(!isChannelOpen(channelId), "StateChannelManagerProxy: openChannel - channel already open");
-        AConsumerFacet(consumerFacetAddress).openChannel(channelId, openChannelData, signatures);
-    }
+    // function openChannel(OpenChannelConfirmation calldata openChannelConfirmation)
+    //     public
+    //     virtual
+    //     override
+    // {
+    //     // OpenChannel memory openChannelData = abi.decode(openChannelConfirmation.encodedOpenChannel, (OpenChannel));
+    //     // require(!isChannelOpen(openChannelData.channelId), ErrorChannelAlreadyOpen());
 
-    function closeChannel(bytes32 channelId, bytes[] calldata closeChannelData, bytes[] calldata signatures)
-        public
-        virtual
-        override
-    {
-        AConsumerFacet(consumerFacetAddress).closeChannel(channelId, closeChannelData, signatures);
-    }
+    //     // // set zero balance for on-chain deposits/withdrawals
+    //     // Balance memory zeroBalance = stateMachineImplementation.getZeroBalance();
+    //     // {
+    //     // ChannelBalance storage channelBalance = channelBalances[openChannelData.channelId];
+    //     // channelBalance.onChainJoinChannelMap[channelBalance.latestJoinChannelBlockHash].totalDeposits = zeroBalance;
+    //     // channelBalance.totalOnChainWithdrawals = zeroBalance;
+    //     // }
+    //     // // verify threshold signature - must be from all participants - this is deterministic - no race condition on-chain
+    //     // (bool isValid, string memory reason ) = StateChannelUtilLibrary.verifyThresholdSigned(
+    //     //     openChannelData.participants, openChannelConfirmation.encodedOpenChannel, openChannelConfirmation.signatures
+    //     // );
+    //     // require(isValid, reason);
 
-    function removeParticipant(bytes32 channelId, bytes[] calldata removeParticipantData, bytes[] calldata signatures)
-        public
-        virtual
-        override
-    {
-        AConsumerFacet(consumerFacetAddress).removeParticipant(channelId, removeParticipantData, signatures);
-    }
+    //     // JoinChannel[] memory joinChannels = new JoinChannel[](openChannelData.participants.length);
+    //     // for(uint256 i = 0; i < openChannelData.participants.length; i++) {
+    //     //     joinChannels[i] = JoinChannel({
+    //     //         channelId: openChannelData.channelId,
+    //     //         participant: openChannelData.participants[i],
+    //     //         deadlineTimestamp: openChannelData.deadlineTimestamp,
+    //     //         balance: openChannelData.balances[i]
+    //     //     });
+    //     // }
 
-    function addParticipant(bytes32 channelId, bytes[] calldata addParticipantData, bytes[] calldata signatures)
-        public
-        virtual
-        override
-    {
-        AConsumerFacet(consumerFacetAddress).addParticipant(channelId, addParticipantData, signatures);
-    }
+    //     // (JoinChannelBlock memory jcb, Balance memory newTotalDeposits) = depositAssetsComposable(joinChannels, openChannelData.isAtomic);
+
+    //     // require(jcb.joinChannels.length >= 2, ErrorAtLeastTwoParticipantsRequired());
+    //     // (bytes memory genesisState, address[] memory participants) = AConsumerFacet(consumerFacetAddress).openChannelGenesis(jcb.joinChannels, openChannelData.data);
+
+    //     // SnapshotData memory genesisSnapshotData = SnapshotData({
+    //     //     originForkId: bytes32(0),
+    //     //     stateMachineStateHash: keccak256(genesisState),
+    //     //     participants: participants,
+    //     //     latestJoinChannelBlockHash: keccak256(abi.encode(jcb)),
+    //     //     latestExitChannelBlockHash: bytes32(0),
+    //     //     totalDeposits: newTotalDeposits,
+    //     //     totalWithdrawals: zeroBalance
+    //     // });
+
+    //     // bytes32 forkId = keccak256(abi.encode(genesisSnapshotData));
+    //     // StateSnapshot memory genesisStateSnapshot = StateSnapshot({
+    //     //     snapshotData: genesisSnapshotData,
+    //     //     forkId: forkId,
+    //     //     blockHeight: 0,
+    //     //     timestamp: block.timestamp
+    //     // });
+
+    //     // stateSnapshots[openChannelData.channelId]= genesisStateSnapshot;
+
+    //     // emit ChannelOpened(openChannelData.channelId, genesisStateSnapshot, genesisState);
+    // }
 
     function uploadDispute(DisputeConfirmation memory disputeConfirmation) public override {
         _delegatecall(
             disputeManagerFacetAddress, abi.encodeCall(DisputeManagerFacet.uploadDispute, (disputeConfirmation))
         );
-    }
-
-    function auditDispute(Dispute memory dispute, DisputeAuditingData memory disputeAuditingData)
-        public
-        override
-        returns (address[] memory slashParticipants)
-    {
-        //This is done manually since the logic is different from other _delegatecalls
-
-        // Encode the function selector and arguments
-        bytes memory data = abi.encodeCall(DisputeVerificationFacet.auditDispute, (dispute, disputeAuditingData));
-        // Perform the low-level call with a gas limit
-        (bool success, bytes memory returnData) = disputeVerificationFacetAddress.delegatecall{gas: getGasLimit()}(data);
-        if (!success) {
-            assembly {
-                revert(add(returnData, 0x20), mload(returnData))
-            }
-        }
-        address[] memory slashedParticipants = abi.decode(returnData, (address[]));
-        return slashedParticipants;
     }
 
     function uploadDisputeWithCalldata(
@@ -140,13 +146,6 @@ contract StateChannelManagerProxy is StateChannelManagerInterface, StateChannelC
         _delegatecall(
             disputeManagerFacetAddress,
             abi.encodeCall(DisputeManagerFacet.uploadDisputeWithCalldata, (disputeConfirmation, disputeAuditingData))
-        );
-    }
-
-    function challengeDispute(Dispute memory dispute, DisputeAuditingData memory disputeAuditingData) public override {
-        _delegatecall(
-            disputeVerificationFacetAddress,
-            abi.encodeCall(DisputeVerificationFacet.challengeDispute, (dispute, disputeAuditingData))
         );
     }
 
@@ -204,29 +203,53 @@ contract StateChannelManagerProxy is StateChannelManagerInterface, StateChannelC
     // ********** public/external DIAMOND functions **********
 
     /// @dev Callable only by diamond facets - performs the deposit of the specific assets by interpreting `joinChannel` - returns bool success
-    function depositAssetsComposable(JoinChannel memory joinChannel) public virtual onlySelf returns (bool) {
-        return AConsumerFacet(consumerFacetAddress).depositAssetsComposable(joinChannel);
-    }
+    // function depositAssetsComposable(JoinChannel[] memory joinChannels, bool isAtomic) public virtual onlySelf returns (JoinChannelBlock memory jcb, Balance memory newTotalDeposits) {
+    // require(joinChannels.length > 0, ErrorNoJoinChannelProvided());
+    // bytes32 channelId = joinChannels[0].channelId;
+
+    // JoinChannel[] memory filteredJoinChannels = new JoinChannel[](joinChannels.length);
+    // uint256 successfulJoins = 0;
+    // for(uint i = 1; i < joinChannels.length; i++) {
+    //     bool success = AConsumerFacet(consumerFacetAddress).deposit(joinChannels[i]);
+    //     if (!success && isAtomic) revert ErrorJoinChannelAtomicFailure();
+    //     if (success) {
+    //         filteredJoinChannels[successfulJoins++] = joinChannels[i];
+    //     }
+    // }
+    // require(successfulJoins > 0, ErrorNoSuccessfulJoinChannel());
+    // // Resize the array to the number of successful joins - only ok for shrinking the array
+    // // TODO - find other places in the code that shrink MEMORY arrays and do the same - better than to allocate more space
+    // assembly { mstore(filteredJoinChannels, successfulJoins) }
+
+    // // Create JoinChannelBlock
+    // jcb = _createJoinChannelBlock(filteredJoinChannels);
+    // bytes32 blockHash = keccak256(abi.encode(jcb));
+
+    // // Update on-chain balance
+    // ChannelBalance storage channelBalance = channelBalances[channelId];
+    // // Get previous total deposits
+    // newTotalDeposits =
+    //     channelBalance.onChainJoinChannelMap[channelBalance.latestJoinChannelBlockHash].totalDeposits;
+    // // Calculate new totalDeposits
+    // for(uint i = 0; i < filteredJoinChannels.length; i++) {
+    //     newTotalDeposits = stateMachineImplementation.addBalance(newTotalDeposits, filteredJoinChannels[i].balance);
+    // }
+
+    // // Persist the onChainJoinChannel in the map
+    // channelBalance.onChainJoinChannelMap[blockHash] = OnChainJoinChannel({
+    //     previousJoinChannelBlockHash: channelBalance.latestJoinChannelBlockHash,
+    //     timestamp: block.timestamp,
+    //     totalDeposits: newTotalDeposits
+    // });
+    // // Update the latestJoinChannelBlockHash;
+    // channelBalance.latestJoinChannelBlockHash = blockHash;
+
+    // return (jcb, newTotalDeposits);
+    // }
 
     /// @dev Callable only by diamond facets - performs the withdrawal of the specific assets by interpreting `exitChannel` - returns bool success
     function withdrawAssetsComposable(ExitChannel memory exitChannel) public virtual onlySelf returns (bool) {
-        return AConsumerFacet(consumerFacetAddress).withdrawAssetsComposable(exitChannel);
-    }
-
-    function applySlashesToStateMachine(bytes memory encodedState, address[] memory slashedParticipants)
-        public
-        onlySelf
-        returns (bytes memory encodedModifiedState, ExitChannel[] memory)
-    {
-        return _applySlashesToStateMachine(encodedState, slashedParticipants);
-    }
-
-    function removeParticipantsFromStateMachine(bytes memory encodedState, address[] memory participants)
-        public
-        onlySelf
-        returns (bytes memory encodedModifiedState, ExitChannel[] memory)
-    {
-        return _removeParticipantsFromStateMachine(encodedState, participants);
+        return AConsumerFacet(consumerFacetAddress).withdraw(exitChannel);
     }
 
     function executeStateTransition(bytes32 channelId, bytes memory encodedState, Transaction memory _tx)
@@ -437,35 +460,6 @@ contract StateChannelManagerProxy is StateChannelManagerInterface, StateChannelC
 
     // ********** private/internal functions **********
 
-    function _applySlashesToStateMachine(bytes memory encodedState, address[] memory slashedParticipants)
-        internal
-        returns (bytes memory encodedModifiedState, ExitChannel[] memory exitChannels)
-    {
-        exitChannels = new ExitChannel[](slashedParticipants.length);
-        stateMachineImplementation.setState(encodedState);
-        for (uint256 i = 0; i < slashedParticipants.length; i++) {
-            bool success;
-            (success, exitChannels[i]) = stateMachineImplementation.slashParticipant(slashedParticipants[i]);
-            require(success, ErrorDisputeStateMachineSlashingFailed());
-        }
-        return (stateMachineImplementation.getState(), exitChannels);
-    }
-
-    function _removeParticipantsFromStateMachine(bytes memory encodedState, address[] memory participants)
-        internal
-        returns (bytes memory encodedModifiedState, ExitChannel[] memory)
-    {
-        ExitChannel[] memory exitChannels = new ExitChannel[](participants.length);
-        stateMachineImplementation.setState(encodedState);
-        for (uint256 i = 0; i < participants.length; i++) {
-            bool success;
-            (success, exitChannels[i]) = stateMachineImplementation.removeParticipant(participants[i]);
-            // require(success, "Remove failed");
-            require(success, ErrorDisputeStateMachineRemovingFailed());
-        }
-        return (stateMachineImplementation.getState(), exitChannels);
-    }
-
     function isKillPeriodExpired(bytes32 channelId, bytes32 forkId) public view returns (bool, uint256) {
         DisputeData storage _disputeData = disputeData[channelId];
         DisputeWindow storage disputeWindow = _disputeData.disputeWindowMap[forkId];
@@ -519,4 +513,15 @@ contract StateChannelManagerProxy is StateChannelManagerInterface, StateChannelC
         }
         return abi.decode(returnData, (bool));
     }
+
+    // function _createJoinChannelBlock(JoinChannel[] memory jcs) internal view returns (JoinChannelBlock memory) {
+    //     // require(jcs.length > 0, ErrorNoJoinChannelProvided());
+    //     // bytes32 channelId = jcs[0].channelId;
+    //     // ChannelBalance storage channelBalance = channelBalances[channelId];
+    //     // bytes32 latestBlockHash = channelBalance.latestJoinChannelBlockHash;
+    //     // bytes32 previousBlockHash = channelBalance.onChainJoinChannelMap[latestBlockHash].previousJoinChannelBlockHash;
+    //     // JoinChannelBlock memory joinChannelBlock =
+    //     //     JoinChannelBlock({previousBlockHash: previousBlockHash, joinChannels: jcs});
+    //     // return joinChannelBlock;
+    // }
 }

--- a/contracts/V1/StateChannelManagerEvents.sol
+++ b/contracts/V1/StateChannelManagerEvents.sol
@@ -4,6 +4,8 @@ import "./types/DisputeTypes.sol";
 import "./types/DataTypes.sol";
 
 interface StateChannelManagerEvents {
+    // event ChannelOpened(bytes32 indexed channelId, StateSnapshot stateSnapshot, bytes encodedState);
+
     event StateSnapshotUpdated(bytes32 indexed channelId, StateSnapshot stateSnapshot);
 
     event BlockCalldataPosted(

--- a/contracts/V1/StateChannelManagerInterface.sol
+++ b/contracts/V1/StateChannelManagerInterface.sol
@@ -4,21 +4,9 @@ import "./types/DataTypes.sol";
 import "./types/DisputeTypes.sol";
 
 abstract contract StateChannelManagerInterface {
-    function openChannel(bytes32 channelId, bytes[] calldata openChannelData, bytes[] calldata signatures)
-        public
-        virtual;
-
-    function closeChannel(bytes32 channelId, bytes[] calldata closeChannelData, bytes[] calldata signatures)
-        public
-        virtual;
-
-    function removeParticipant(bytes32 channelId, bytes[] calldata removeParticipantData, bytes[] calldata signatures)
-        public
-        virtual;
-
-    function addParticipant(bytes32 channelId, bytes[] calldata removeParticipantData, bytes[] calldata signatures)
-        public
-        virtual;
+    // function openChannel(OpenChannelConfirmation calldata openChannelConfirmation)
+    //     public
+    //     virtual;
 
     function isChannelOpen(bytes32 channelId) public view virtual returns (bool);
 
@@ -53,13 +41,6 @@ abstract contract StateChannelManagerInterface {
         DisputeConfirmation memory disputeConfirmation,
         DisputeAuditingData memory disputeAuditingData
     ) public virtual;
-
-    function auditDispute(Dispute memory dispute, DisputeAuditingData memory disputeAuditingData)
-        public
-        virtual
-        returns (address[] memory slashParticipants);
-
-    function challengeDispute(Dispute memory dispute, DisputeAuditingData memory disputeAuditingData) public virtual;
 
     function challengeDisputeReduction(
         Dispute[] memory disputes,

--- a/contracts/V1/examples/MathStateMachine/MathConsumerFacet.sol
+++ b/contracts/V1/examples/MathStateMachine/MathConsumerFacet.sol
@@ -11,94 +11,26 @@ import "../../types/DataTypes.sol";
  * @dev Concrete implementation of ConsumerFacet for the Math state machine example
  */
 contract MathConsumerFacet is AConsumerFacet {
-    // Events
-    event SetState(bytes32 indexed channelId, bytes encodedState, uint256 timestamp, uint256 blockTimestamp);
+    // function openChannelGenesis(JoinChannel[] memory successfulJoinChannels, bytes memory optionalOpeningData) external pure override returns (bytes memory encodedGenesisState, address[] memory participants)
+    // {
+    //     // //AStateMachine genesis state
+    //     // MathState memory genesisState;
+    //     // genesisState.number = 0;
+    //     // genesisState.participants = new address[](successfulJoinChannels.length);
+    //     // for (uint256 i = 0; i < successfulJoinChannels.length; i++) {
+    //     //     genesisState.participants[i] = successfulJoinChannels[i].participant;
+    //     // }
+    //     // bytes memory genesisStateEncoded = abi.encode(genesisState);
+    //     // return (genesisStateEncoded, genesisState.participants);
+    // }
 
-    function openChannel(bytes32 channelId, bytes[] calldata openChannelData, bytes[] calldata signatures)
-        external
-        override
-    {
-        require(
-            openChannelData.length > 0 && openChannelData.length == signatures.length,
-            "MathConsumerFacet: openChannel (openChannel <> signatures) incorrect length"
-        );
-
-        JoinChannel[] memory joinChannels = new JoinChannel[](openChannelData.length);
-        for (uint256 i = 0; i < openChannelData.length; i++) {
-            joinChannels[i] = abi.decode(openChannelData[i], (JoinChannel));
-        }
-
-        bool isValid = true;
-        for (uint256 i = 0; i < openChannelData.length; i++) {
-            address[] memory addressesInThreshold = new address[](1);
-            addressesInThreshold[0] = joinChannels[i].participant;
-            bytes[] memory signature = new bytes[](1);
-            signature[0] = signatures[i];
-            (bool succeeds,) =
-                StateChannelUtilLibrary.verifyThresholdSigned(addressesInThreshold, openChannelData[i], signatures);
-            if (!succeeds) {
-                isValid = false;
-                break;
-            }
-        }
-
-        require(isValid, "MathConsumerFacet: openChannel (openChannel <> signatures) signatures don't match");
-
-        require(channelId != bytes32(0), "MathConsumerFacet: openChannel channelId cannot be 0x0");
-
-        // Note: Channel open check is handled by the diamond before delegating to this facet
-
-        for (uint256 i = 0; i < joinChannels.length; i++) {
-            require(channelId == joinChannels[i].channelId, "MathConsumerFacet: openChannel channelId doesn't match");
-
-            require(joinChannels[i].balance.amount > 0, "MathConsumerFacet: openChannel amount must be greater than 0");
-
-            require(
-                joinChannels[i].deadlineTimestamp > block.timestamp,
-                "MathConsumerFacet: openChannel timestampDeadline must be in the future"
-            );
-        }
-        //AStateMachine genesis state
-        MathState memory genesisState;
-        genesisState.number = 0;
-        genesisState.participants = new address[](joinChannels.length);
-        for (uint256 i = 0; i < joinChannels.length; i++) {
-            genesisState.participants[i] = joinChannels[i].participant;
-        }
-        bytes memory genesisStateEncoded = abi.encode(genesisState);
-        // encodedStates[channelId][0] = genesisStateEncoded;
-        //TODO! Snapshot instead of encodedState -> think about this
-        emit SetState(channelId, genesisStateEncoded, 0, block.timestamp);
-    }
-
-    function closeChannel(bytes32 channelId, bytes[] calldata closeChannelData, bytes[] calldata signatures)
-        external
-        override
-    {
-        // Implementation for closing the channel
-    }
-
-    function removeParticipant(bytes32 channelId, bytes[] calldata removeParticipantData, bytes[] calldata signatures)
-        external
-        override
-    {
-        // Implementation for removing a participant from the channel
-    }
-
-    function addParticipant(bytes32 channelId, bytes[] calldata addParticipantData, bytes[] calldata signatures)
-        external
-        override
-    {
-        // Implementation for adding a new participant to the channel
-    }
-
-    function depositAssetsComposable(JoinChannel memory joinChannel) external override returns (bool) {
+    function deposit(JoinChannel memory joinChannel) external override returns (bool) {
         // Implementation for depositing assets when a participant joins
 
         return true; // Placeholder implementation
     }
 
-    function withdrawAssetsComposable(ExitChannel memory exitChannel) external override returns (bool) {
+    function withdraw(ExitChannel memory exitChannel) external override returns (bool) {
         // Implementation for withdrawing assets when a participant exits
         return true; // Placeholder implementation
     }

--- a/contracts/V1/types/DataTypes.sol
+++ b/contracts/V1/types/DataTypes.sol
@@ -64,6 +64,19 @@ struct Balance {
     bytes data; //custom data
 }
 
+// struct OpenChannel{
+//     bytes32 channelId; // could be computed on-chain, but if known in advance, easy to index
+//     address[] participants;
+//     Balance[] balances; // parallel array to participants
+//     uint256 deadlineTimestamp;
+//     bool isAtomic; // (all or nothing) or allow deposits to fail and only open with successful deposits
+//     bytes data; // custom data
+// }
+// struct OpenChannelConfirmation{
+//     bytes encodedOpenChannel;
+//     bytes[] signatures;
+// }
+
 struct JoinChannel {
     bytes32 channelId;
     address participant;

--- a/examples/TicTacToe/contracts/TicTacToe/TicTacToeStateChannelManagerProxy.sol
+++ b/examples/TicTacToe/contracts/TicTacToe/TicTacToeStateChannelManagerProxy.sol
@@ -88,19 +88,7 @@ contract TicTacToeStateChannelManagerProxy is AStateChannelManagerProxy {
         emit SetState(channelId, genesisStateEcoded, 0, block.timestamp);
     }
 
-    function closeChannel(bytes32 channelId, bytes[] calldata closeChannelData, bytes[] calldata signatures)
-        public
-        virtual
-        override
-    {}
-
     function removeParticipant(bytes32 channelId, bytes[] calldata removeParticipantData, bytes[] calldata signatures)
-        public
-        virtual
-        override
-    {}
-
-    function addParticipant(bytes32 channelId, bytes[] calldata removeParticipantData, bytes[] calldata signatures)
         public
         virtual
         override

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -27,6 +27,9 @@ const config: HardhatUserConfig = {
             viaIR: true, // Enable the via-IR pipeline
             optimizer: {
                 enabled: true,
+                // details: {
+                //     yul: false
+                // },
                 runs: 100
             }
         }


### PR DESCRIPTION
The solidity compiler, specifically the optimizer when it goes through `yul` throws and error when compiling that the stack is too deep, but doesn't indicate where. 

This PR is mostly a helper to me while debugging the root cause 

If `yul` is disabled, everything compiles correctly, but we don't want it disabled - we want optimized bytecode  