### PR TITLE
await `.off` promises

### DIFF
--- a/src/StateChannelEventListener.ts
+++ b/src/StateChannelEventListener.ts
@@ -28,7 +28,7 @@ class StateChannelEventListener {
     private async setListener(
         key: string,
         filterFactory: () => any,
-        handler: (logObj: any) => Promise<void> | void
+        handler: (logObj: any) => Promise<void>
     ) {
         if (this.filters[key]) {
             await this.stateChannelManagerContract.off(
@@ -57,9 +57,9 @@ class StateChannelEventListener {
                 this.stateChannelManagerContract.filters.ChannelOpened(
                     channelId
                 ),
-            handler: async (logObj: any) => {
+            handler: (logObj: any) => {
                 const { channelId, stateSnapshot, encodedState } = logObj.args;
-                await this.eventHandler.onChannelOpened(
+                return this.eventHandler.onChannelOpened(
                     channelId,
                     stateSnapshot,
                     encodedState
@@ -71,9 +71,9 @@ class StateChannelEventListener {
                 this.stateChannelManagerContract.filters.StateSnapshotUpdated(
                     channelId
                 ),
-            handler: async (logObj: any) => {
+            handler: (logObj: any) => {
                 const { channelId, stateSnapshot } = logObj.args;
-                await this.eventHandler.onStateSnapshotUpdated(
+                return this.eventHandler.onStateSnapshotUpdated(
                     channelId,
                     stateSnapshot
                 );
@@ -93,7 +93,7 @@ class StateChannelEventListener {
                     signedBlock,
                     timestamp
                 } = logObj.args;
-                this.eventHandler.onBlockCalldataPosted(
+                return this.eventHandler.onBlockCalldataPosted(
                     channelId,
                     commitmentHash,
                     sender,
@@ -116,7 +116,7 @@ class StateChannelEventListener {
                     windowCreationTimestamp
                 } = logObj.args;
 
-                this.eventHandler.onDisputeCommitted(
+                return this.eventHandler.onDisputeCommitted(
                     channelId,
                     disputeConfirmation,
                     Number(disputeCreationTimestamp),
@@ -130,9 +130,9 @@ class StateChannelEventListener {
                 this.stateChannelManagerContract.filters.ChainSlashed(
                     channelId
                 ),
-            handler: (logObj: any) => {
+            handler: async (logObj: any) => {
                 const { channelId, participant, timestamp } = logObj.args;
-                this.eventHandler.onChainSlashed(
+                return this.eventHandler.onChainSlashed(
                     channelId,
                     participant,
                     timestamp
@@ -152,7 +152,7 @@ class StateChannelEventListener {
                     reductionTimestamp,
                     reducer
                 } = logObj.args;
-                this.eventHandler.onDisputeReducedResultCommitted(
+                return this.eventHandler.onDisputeReducedResultCommitted(
                     channelId,
                     forkId,
                     reducedForkId,
@@ -175,7 +175,7 @@ class StateChannelEventListener {
                     windowCreationTimestamp,
                     disputeAuditingData
                 } = logObj.args;
-                this.eventHandler.onDisputeCommitted(
+                return this.eventHandler.onDisputeCommitted(
                     channelId,
                     dispute,
                     Number(disputeCreationTimestamp),
@@ -192,7 +192,7 @@ class StateChannelEventListener {
                 ),
             handler: (logObj: any) => {
                 const { channelId, totalWithdrawals } = logObj.args;
-                this.eventHandler.onWithdrawalsUpdated(
+                return this.eventHandler.onWithdrawalsUpdated(
                     channelId,
                     totalWithdrawals
                 );
@@ -206,7 +206,7 @@ class StateChannelEventListener {
             handler: (logObj: any) => {
                 const { channelId, latestInboundMessageBlockHash } =
                     logObj.args;
-                this.eventHandler.onChannelStorageCleared(
+                return this.eventHandler.onChannelStorageCleared(
                     channelId,
                     latestInboundMessageBlockHash
                 );
@@ -219,7 +219,11 @@ class StateChannelEventListener {
                 ),
             handler: (logObj: any) => {
                 const { channelId, forkId, disputer } = logObj.args;
-                this.eventHandler.onDisputeKilled(channelId, forkId, disputer);
+                return this.eventHandler.onDisputeKilled(
+                    channelId,
+                    forkId,
+                    disputer
+                );
             }
         },
 
@@ -230,7 +234,7 @@ class StateChannelEventListener {
                 ),
             handler: (logObj: any) => {
                 const { channelId, messageBlock } = logObj.args;
-                this.eventHandler.onInboundMessagesProcessed(
+                return this.eventHandler.onInboundMessagesProcessed(
                     channelId,
                     messageBlock
                 );

--- a/src/StateChannelEventListener.ts
+++ b/src/StateChannelEventListener.ts
@@ -10,7 +10,10 @@ class StateChannelEventListener {
     stateChannelManagerContract: StateChannelManagerProxy;
     eventHandler: EventHandler;
     localDiamondContract: LocalDiamond;
-    filters: Record<string, any> = {};
+    filters: Record<
+        string,
+        { filter: any; listener: (logObj: any) => Promise<void> }
+    > = {};
 
     constructor(
         stateChannelManagerContract: StateChannelManagerProxy,
@@ -28,19 +31,23 @@ class StateChannelEventListener {
         handler: (logObj: any) => Promise<void> | void
     ) {
         if (this.filters[key]) {
-            await this.stateChannelManagerContract.off(this.filters[key]);
+            await this.stateChannelManagerContract.off(
+                this.filters[key].filter,
+                this.filters[key].listener
+            );
         }
-        this.filters[key] = filterFactory();
-        await this.stateChannelManagerContract.on(this.filters[key], handler);
+        const filter = filterFactory();
+        await this.stateChannelManagerContract.on(filter, handler);
+        this.filters[key] = { filter, listener: handler };
     }
 
     //Mark resources for garbage collection
-    public dispose() {
-        Object.values(this.filters).forEach((filter) => {
-            if (filter) {
-                this.stateChannelManagerContract.off(filter);
-            }
-        });
+    public async dispose() {
+        const unsubscribePromises = Object.values(this.filters).map(
+            ({ filter, listener }) =>
+                this.stateChannelManagerContract.off(filter, listener)
+        );
+        await Promise.all(unsubscribePromises);
         this.filters = {};
     }
 

--- a/src/eventHandlers/EventHandler.ts
+++ b/src/eventHandlers/EventHandler.ts
@@ -44,9 +44,6 @@ export class EventHandler {
         stateSnapshot: StateSnapshotStruct,
         encodedState: Bytes
     ): Promise<void> {
-        if (this.stateManager.isDisposed) {
-            return;
-        }
         this.logger.debug("Channel opened", {
             channelId,
             forkId: stateSnapshot.forkId
@@ -70,9 +67,6 @@ export class EventHandler {
         channelId: ChannelId,
         stateSnapshot: StateSnapshotStruct
     ): Promise<void> {
-        if (this.stateManager.isDisposed) {
-            return;
-        }
         //TODO - make sure snapshots are in ascending order if events can be collected in random order - e.g we have the latest one always
 
         await this.diamondStateMachine.localDiamondContract.onStateSnapshotUpdated(
@@ -93,9 +87,6 @@ export class EventHandler {
     }
 
     private async handleChannelClose(channelId: ChannelId): Promise<void> {
-        if (this.stateManager.isDisposed) {
-            return;
-        }
         this.logger.info("Handling channel close", { channelId });
 
         // Disconnect from all peers in this channel
@@ -112,9 +103,6 @@ export class EventHandler {
         signedBlock: SignedBlockStruct,
         timestamp: Timestamp
     ): Promise<void> {
-        if (this.stateManager.isDisposed) {
-            return;
-        }
         this.logger.verbose("Block calldata posted on-chain", {
             channelId,
             commitmentHash,
@@ -154,9 +142,6 @@ export class EventHandler {
         windowCreationTimestamp: Timestamp,
         disputeAuditingData?: DisputeAuditingDataStruct
     ): Promise<void> {
-        if (this.stateManager.isDisposed) {
-            return;
-        }
         const dispute = Codec.decode(
             disputeConfirmation.signedDispute.encodedDispute,
             Type.Dispute
@@ -253,9 +238,6 @@ export class EventHandler {
     private async canConstructMoreEvidence(
         dispute: DisputeStruct
     ): Promise<boolean> {
-        if (this.stateManager.isDisposed) {
-            return false;
-        }
         // Create our own dispute
         const {
             dispute: ourDispute,
@@ -288,9 +270,6 @@ export class EventHandler {
         participant: Address,
         timestamp: Timestamp
     ): Promise<void> {
-        if (this.stateManager.isDisposed) {
-            return;
-        }
         await this.diamondStateMachine.localDiamondContract.onOnChainSlashAdded(
             channelId,
             participant,
@@ -324,9 +303,6 @@ export class EventHandler {
         reductionTimestamp: Timestamp,
         reducer: Address
     ): Promise<void> {
-        if (this.stateManager.isDisposed) {
-            return;
-        }
         // sync LocalDiamond state
         await this.diamondStateMachine.localDiamondContract.onDisputeReducedResultCommitted(
             channelId,
@@ -386,9 +362,6 @@ export class EventHandler {
         channelId: ChannelId,
         totalWithdrawals: any
     ): Promise<void> {
-        if (this.stateManager.isDisposed) {
-            return;
-        }
         await this.diamondStateMachine.localDiamondContract.onWithdrawalsUpdated(
             channelId,
             totalWithdrawals
@@ -399,9 +372,6 @@ export class EventHandler {
         channelId: ChannelId,
         latestInboundMessageBlockHash: Hash
     ): Promise<void> {
-        if (this.stateManager.isDisposed) {
-            return;
-        }
         await this.diamondStateMachine.localDiamondContract.onChannelStorageCleared(
             channelId,
             latestInboundMessageBlockHash
@@ -413,9 +383,6 @@ export class EventHandler {
         forkId: ForkId,
         disputer: Address
     ): Promise<void> {
-        if (this.stateManager.isDisposed) {
-            return;
-        }
         await this.diamondStateMachine.localDiamondContract.onDisputeKilled(
             channelId,
             forkId,

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -186,10 +186,11 @@ class StateManager {
         }
         this.reductionTriggerMap.clear();
 
-        await this.timeoutManager.dispose();
-
-        this.stateChannelEventListener.dispose();
-        await this.p2pManager.dispose();
+        await Promise.all([
+            this.timeoutManager.dispose(),
+            this.stateChannelEventListener.dispose(),
+            this.p2pManager.dispose()
+        ]);
     }
     public setP2pEventHooks(p2pEventHooks: P2pEventHooks) {
         this.p2pEventHooks = p2pEventHooks;


### PR DESCRIPTION
Better solution for event leak:

- Remove `isDisposed` check from `EventHandler`
- when disposing of `StateChannelEventListener`, await all the `.off` promises

Before:  `StateChannelEventListener` was marked as dispoed BEFORE all the event listener were closed off, meaning an event could still be observed by `StateChannelEventListener` that was considered disposed

After: The disposal chain starting from `P2Pinstance` will wait  until all event listener are removed => impossible for a listener to remain alive after it's test was done

* Ran E2e test suite 20 times in a loop, all passed. **observed 0 failures**