### PR TITLE
dispute confirmation pipeline fixes

### DIFF
--- a/src/disputeManager/DisputeManager.ts
+++ b/src/disputeManager/DisputeManager.ts
@@ -73,31 +73,8 @@ class DisputeManager {
         try {
             await this.mutex.lock();
             if (this.storage.disputes.didIDispute(forkId)) return;
-            const {
-                dispute,
-                disputeConfirmation,
-                auditingData,
-                fraudProofsToApply
-            } = await this.constructDispute(forkId);
-
-            // Check if there's anything meaningful to dispute
-            const hasTimeout =
-                dispute.input.timeout.participant !== ethers.ZeroAddress;
-            const hasFraudProofs = fraudProofsToApply.length > 0;
-            const hasSelfRemoval = dispute.input.selfRemoval;
-
-            if (!hasTimeout && !hasFraudProofs && !hasSelfRemoval) {
-                this.logger.verbose(
-                    "No timeout, fraud proofs, or self-removal to submit - skipping dispute",
-                    {
-                        forkId,
-                        hasTimeout,
-                        hasFraudProofs,
-                        hasSelfRemoval
-                    }
-                );
-                return;
-            }
+            const { disputeConfirmation, auditingData, fraudProofsToApply } =
+                await this.constructDispute(forkId);
 
             const pendingParticipants =
                 await this.stateChannelManagerContract.getPendingParticipants(

--- a/src/disputeManager/DisputeManager.ts
+++ b/src/disputeManager/DisputeManager.ts
@@ -80,6 +80,25 @@ class DisputeManager {
                 fraudProofsToApply
             } = await this.constructDispute(forkId);
 
+            // Check if there's anything meaningful to dispute
+            const hasTimeout =
+                dispute.input.timeout.participant !== ethers.ZeroAddress;
+            const hasFraudProofs = fraudProofsToApply.length > 0;
+            const hasSelfRemoval = dispute.input.selfRemoval;
+
+            if (!hasTimeout && !hasFraudProofs && !hasSelfRemoval) {
+                this.logger.verbose(
+                    "No timeout, fraud proofs, or self-removal to submit - skipping dispute",
+                    {
+                        forkId,
+                        hasTimeout,
+                        hasFraudProofs,
+                        hasSelfRemoval
+                    }
+                );
+                return;
+            }
+
             const pendingParticipants =
                 await this.stateChannelManagerContract.getPendingParticipants(
                     this.channelId

--- a/src/eventHandlers/EventHandler.ts
+++ b/src/eventHandlers/EventHandler.ts
@@ -225,7 +225,7 @@ export class EventHandler {
         this.storage.disputes.storeDisputeConfirmation(disputeConfirmation);
         // this is like success - TODO - consider moving this to DisputeStrategy.success
         if (await this.canConstructMoreEvidence(dispute)) {
-            this.stateManager.disputeManager.dispute(forkId);
+            await this.stateManager.disputeManager.dispute(forkId);
             return;
         }
         const [_, potentialGenesisTimestamp] =

--- a/src/stateManager/DisputeValidationService.ts
+++ b/src/stateManager/DisputeValidationService.ts
@@ -327,7 +327,10 @@ export default class DisputeValidationService {
             const expectedTimeoutHeight = hasBlock
                 ? Number(latestBlock.transaction.header.transactionCnt) + 1
                 : 0;
-            if (expectedTimeoutHeight !== dispute.input.timeout.blockHeight) {
+            if (
+                expectedTimeoutHeight !==
+                Number(dispute.input.timeout.blockHeight)
+            ) {
                 this.disputeFraudProofService.createTimeoutNotLinkedToLatestState(
                     dispute
                 );
@@ -401,8 +404,14 @@ export default class DisputeValidationService {
                 return false;
             }
 
-            // [check] N/N Threshold
-            if (block && block.didEveryoneSign(participants)) {
+            // [check] N/N Threshold - only for normal timeouts
+            // For forced timeouts: skip this check
+            //   the participant just posted junk calldata, so we timeout them anyway.
+            if (
+                !dispute.input.timeout.isForced &&
+                block &&
+                block.didEveryoneSign(participants)
+            ) {
                 this.disputeFraudProofService.createTimeoutThreshold(
                     dispute,
                     disputeAuditingData,
@@ -450,19 +459,6 @@ export default class DisputeValidationService {
         }
 
         // if we're here - it's all good
-        return true;
-    }
-
-    private async isTimeoutTooEarly(
-        dispute: DisputeStruct,
-        disputeAuditingData: DisputeAuditingDataStruct
-    ): Promise<boolean> {
-        const [hasBlock, latestBlock] =
-            await this.diamondStateMachine.localDiamondContract.getLatestBlockFromStateProof(
-                dispute.input.stateProof
-            );
-        const previousTimestamp = 0;
-
         return true;
     }
 }

--- a/src/stateManager/DisputeValidationService.ts
+++ b/src/stateManager/DisputeValidationService.ts
@@ -280,6 +280,7 @@ export default class DisputeValidationService {
                 disputeAuditingData
             );
             this.logger.debug(`Balance invariant failed on local diamond`);
+
             return false;
         }
 

--- a/src/stateManager/DisputeValidationService.ts
+++ b/src/stateManager/DisputeValidationService.ts
@@ -404,14 +404,8 @@ export default class DisputeValidationService {
                 return false;
             }
 
-            // [check] N/N Threshold - only for normal timeouts
-            // For forced timeouts: skip this check
-            //   the participant just posted junk calldata, so we timeout them anyway.
-            if (
-                !dispute.input.timeout.isForced &&
-                block &&
-                block.didEveryoneSign(participants)
-            ) {
+            // [check] N/N Threshold
+            if (block && block.didEveryoneSign(participants)) {
                 this.disputeFraudProofService.createTimeoutThreshold(
                     dispute,
                     disputeAuditingData,

--- a/src/stateManager/utils/DisputeFraudProofService.ts
+++ b/src/stateManager/utils/DisputeFraudProofService.ts
@@ -1,3 +1,4 @@
+import { Block } from "@/models";
 import Storage from "@/storage";
 import {
     DisputeFraudProofType,


### PR DESCRIPTION

### PR targets `dispute-confimation-pipeline` branch


1. fix / optimize: avoid submitting empty disputes
2. fix blockHeight comparison in `[check] isLinked to stateProof`

one side is a number, the other (was) a big Int 

3.fix `[check] N/N Threshold`, does not apply when timeout is forced

4. small modifications to per-exisitng e2e tests
a. raise number of participants from 2 to 3 => avoid yet unimplemented final disputes
b. slight increase p2p time => avoid undesired timeouts