### PR TITLE
seperare turns from contract value

### DIFF
--- a/contracts/V1/examples/MathStateMachine/MathStateMachine.sol
+++ b/contracts/V1/examples/MathStateMachine/MathStateMachine.sol
@@ -9,6 +9,7 @@ struct MathState {
     uint256 number;
     address[] participants;
     uint256[] balances;
+    uint256 currentTurnIndex;
 }
 
 contract MathStateMachine is AStateMachine {
@@ -25,6 +26,7 @@ contract MathStateMachine is AStateMachine {
         require(_tx.header.participant == getNextToWrite(), "MathStateMachine: add only next player can write");
         emit Addition(state.number, _number, state.number + _number);
         state.number += _number;
+        state.currentTurnIndex++;
         emit NextToPlay(getNextToWrite());
         return state.number;
     }
@@ -59,7 +61,7 @@ contract MathStateMachine is AStateMachine {
         if (state.participants.length == 0) {
             return _tx.header.participant;
         }
-        return state.participants[state.number % state.participants.length];
+        return state.participants[state.currentTurnIndex % state.participants.length];
     }
 
     function _slashParticipant(address adr) internal virtual override returns (bool, ExitChannel memory) {


### PR DESCRIPTION
this solves a silly pitfall when writing tests that causes time waste on debugging unexpected behviour

- when writing tests, one expects the turn to advance in a round-robin fashion regardless of the number added
```ts
harness!.submitNextTransaction((contract) =>
                    contract.add(1)
                );
```


