### PR TITLE
Spectate extra features - wip

### DIFF
--- a/src/eventHandlers/EventHandler.ts
+++ b/src/eventHandlers/EventHandler.ts
@@ -24,7 +24,6 @@ import { Codec, hash, Logger, Type } from "@/utils";
 import { isEqual } from "lodash";
 import { ZeroHash } from "ethers";
 import CalldataCommittedStrategy from "@/stateManager/validationStrategy/CalldataCommittedStrategy";
-import { Status } from "@/types";
 
 export class EventHandler {
     private logger: Logger;
@@ -67,13 +66,7 @@ export class EventHandler {
         channelId: ChannelId,
         stateSnapshot: StateSnapshotStruct
     ): Promise<void> {
-        if (!(await this.isSnapshotInPast(channelId, stateSnapshot))) {
-            throw new Error(
-                "StateSnapshotUpdated: Rejected snapshot for channel " +
-                    channelId +
-                    " - not in past"
-            );
-        }
+        //TODO - make sure snapshots are in ascending order if events can be collected in random order - e.g we have the latest one always
 
         await this.diamondStateMachine.localDiamondContract.onStateSnapshotUpdated(
             channelId,
@@ -408,37 +401,6 @@ export class EventHandler {
             joinChannelBlock,
             timestamp,
             totalDeposits
-        );
-    }
-
-    private async isSnapshotInPast(
-        channelId: ChannelId,
-        incomingSnapshot: StateSnapshotStruct
-    ): Promise<boolean> {
-        // For spectators with no local state, allow the first snapshot
-        if (
-            this.stateManager.getStatus() === Status.SPECTATING &&
-            !this.storage.blocks.getLatestBlock(this.stateManager.latestForkId)
-        ) {
-            return true;
-        }
-
-        const previousOnChainSnapshot =
-            await this.diamondStateMachine.localDiamondContract.getStateSnapshot(
-                channelId
-            );
-
-        if (previousOnChainSnapshot.forkId === incomingSnapshot.forkId) {
-            return (
-                Number(incomingSnapshot.blockHeight) <
-                Number(previousOnChainSnapshot.blockHeight)
-            );
-        }
-
-        // Different fork
-        return this.isIncomingSnapshotInForkChain(
-            previousOnChainSnapshot.forkId,
-            incomingSnapshot.forkId
         );
     }
 

--- a/src/eventHandlers/EventHandler.ts
+++ b/src/eventHandlers/EventHandler.ts
@@ -24,6 +24,7 @@ import { Codec, hash, Logger, Type } from "@/utils";
 import { isEqual } from "lodash";
 import { ZeroHash } from "ethers";
 import CalldataCommittedStrategy from "@/stateManager/validationStrategy/CalldataCommittedStrategy";
+import { Status } from "@/types";
 
 export class EventHandler {
     private logger: Logger;
@@ -414,6 +415,14 @@ export class EventHandler {
         channelId: ChannelId,
         incomingSnapshot: StateSnapshotStruct
     ): Promise<boolean> {
+        // For spectators with no local state, allow the first snapshot
+        if (
+            this.stateManager.getStatus() === Status.SPECTATING &&
+            !this.storage.blocks.getLatestBlock(this.stateManager.latestForkId)
+        ) {
+            return true;
+        }
+
         const previousOnChainSnapshot =
             await this.diamondStateMachine.localDiamondContract.getStateSnapshot(
                 channelId

--- a/src/rpc/services/spectate/SpectateService.ts
+++ b/src/rpc/services/spectate/SpectateService.ts
@@ -461,7 +461,7 @@ class SpectateService extends ARpcService<SpectateServiceRpcMethods> {
     }
 
     public abort(transport: ATransport) {
-        if (this.p2pManager.stateManager.status == Status.SPECTATING) {
+        if (this.p2pManager.stateManager.getStatus() == Status.SPECTATING) {
             this.p2pManager.disconnectAll();
             return;
         }

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -205,6 +205,9 @@ class StateManager {
         });
         this.status = status;
     }
+    public getStatus(): Status {
+        return this.status;
+    }
     public setChannelId(channelId: ChannelId) {
         this.logger.verbose("Setting channel ID", { channelId });
         this.channelId = channelId;


### PR DESCRIPTION
- added spectator logic to isSnapshotInPast(), so if the peer is spectating and has no blocks, the snapshot is allowed. before, spectate would call fetchAndPersistOnChainSnapshot() which in turn calls onStateSnapshotUpdated() which itself calls isSnapshotInPast(), even though the snapshot is from the chain.
- added getStatus() getter