### PR TITLE
partial fix of Timeout dispute creation

### DIFF
--- a/src/disputeManager/DisputeManager.ts
+++ b/src/disputeManager/DisputeManager.ts
@@ -147,7 +147,7 @@ class DisputeManager {
                     timeoutOptions.previousBlockProducerPostedCalldata || false,
                 participantSignatureOnPreviousBlock:
                     (timeoutOptions.participantSignatureOnPreviousBlock as Bytes) ||
-                    ""
+                    "0x"
             };
         } else {
             timeoutStruct = this.getEmptyTimeoutStruct();
@@ -215,7 +215,9 @@ class DisputeManager {
             signatures: []
         };
 
-        this.stateChannelManagerContract.uploadDispute(disputeConfirmation);
+        await this.stateChannelManagerContract.uploadDispute(
+            disputeConfirmation
+        );
 
         this.p2pEventHooks.onInitiatingDispute?.();
 
@@ -254,7 +256,7 @@ class DisputeManager {
             latestStateSnapshot = genesisStateSnapshot;
         } else {
             const snapshot = this.storage.stateSnapshots.getStateSnapshotByHash(
-                latestBlock.hash
+                latestBlock.stateSnapshotHash
             );
             if (!snapshot) {
                 isPartial = true;
@@ -303,7 +305,7 @@ class DisputeManager {
             isForced: false,
             previousBlockProducer: ethers.ZeroAddress,
             previousBlockProducerPostedCalldata: false,
-            participantSignatureOnPreviousBlock: ""
+            participantSignatureOnPreviousBlock: "0x"
         };
     }
 

--- a/src/evm/EvmDiamondStateMachine.ts
+++ b/src/evm/EvmDiamondStateMachine.ts
@@ -7,7 +7,7 @@ import {
 } from "@typechain-types";
 import { TransactionStruct } from "@typechain-types/contracts/V1/types/DataTypes";
 
-import StateManager from "@/stateManager";
+import StateManager from "../stateManager/StateManager";
 import Clock from "@/Clock";
 import { TimeConfig } from "@/types";
 import { ExitChannelEthersType, BalanceEthersType } from "@/types/ethers";

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -195,6 +195,7 @@ class StateManager {
     public setChannelId(channelId: ChannelId) {
         this.channelId = channelId;
         this.stateChannelEventListener.setChannelId(channelId);
+        this.disputeManager.setChannelId(channelId);
     }
     public getChannelId(): ChannelId {
         return this.channelId;
@@ -1131,15 +1132,7 @@ class StateManager {
 
         // Get the block entry - if it doesn't exist (can happen ONLY from setState), skip timeout
         const block = this.storage.blocks.getBlock(forkId, blockHeight);
-        if (!block) {
-            return;
-        }
-
-        // If I already signed or block has already onChainTimestamp, no timeout needed
-        if (
-            block.didISign(this.signerAddress) ||
-            block.onChainTimestamp !== undefined
-        ) {
+        if (block && block.didISign(this.signerAddress)) {
             return;
         }
 
@@ -1163,16 +1156,19 @@ class StateManager {
         }
 
         // Validate the on-chain commitment is legitimate
-        const isValidCommitment = await this.validateBlockCommitment(
-            block,
-            commitmentResponse.blockCalldataCommitment,
-            participantAddress
-        );
+        // TODO, we dont have a block in storage to validate the commitment against.
+        // what we want to do is to the the block from the calldata and run it through the block validation pipeline
+        // after which, if the block can be found in storage , then it was good and we don't timeout, oterwose => force t
+        // const isValidCommitment = await this.validateBlockCommitment(
+        //     block,
+        //     commitmentResponse.blockCalldataCommitment,
+        //     participantAddress
+        // );
 
-        if (!isValidCommitment) {
-            // Invalid commitment - force timeout
-            // TODO
-        }
+        // if (!isValidCommitment) {
+        //     // Invalid commitment - force timeout
+        //     // TODO
+        // }
     }
 
     private async validateBlockCommitment(
@@ -1252,8 +1248,8 @@ class StateManager {
 
         if (remainingDelay <= 0) {
             // Time has fully elapsed - create dispute immediately
-            this.disputeManager.createDispute(forkId, false, {
-                blockHeightToTimeout: blockHeight + 1,
+            await this.disputeManager.createDispute(forkId, false, {
+                blockHeightToTimeout: blockHeight,
                 isForced: false,
                 previousBlockProducer: participantAddress,
                 previousBlockProducerPostedCalldata: false
@@ -1483,7 +1479,7 @@ class StateManager {
             () =>
                 this.tryTimeoutParticipant(
                     block.forkId,
-                    block.height,
+                    block.height + 1, // Check for the next block that the participant should create
                     nextToWrite
                 ),
             this.getTimeoutWaitTimeSeconds() * 1000,

--- a/src/types/ethers.ts
+++ b/src/types/ethers.ts
@@ -99,7 +99,7 @@ bytes participantSignatureOnPreviousBlock
 )`;
 
 export const DisputeAuditingDataEthersType = `tuple(
-${StateSnapshotEthersType} genesisStateSnapshot,
+${SnapshotDataEthersType} genesisStateSnapshotData,
 ${StateSnapshotEthersType} latestStateSnapshot,
 ${StateSnapshotEthersType}[] milestoneSnapshots,
 bytes latestStateStateMachineState,

--- a/test/e2e/E2E-Core.test.ts
+++ b/test/e2e/E2E-Core.test.ts
@@ -218,7 +218,80 @@ describe("E2E: Core Functionality", function () {
         // Arrange: Setup 3 participants with initial balances, open channel, configure short timeout
         // Act: disconnect author peer, just when it is their turn to write
         // Assert: timeout dispute is created and submitted on-chain
-        it("should handle timeout when author peer disconnects");
+        it("should handle timeout when author peer disconnects", async function () {
+            // Arrange - Setup with 3 participants and short timeout for fast testing
+            const harness = new PeerTestHarness<MathStateMachine>();
+            await harness.setup(3, ethers, {
+                debug: true, // Enable debug logging
+                timeConfig: {
+                    p2pTime: 1,
+                    agreementTime: 1,
+                    chainFallbackTime: 1
+                    // Total timeout: 3 seconds
+                }
+            });
+            await harness.openChannel();
+
+            // Make 3 transactions to establish normal operation
+
+            await harness.submitNextTransaction((contract) => contract.add(1)); // peer 0
+            await harness.submitNextTransaction((contract) => contract.add(2)); // peer 1
+            await harness.submitNextTransaction((contract) => contract.add(3)); // peer 2
+
+            // Reset spies after setup
+            harness.resetEventSpies();
+
+            // Act
+            // Now it should be peer 0's turn again - let them create a block first
+            const nextPeer = await harness.getNextPeerToWrite();
+
+            // Disconnect peer 1 (the author peer who should write next) so they can't create a block
+
+            await harness.simulatePeerTimeout(1);
+
+            // Let peer 0 create a block (this will schedule timeout for the next participant)
+            await harness.submitTransaction(
+                nextPeer,
+                (contract) => contract.add(100),
+                { waitForPeers: [0, 2] }
+            );
+
+            // Wait for timeout dispute to be created and submitted on-chain
+            // The remaining peers (0 and 2) should detect the timeout and create a dispute
+
+            const disputeCreated = await harness.waitForCondition(
+                () => {
+                    // Check if any of the remaining peers initiated a dispute
+                    const peer0DisputeCount = harness.getEventCallCount(
+                        0,
+                        "onInitiatingDispute"
+                    );
+                    const peer2DisputeCount = harness.getEventCallCount(
+                        2,
+                        "onInitiatingDispute"
+                    );
+
+                    return peer0DisputeCount > 0 || peer2DisputeCount > 0;
+                },
+                50000 // Wait up to 5 seconds for dispute creation
+            );
+
+            // Assert - A timeout dispute should be created by one of the remaining peers
+            expect(disputeCreated).to.be.true;
+
+            // Verify that at least one peer initiated a dispute
+            const totalDisputeCount =
+                harness.getEventCallCount(0, "onInitiatingDispute") +
+                harness.getEventCallCount(2, "onInitiatingDispute");
+            expect(totalDisputeCount).to.be.at.least(1);
+
+            // Verify that the disconnected peer (peer 1) did not initiate any disputes
+            expect(
+                harness.getEventCallCount(1, "onInitiatingDispute")
+            ).to.equal(0);
+
+            await harness.cleanup();
+        });
 
         // Future test for dispute resolution
         it("should create timeout dispute for non-responsive participant");


### PR DESCRIPTION
I wrote a test to assert hat timeout dispute is being created
the test revealed quite a few bug in the code path

with this PR, the test does not pass yet, but quite a few of the bugs fixed

the current bug is from
`computeDisputeOutputSnapshotDatastaticCall`
in `DisputeManager`
```
Error: LocalDiamond call failed: Error: EVM execution failed: revert
    at LocalDiamondSigner.call (/home/luke/Documents/peer3/state-channels-plus/src/evm/LocalDiamondSigner.ts:56:19)
    at async staticCallResult (/home/luke/Documents/peer3/state-channels-plus/node_modules/ethers/src.ts/contract/contract.ts:337:22)
    at async AsyncFunction.staticCall (/home/luke/Documents/peer3/state-channels-plus/node_modules/ethers/src.ts/contract/contract.ts:303:24)
    at async DisputeManager.createDispute (/home/luke/Documents/peer3/state-channels-plus/src/disputeManager/DisputeManager.ts:185:13)
    at async StateManager.createTimeOutDispute (/home/luke/Documents/peer3/state-channels-plus/src/stateManager/StateManager.ts:1251:13)
    at async StateManager.tryTimeoutParticipant (/home/luke/Documents/peer3/state-channels-plus/src/stateManager/StateManager.ts:1150:13)
    at async Timeout._onTimeout (/home/luke/Documents/peer3/state-channels-plus/src/utils/TimeoutManager.ts:27:21)
```

@lukastanisic99  something is wrong with `computeDisputeOutputSnapshotData`
i put debug console logs, and even the first line of it is not reaced
the revert is happening before, the function code is nevr entered into
I'm guessing it is something about the static call 