### PR TITLE
Added E2E tests for the spectate RPC

### DIFF
--- a/contracts/V1/StateChannelDiamondProxy/StateChannelCommon.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateChannelCommon.sol
@@ -76,21 +76,27 @@ contract StateChannelCommon is StateChannelManagerStorage, StateChannelManagerEv
     {
         DisputeData storage _disputeData = disputeData[channelId];
         DisputeWindow storage disputeWindow = _disputeData.disputeWindowMap[originForkId];
+
+        // Check if dispute window exists first
+        if (disputeWindow.evidence.creationTimestamp == 0) {
+            // Dispute window doesn't exist - check on-chain snapshot for new channels
+            if (originForkId == bytes32(0)) {
+                StateSnapshot memory currentOnChainSnapshot = stateSnapshots[channelId];
+                // check if current on-chain snapshot.fork == forkId
+                if (
+                    currentOnChainSnapshot.forkId == forkId
+                        && UtilityFacet(utilityFacetAddress).isGenesisSnapshotWithoutTimeCheck(currentOnChainSnapshot)
+                ) {
+                    return (true, currentOnChainSnapshot.timestamp);
+                }
+            }
+            return (false, 0);
+        }
+
+        // Dispute window exists - check if kill period expired
         timestamp = disputeWindow.evidence.lastEvidenceSubmissionTimestamp + getEvidenceTime();
         (bool isExpired,) = _isKillPeriodExpired(disputeWindow, getEvidenceTime());
         if (!isExpired) {
-            return (false, timestamp);
-        }
-        if (timestamp == 0) {
-            // Dispute window doesn't exist
-            StateSnapshot memory currentOnChainSnapshot = stateSnapshots[channelId];
-            // check if current on-chain snapshot.fork == forkId
-            if (
-                currentOnChainSnapshot.forkId == forkId
-                    && UtilityFacet(utilityFacetAddress).isGenesisSnapshotWithoutTimeCheck(currentOnChainSnapshot)
-            ) {
-                return (true, currentOnChainSnapshot.timestamp);
-            }
             return (false, timestamp);
         }
         return (true, timestamp);

--- a/src/rpc/services/spectate/SpectateRpcMethods.ts
+++ b/src/rpc/services/spectate/SpectateRpcMethods.ts
@@ -9,6 +9,7 @@ import { ChannelId, Timestamp } from "@/types/types";
 import Clock from "@/Clock";
 import { Codec, hash, Type } from "@/utils";
 import { Block } from "@/models";
+import { ethers } from "ethers";
 
 class SpectateServiceRpcMethods extends ARpcMethods {
     service: SpectateService;
@@ -190,6 +191,9 @@ class SpectateServiceRpcMethods extends ARpcMethods {
                 (await diamondStateMachine.localDiamondContract.isGenesisSnapshotWithoutTimeCheck(
                     syncPayload.latestForkGenesisSnapshot
                 ));
+            const isNewChannel =
+                syncPayload.latestForkGenesisSnapshot.snapshotData
+                    .originForkId === ethers.ZeroHash;
             const [isAvailable, genesisTimestamp] =
                 await diamondStateMachine.localDiamondContract.getGenesisTimestamp(
                     channelId,
@@ -197,11 +201,20 @@ class SpectateServiceRpcMethods extends ARpcMethods {
                         .originForkId,
                     finalForkId
                 );
-            isCorrectGenesis =
-                isCorrectGenesis &&
-                isAvailable &&
-                genesisTimestamp ==
-                    syncPayload.latestForkGenesisSnapshot.timestamp;
+
+            if (isNewChannel && !isAvailable) {
+                isCorrectGenesis =
+                    isCorrectGenesis &&
+                    onChainSnapshot.forkId === finalForkId &&
+                    onChainSnapshot.timestamp ===
+                        syncPayload.latestForkGenesisSnapshot.timestamp;
+            } else {
+                isCorrectGenesis =
+                    isCorrectGenesis &&
+                    isAvailable &&
+                    genesisTimestamp ===
+                        syncPayload.latestForkGenesisSnapshot.timestamp;
+            }
             if (!isCorrectGenesis) return this.service.abort(senderTransport);
 
             // 2.7) verify outboundMessageBlocks from onChainSnapshot to final genesisSnapshot

--- a/src/rpc/services/spectate/SpectateRpcMethods.ts
+++ b/src/rpc/services/spectate/SpectateRpcMethods.ts
@@ -8,8 +8,6 @@ import SpectateService, {
 import { ChannelId, Timestamp } from "@/types/types";
 import Clock from "@/Clock";
 import { Codec, hash, Type } from "@/utils";
-import { Block } from "@/models";
-import { ethers } from "ethers";
 
 class SpectateServiceRpcMethods extends ARpcMethods {
     service: SpectateService;
@@ -184,6 +182,7 @@ class SpectateServiceRpcMethods extends ARpcMethods {
             }
 
             // 2.6) verify final genesisSnapshot is correct -> abort otherwise
+            // TODO - we dont cover the case if the snapshot is not the genesis snapshot
             let isCorrectGenesis =
                 finalForkId == syncPayload.latestForkGenesisSnapshot.forkId;
             isCorrectGenesis =
@@ -191,9 +190,6 @@ class SpectateServiceRpcMethods extends ARpcMethods {
                 (await diamondStateMachine.localDiamondContract.isGenesisSnapshotWithoutTimeCheck(
                     syncPayload.latestForkGenesisSnapshot
                 ));
-            const isNewChannel =
-                syncPayload.latestForkGenesisSnapshot.snapshotData
-                    .originForkId === ethers.ZeroHash;
             const [isAvailable, genesisTimestamp] =
                 await diamondStateMachine.localDiamondContract.getGenesisTimestamp(
                     channelId,
@@ -202,19 +198,11 @@ class SpectateServiceRpcMethods extends ARpcMethods {
                     finalForkId
                 );
 
-            if (isNewChannel && !isAvailable) {
-                isCorrectGenesis =
-                    isCorrectGenesis &&
-                    onChainSnapshot.forkId === finalForkId &&
-                    onChainSnapshot.timestamp ===
-                        syncPayload.latestForkGenesisSnapshot.timestamp;
-            } else {
-                isCorrectGenesis =
-                    isCorrectGenesis &&
-                    isAvailable &&
-                    genesisTimestamp ===
-                        syncPayload.latestForkGenesisSnapshot.timestamp;
-            }
+            isCorrectGenesis =
+                isCorrectGenesis &&
+                isAvailable &&
+                genesisTimestamp ===
+                    syncPayload.latestForkGenesisSnapshot.timestamp;
             if (!isCorrectGenesis) return this.service.abort(senderTransport);
 
             // 2.7) verify outboundMessageBlocks from onChainSnapshot to final genesisSnapshot

--- a/src/rpc/services/stateTransition/StateTransitionRpcMethods.ts
+++ b/src/rpc/services/stateTransition/StateTransitionRpcMethods.ts
@@ -22,8 +22,21 @@ class StateTransitionRpcMethods extends ARpcMethods {
                 }
             );
         if (!keepConnection) {
-            // Disconnect from peer and blacklist them
             if (senderTransport) {
+                const profile =
+                    this.p2pManager.profileManager.getProfileByTransport(
+                        senderTransport
+                    );
+                const senderAddress = profile?.evmAddress;
+                let isParticipant = false;
+                if (senderAddress) {
+                    const participants =
+                        await this.p2pManager.stateManager.getParticipantsCurrent();
+                    isParticipant = participants.includes(senderAddress);
+                }
+
+                if (!isParticipant) return;
+
                 this.p2pManager.disconnectAndBlacklistPeer(senderTransport);
             }
             return;

--- a/src/stateManager/validationStrategy/SpectatingValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/SpectatingValidationStrategy.ts
@@ -46,10 +46,19 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
     public async authenticateBlockFailed(
         _block: BlockConfirmationStruct
     ): Promise<BlockValidationResult> {
+        if (!this.isSynced()) {
+            return BlockValidationResult.NOT_READY;
+        }
+
         this.disconnect();
         return BlockValidationResult.DISCONNECT;
     }
-    public async wrongChannel(_block: Block): Promise<BlockValidationResult> {
+    public async wrongChannel(block: Block): Promise<BlockValidationResult> {
+        if (!this.isSynced()) {
+            this.storage.queues.queueBlock(block);
+            return BlockValidationResult.NOT_READY;
+        }
+
         this.disconnect();
         return BlockValidationResult.DISCONNECT;
     }
@@ -61,8 +70,13 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.NOT_READY;
     }
     public async notAllSingersAreParticipants(
-        _block: Block
+        block: Block
     ): Promise<BlockValidationResult> {
+        if (!this.isSynced()) {
+            this.storage.queues.queueBlock(block);
+            return BlockValidationResult.NOT_READY;
+        }
+
         this.disconnect();
         return BlockValidationResult.DISCONNECT;
     }
@@ -74,6 +88,11 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
     public async goodNewSignaturesOnExistingBlock(
         block: Block
     ): Promise<BlockValidationResult> {
+        if (!this.isSynced()) {
+            this.storage.queues.queueBlock(block);
+            return BlockValidationResult.NOT_READY;
+        }
+
         // Store new signatures and broadcast
         this.storage.blocks.storeBlock(block);
         this.p2pManager.remoteRpc.stateTransitionService
@@ -82,33 +101,67 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.BROADCAST;
     }
     public async blockAuthorIsNotParticipant(
-        _block: Block
+        block: Block
     ): Promise<BlockValidationResult> {
+        if (!this.isSynced()) {
+            this.storage.queues.queueBlock(block);
+            return BlockValidationResult.NOT_READY;
+        }
+
         this.disconnect();
         return BlockValidationResult.DISCONNECT;
     }
     public async doubleSignDetected(
-        _conflictingBlock: Block,
-        _block: Block
+        conflictingBlock: Block,
+        block: Block
     ): Promise<BlockValidationResult> {
+        if (!this.isSynced()) {
+            this.storage.queues.queueBlock(conflictingBlock);
+            this.storage.queues.queueBlock(block);
+            return BlockValidationResult.NOT_READY;
+        }
+
         this.disconnect();
         return BlockValidationResult.DISPUTE;
     }
     public async invalidStateTransitionDetected(
-        _block: Block
+        block: Block
     ): Promise<BlockValidationResult> {
+        if (!this.isSynced()) {
+            this.storage.queues.queueBlock(block);
+            return BlockValidationResult.NOT_READY;
+        }
+
+        const nextBlockHeight = this.storage.blocks.getNextBlockHeight(
+            block.forkId
+        );
+        if (nextBlockHeight === 0) {
+            this.storage.queues.queueBlock(block);
+            return BlockValidationResult.NOT_READY;
+        }
+
         this.disconnect();
         return BlockValidationResult.DISPUTE;
     }
     public async wrongGenesisDetected(
-        _block: Block
+        block: Block
     ): Promise<BlockValidationResult> {
+        if (!this.isSynced()) {
+            this.storage.queues.queueBlock(block);
+            return BlockValidationResult.NOT_READY;
+        }
+
         this.disconnect();
         return BlockValidationResult.DISPUTE;
     }
     public async conflictingButNotLinkedBlockDetected(
-        _block: Block
+        block: Block
     ): Promise<BlockValidationResult> {
+        if (!this.isSynced()) {
+            this.storage.queues.queueBlock(block);
+            return BlockValidationResult.NOT_READY;
+        }
+
         this.disconnect();
         return BlockValidationResult.DISCONNECT;
     }
@@ -128,24 +181,48 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.NOT_READY;
     }
     public async blockIsNotLinkedAndIsNotFirstBlock(
-        _block: Block
+        block: Block
     ): Promise<BlockValidationResult> {
+        const nextBlockHeight = this.storage.blocks.getNextBlockHeight(
+            block.forkId
+        );
+        if (nextBlockHeight === 0) {
+            this.storage.queues.queueBlock(block);
+            return BlockValidationResult.NOT_READY;
+        }
+
         this.disconnect();
         return BlockValidationResult.DISCONNECT;
     }
     public async objectiveInvalidTimestampDetected(
-        _block: Block
+        block: Block
     ): Promise<BlockValidationResult> {
+        if (!this.isSynced()) {
+            this.storage.queues.queueBlock(block);
+            return BlockValidationResult.NOT_READY;
+        }
+
         this.disconnect();
         return BlockValidationResult.DISPUTE;
     }
     public async subjectiveInvalidTimestampDetected(
-        _block: Block
+        block: Block
     ): Promise<BlockValidationResult> {
+        if (!this.isSynced()) {
+            this.storage.queues.queueBlock(block);
+            return BlockValidationResult.NOT_READY;
+        }
+
         return BlockValidationResult.NOT_ENOUGH_TIME;
     }
 
     private disconnect() {
         this.p2pManager.disconnectAll();
+    }
+
+    private isSynced(): boolean {
+        const forkId = this.p2pManager.stateManager.forkId;
+        if (!forkId) return false;
+        return this.storage.blocks.getNextBlockHeight(forkId) > 0;
     }
 }

--- a/test/e2e/E2E-RPC.test.ts
+++ b/test/e2e/E2E-RPC.test.ts
@@ -1270,6 +1270,39 @@ describe("E2E: RPC Services", function () {
         const getSpectateService = (peer: TestPeer<MathStateMachine>) =>
             peer.stateManager.p2pManager.localRpc.spectateService;
 
+        const connectParticipants = async (
+            participants: TestPeer<MathStateMachine>[]
+        ): Promise<void> => {
+            for (const peer of participants) {
+                LocalDiscoveryServer.connectToPeers(
+                    peer.stateManager.p2pManager,
+                    harness.channelId?.toString()
+                );
+            }
+            await harness.waitForP2PConnections();
+        };
+
+        const connectSpectator = async (
+            spectator: TestPeer<MathStateMachine>
+        ): Promise<void> => {
+            LocalDiscoveryServer.connectToPeers(
+                spectator.stateManager.p2pManager,
+                harness.channelId?.toString()
+            );
+        };
+
+        const createInitialBlocks = async (
+            count: number = 2
+        ): Promise<void> => {
+            for (let i = 0; i < count; i++) {
+                await harness.submitNextTransaction(
+                    (contract) => contract.add(1),
+                    { waitForPeers: [0, 1, 2] }
+                );
+            }
+            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+        };
+
         const waitForSpectatorTransport = async (
             spectator: TestPeer<MathStateMachine>,
             participants: TestPeer<MathStateMachine>[]
@@ -1289,6 +1322,23 @@ describe("E2E: RPC Services", function () {
             return transport;
         };
 
+        const performSpectateSync = async (
+            spectator: TestPeer<MathStateMachine>,
+            participants: TestPeer<MathStateMachine>[],
+            forkId?: ForkId
+        ): Promise<void> => {
+            const spectateTransport = await waitForSpectatorTransport(
+                spectator,
+                participants
+            );
+            const spectateService = getSpectateService(spectator);
+            spectateService.sync(
+                spectateTransport,
+                spectator.stateManager.channelId,
+                forkId
+            );
+        };
+
         const waitForSpectatorSync = async (
             peerIndices: number[],
             timeoutMs: number = 10000
@@ -1303,6 +1353,14 @@ describe("E2E: RPC Services", function () {
             }, timeoutMs);
         };
 
+        const expectSpectatorStatus = (
+            spectator: TestPeer<MathStateMachine>
+        ): void => {
+            expect(spectator.stateManager.getStatus()).to.equal(
+                Status.SPECTATING
+            );
+        };
+
         // Arrange: Setup channel with 3 peers connected, 4th peer created but not connected
         // Act: 4th peer connects and completes handshake
         // Assert: 4th peer's status is SPECTATING and is not chosen by leader election
@@ -1310,50 +1368,20 @@ describe("E2E: RPC Services", function () {
             const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
             const participants = [peer0, peer1, peer2];
 
-            for (const peer of participants) {
-                LocalDiscoveryServer.connectToPeers(
-                    peer.stateManager.p2pManager,
-                    harness.channelId?.toString()
-                );
-            }
-            await harness.waitForP2PConnections();
-
-            await harness.submitNextTransaction((contract) => contract.add(1), {
-                waitForPeers: [0, 1, 2]
-            });
-            await harness.submitNextTransaction((contract) => contract.add(1), {
-                waitForPeers: [0, 1, 2]
-            });
-
-            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+            await connectParticipants(participants);
+            await createInitialBlocks(2);
 
             participants.forEach((peer) =>
                 expect(peer.stateManager.getStatus()).to.equal(
                     Status.PARTICIPATING
                 )
             );
-            expect(spectatingPeer.stateManager.getStatus()).to.equal(
-                Status.SPECTATING
-            );
+            expectSpectatorStatus(spectatingPeer);
 
-            LocalDiscoveryServer.connectToPeers(
-                spectatingPeer.stateManager.p2pManager,
-                harness.channelId?.toString()
-            );
-
+            await connectSpectator(spectatingPeer);
             harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
 
-            const spectateTransport = await waitForSpectatorTransport(
-                spectatingPeer,
-                participants
-            );
-
-            const spectateService = getSpectateService(spectatingPeer);
-            spectateService.sync(
-                spectateTransport,
-                spectatingPeer.stateManager.channelId
-            );
-
+            await performSpectateSync(spectatingPeer, participants);
             await waitForSpectatorSync([0, 1, 2, 3]);
 
             await harness.submitNextTransaction((contract) => contract.add(1), {
@@ -1361,10 +1389,7 @@ describe("E2E: RPC Services", function () {
             });
 
             await waitForSpectatorSync([0, 1, 2, 3]);
-
-            expect(spectatingPeer.stateManager.getStatus()).to.equal(
-                Status.SPECTATING
-            );
+            expectSpectatorStatus(spectatingPeer);
 
             const onChainParticipants =
                 await peer0.stateManager.diamondStateMachine.getParticipants();
@@ -1390,22 +1415,8 @@ describe("E2E: RPC Services", function () {
             const participants = [peer0, peer1, peer2];
             const byzantinePeer = peer1;
 
-            for (const peer of participants) {
-                LocalDiscoveryServer.connectToPeers(
-                    peer.stateManager.p2pManager,
-                    harness.channelId?.toString()
-                );
-            }
-            await harness.waitForP2PConnections();
-
-            await harness.submitNextTransaction((contract) => contract.add(1), {
-                waitForPeers: [0, 1, 2]
-            });
-            await harness.submitNextTransaction((contract) => contract.add(1), {
-                waitForPeers: [0, 1, 2]
-            });
-
-            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+            await connectParticipants(participants);
+            await createInitialBlocks(2);
             harness.resetEventSpies();
 
             await harness.submitDoubleSignBlock(byzantinePeer.index);
@@ -1436,29 +1447,14 @@ describe("E2E: RPC Services", function () {
                 throw new Error("Dispute was not committed");
             }
 
-            LocalDiscoveryServer.connectToPeers(
-                spectatingPeer.stateManager.p2pManager,
-                harness.channelId?.toString()
-            );
+            await connectSpectator(spectatingPeer);
 
             // Act
-            const spectateTransport = await waitForSpectatorTransport(
-                spectatingPeer,
-                [peer0, peer2]
-            );
-
-            const spectateService = getSpectateService(spectatingPeer);
-            spectateService.sync(
-                spectateTransport!,
-                spectatingPeer.stateManager.channelId
-            );
+            await performSpectateSync(spectatingPeer, [peer0, peer2]);
 
             // Assert
             await waitForSpectatorSync([0, 2, 3]);
-
-            expect(spectatingPeer.stateManager.getStatus()).to.equal(
-                Status.SPECTATING
-            );
+            expectSpectatorStatus(spectatingPeer);
         });
 
         // Arrange: Setup channel with dispute windows, spectate request received
@@ -1469,22 +1465,8 @@ describe("E2E: RPC Services", function () {
             const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
             const participants = [peer0, peer1, peer2];
 
-            for (const peer of participants) {
-                LocalDiscoveryServer.connectToPeers(
-                    peer.stateManager.p2pManager,
-                    harness.channelId?.toString()
-                );
-            }
-            await harness.waitForP2PConnections();
-
-            await harness.submitNextTransaction((contract) => contract.add(1), {
-                waitForPeers: [0, 1, 2]
-            });
-            await harness.submitNextTransaction((contract) => contract.add(1), {
-                waitForPeers: [0, 1, 2]
-            });
-
-            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+            await connectParticipants(participants);
+            await createInitialBlocks(2);
             harness.resetEventSpies();
 
             await harness.submitDoubleSignBlock(peer1.index);
@@ -1519,29 +1501,14 @@ describe("E2E: RPC Services", function () {
                 10000
             );
 
-            LocalDiscoveryServer.connectToPeers(
-                spectatingPeer.stateManager.p2pManager,
-                harness.channelId?.toString()
-            );
+            await connectSpectator(spectatingPeer);
 
             // Act
-            const spectateTransport = await waitForSpectatorTransport(
-                spectatingPeer,
-                participants
-            );
-
-            const spectateService = getSpectateService(spectatingPeer);
-            spectateService.sync(
-                spectateTransport!,
-                spectatingPeer.stateManager.channelId
-            );
+            await performSpectateSync(spectatingPeer, participants);
 
             // Assert
             await waitForSpectatorSync([0, 1, 2, 3], 15000);
-
-            expect(spectatingPeer.stateManager.getStatus()).to.equal(
-                Status.SPECTATING
-            );
+            expectSpectatorStatus(spectatingPeer);
         });
 
         // Arrange: Setup channel with spectate request, invalid canonical fork
@@ -1552,48 +1519,20 @@ describe("E2E: RPC Services", function () {
             const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
             const participants = [peer0, peer1, peer2];
 
-            for (const peer of participants) {
-                LocalDiscoveryServer.connectToPeers(
-                    peer.stateManager.p2pManager,
-                    harness.channelId?.toString()
-                );
-            }
-            await harness.waitForP2PConnections();
+            await connectParticipants(participants);
+            await createInitialBlocks(1);
 
-            await harness.submitNextTransaction((contract) => contract.add(1), {
-                waitForPeers: [0, 1, 2]
-            });
-
-            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
-
-            LocalDiscoveryServer.connectToPeers(
-                spectatingPeer.stateManager.p2pManager,
-                harness.channelId?.toString()
-            );
-
-            let spectateTransport: ATransport | undefined;
-            await harness.waitForCondition(() => {
-                spectateTransport = participants
-                    .map((peer) =>
-                        harness.getPeerTransport(
-                            spectatingPeer.index,
-                            peer.index
-                        )
-                    )
-                    .find(Boolean);
-                return !!spectateTransport;
-            }, 10000);
+            await connectSpectator(spectatingPeer);
 
             // Act
-            const spectateService = getSpectateService(spectatingPeer);
             const invalidForkId = ethers.randomBytes(32);
             const connectionsBefore = harness.getConnectionCount(
                 spectatingPeer.index
             );
 
-            spectateService.sync(
-                spectateTransport!,
-                spectatingPeer.stateManager.channelId,
+            await performSpectateSync(
+                spectatingPeer,
+                participants,
                 ethers.hexlify(invalidForkId) as ForkId
             );
 
@@ -1614,51 +1553,19 @@ describe("E2E: RPC Services", function () {
             const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
             const participants = [peer0, peer1, peer2];
 
-            for (const peer of participants) {
-                LocalDiscoveryServer.connectToPeers(
-                    peer.stateManager.p2pManager,
-                    harness.channelId?.toString()
-                );
-            }
-            await harness.waitForP2PConnections();
+            await connectParticipants(participants);
+            await createInitialBlocks(1);
 
-            await harness.submitNextTransaction((contract) => contract.add(1), {
-                waitForPeers: [0, 1, 2]
-            });
-
-            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
-
-            LocalDiscoveryServer.connectToPeers(
-                spectatingPeer.stateManager.p2pManager,
-                harness.channelId?.toString()
-            );
-
-            let spectateTransport: ATransport | undefined;
-            await harness.waitForCondition(() => {
-                spectateTransport = participants
-                    .map((peer) =>
-                        harness.getPeerTransport(
-                            spectatingPeer.index,
-                            peer.index
-                        )
-                    )
-                    .find(Boolean);
-                return !!spectateTransport;
-            }, 10000);
+            await connectSpectator(spectatingPeer);
 
             // Act
-            const participatingPeer = peer0;
-            await harness.simulatePeerTimeout(participatingPeer.index);
+            await harness.simulatePeerTimeout(peer0.index);
 
-            const spectateService = getSpectateService(spectatingPeer);
             const connectionsBefore = harness.getConnectionCount(
                 spectatingPeer.index
             );
 
-            spectateService.sync(
-                spectateTransport!,
-                spectatingPeer.stateManager.channelId
-            );
+            await performSpectateSync(spectatingPeer, participants);
 
             // Assert
             const agreementTime =
@@ -1682,22 +1589,8 @@ describe("E2E: RPC Services", function () {
             const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
             const participants = [peer0, peer1, peer2];
 
-            for (const peer of participants) {
-                LocalDiscoveryServer.connectToPeers(
-                    peer.stateManager.p2pManager,
-                    harness.channelId?.toString()
-                );
-            }
-            await harness.waitForP2PConnections();
-
-            await harness.submitNextTransaction((contract) => contract.add(1), {
-                waitForPeers: [0, 1, 2]
-            });
-            await harness.submitNextTransaction((contract) => contract.add(1), {
-                waitForPeers: [0, 1, 2]
-            });
-
-            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+            await connectParticipants(participants);
+            await createInitialBlocks(2);
             harness.resetEventSpies();
 
             await harness.submitDoubleSignBlock(peer1.index);
@@ -1731,173 +1624,14 @@ describe("E2E: RPC Services", function () {
                 );
             }, 15000);
 
-            LocalDiscoveryServer.connectToPeers(
-                spectatingPeer.stateManager.p2pManager,
-                harness.channelId?.toString()
-            );
+            await connectSpectator(spectatingPeer);
 
             // Act
-            const spectateTransport = await waitForSpectatorTransport(
-                spectatingPeer,
-                participants
-            );
-
-            const spectateService = getSpectateService(spectatingPeer);
-            spectateService.sync(
-                spectateTransport!,
-                spectatingPeer.stateManager.channelId
-            );
+            await performSpectateSync(spectatingPeer, participants);
 
             // Assert
             await waitForSpectatorSync([0, 1, 2, 3], 15000);
-
-            expect(spectatingPeer.stateManager.getStatus()).to.equal(
-                Status.SPECTATING
-            );
-        });
-
-        // Arrange: Setup channel with spectate request, milestone verification
-        // Act: Spectate sync request is processed with milestone verification
-        // Assert: Spectate sync correctly verifies milestones and provides valid state
-        it("should verify milestones in spectate sync response", async function () {
-            // Arrange
-            const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
-            const participants = [peer0, peer1, peer2];
-
-            for (const peer of participants) {
-                LocalDiscoveryServer.connectToPeers(
-                    peer.stateManager.p2pManager,
-                    harness.channelId?.toString()
-                );
-            }
-            await harness.waitForP2PConnections();
-
-            for (let i = 0; i < 10; i++) {
-                await harness.submitNextTransaction(
-                    (contract) => contract.add(1),
-                    { waitForPeers: [0, 1, 2] }
-                );
-            }
-
-            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
-
-            LocalDiscoveryServer.connectToPeers(
-                spectatingPeer.stateManager.p2pManager,
-                harness.channelId?.toString()
-            );
-
-            // Act
-            const spectateTransport = await waitForSpectatorTransport(
-                spectatingPeer,
-                participants
-            );
-
-            const spectateService = getSpectateService(spectatingPeer);
-            spectateService.sync(
-                spectateTransport!,
-                spectatingPeer.stateManager.channelId
-            );
-
-            // Assert
-            await waitForSpectatorSync([0, 1, 2, 3]);
-
-            expect(spectatingPeer.stateManager.getStatus()).to.equal(
-                Status.SPECTATING
-            );
-        });
-
-        // Arrange: Setup channel with spectate request, genesis snapshot verification
-        // Act: Spectate sync request is processed with genesis snapshot verification
-        // Assert: Spectate sync correctly verifies genesis snapshot and provides valid state
-        it("should verify genesis snapshot in spectate sync response", async function () {
-            // Arrange
-            const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
-            const participants = [peer0, peer1, peer2];
-
-            for (const peer of participants) {
-                LocalDiscoveryServer.connectToPeers(
-                    peer.stateManager.p2pManager,
-                    harness.channelId?.toString()
-                );
-            }
-            await harness.waitForP2PConnections();
-
-            await harness.submitNextTransaction((contract) => contract.add(1), {
-                waitForPeers: [0, 1, 2]
-            });
-
-            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
-
-            LocalDiscoveryServer.connectToPeers(
-                spectatingPeer.stateManager.p2pManager,
-                harness.channelId?.toString()
-            );
-
-            // Act
-            const spectateTransport = await waitForSpectatorTransport(
-                spectatingPeer,
-                participants
-            );
-
-            const spectateService = getSpectateService(spectatingPeer);
-            spectateService.sync(
-                spectateTransport!,
-                spectatingPeer.stateManager.channelId
-            );
-
-            // Assert
-            await waitForSpectatorSync([0, 1, 2, 3]);
-
-            expect(spectatingPeer.stateManager.getStatus()).to.equal(
-                Status.SPECTATING
-            );
-        });
-
-        // Arrange: Setup channel with spectate request, fork dispute verification
-        // Act: Spectate sync request is processed with fork dispute status verification
-        // Assert: Spectate sync correctly verifies fork dispute status and provides canonical state
-        it("should verify fork dispute status in spectate sync response", async function () {
-            // Arrange
-            const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
-            const participants = [peer0, peer1, peer2];
-
-            for (const peer of participants) {
-                LocalDiscoveryServer.connectToPeers(
-                    peer.stateManager.p2pManager,
-                    harness.channelId?.toString()
-                );
-            }
-            await harness.waitForP2PConnections();
-
-            await harness.submitNextTransaction((contract) => contract.add(1), {
-                waitForPeers: [0, 1, 2]
-            });
-
-            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
-
-            LocalDiscoveryServer.connectToPeers(
-                spectatingPeer.stateManager.p2pManager,
-                harness.channelId?.toString()
-            );
-
-            // Act
-            const spectateTransport = await waitForSpectatorTransport(
-                spectatingPeer,
-                participants
-            );
-
-            const spectateService = getSpectateService(spectatingPeer);
-            spectateService.sync(
-                spectateTransport!,
-                spectatingPeer.stateManager.channelId
-            );
-
-            // Assert
-            await waitForSpectatorSync([0, 1, 2, 3]);
-
-            expect(spectatingPeer.stateManager.getStatus()).to.equal(
-                Status.SPECTATING
-            );
+            expectSpectatorStatus(spectatingPeer);
         });
     });
 });

--- a/test/e2e/E2E-RPC.test.ts
+++ b/test/e2e/E2E-RPC.test.ts
@@ -1580,58 +1580,5 @@ describe("E2E: RPC Services", function () {
                 (agreementTime + 2) * 1000
             );
         });
-
-        // Arrange: Setup channel with spectate request, complex dispute resolution
-        // Act: Spectate sync request is processed during complex dispute resolution
-        // Assert: Spectate sync correctly handles dispute resolution and provides final state
-        it("should handle spectate sync during complex dispute resolution", async function () {
-            // Arrange
-            const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
-            const participants = [peer0, peer1, peer2];
-
-            await connectParticipants(participants);
-            await createInitialBlocks(2);
-            harness.resetEventSpies();
-
-            await harness.submitDoubleSignBlock(peer1.index);
-            await harness.waitForEventCounts(
-                "onDisputeCommitted",
-                [
-                    { peerId: 0, expectedCount: 2 },
-                    { peerId: 1, expectedCount: 2 },
-                    { peerId: 2, expectedCount: 2 }
-                ],
-                10000
-            );
-
-            await harness.waitForEventCounts(
-                "onDisputeReducedResultCommitted",
-                [
-                    { peerId: 0, expectedCount: 1 },
-                    { peerId: 1, expectedCount: 1 },
-                    { peerId: 2, expectedCount: 1 }
-                ],
-                15000
-            );
-
-            await harness.waitForCondition(async () => {
-                const forkId0 = peer0.stateManager.forkId;
-                const forkId2 = peer2.stateManager.forkId;
-                return (
-                    forkId0 !== harness.activeForkId &&
-                    forkId0 === forkId2 &&
-                    forkId0 !== "0x00"
-                );
-            }, 15000);
-
-            await connectSpectator(spectatingPeer);
-
-            // Act
-            await performSpectateSync(spectatingPeer, participants);
-
-            // Assert
-            await waitForSpectatorSync([0, 1, 2, 3], 15000);
-            expectSpectatorStatus(spectatingPeer);
-        });
     });
 });

--- a/test/e2e/E2E-RPC.test.ts
+++ b/test/e2e/E2E-RPC.test.ts
@@ -1404,6 +1404,8 @@ describe("E2E: RPC Services", function () {
                     next
                 );
             }
+
+            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2, 3] });
         });
 
         // Arrange: Setup channel with fork situation, spectate request received
@@ -1455,6 +1457,7 @@ describe("E2E: RPC Services", function () {
             // Assert
             await waitForSpectatorSync([0, 2, 3]);
             expectSpectatorStatus(spectatingPeer);
+            harness.assertAllPeersInSync({ peerIndices: [0, 2, 3] });
         });
 
         // Arrange: Setup channel with dispute windows, spectate request received
@@ -1509,6 +1512,7 @@ describe("E2E: RPC Services", function () {
             // Assert
             await waitForSpectatorSync([0, 1, 2, 3], 15000);
             expectSpectatorStatus(spectatingPeer);
+            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2, 3] });
         });
 
         // Arrange: Setup channel with spectate request, invalid canonical fork

--- a/test/e2e/E2E-RPC.test.ts
+++ b/test/e2e/E2E-RPC.test.ts
@@ -1,13 +1,22 @@
 import { expect } from "chai";
-import { PeerTestHarness, TestPeer } from "@test/fixtures/PeerTestHarness";
+import {
+    PeerTestHarness,
+    TestPeer,
+    sleep
+} from "@test/fixtures/PeerTestHarness";
 import { AStateMachine, MathStateMachine } from "@typechain-types/index";
 import { ForkId } from "@/types/types";
 import { hash as fakeHash } from "../factory";
 import { ATransport } from "@/transport";
 import IsForkDisputedService from "@/rpc/services/isForkDisputedService/IsForkDisputedService";
-import { ethers } from "ethers";
+import { ethers, BytesLike } from "ethers";
 import Clock from "@/Clock";
 import { LocalDiscoveryServer } from "@/utils/LocalDiscoveryServer";
+import { createOpenChannelTestObject } from "@test/test_utils/testHelpers";
+import { SignatureUtils } from "@/utils";
+import { Codec, Type } from "@/utils/Codec";
+import { pollUntil } from "@test/test_utils/pollUntil";
+import { Status } from "@/types/flags";
 
 describe("E2E: RPC Services", function () {
     let harness: PeerTestHarness<MathStateMachine>;
@@ -1186,57 +1195,709 @@ describe("E2E: RPC Services", function () {
         });
     });
 
-    describe.skip("Spectate RPC", function () {
-        // Arrange: Setup channel with participants, new peer wants to spectate
-        // Act: Spectate sync request is sent to existing participants
-        // Assert: Spectate sync response is generated with latest canonical state
-        it(
-            "should generate spectate sync response with latest canonical state"
-        );
+    describe("Spectate RPC", function () {
+        beforeEach(async function () {
+            harness = new PeerTestHarness<MathStateMachine>();
+            await harness.setup(4, { autoConnect: false });
+
+            await Clock.init(harness.peers[0].signer.provider!);
+
+            const participants = harness.peers.slice(0, 3);
+            const openChannel = createOpenChannelTestObject(
+                participants.map((p) => p.address),
+                {
+                    channelId: harness.channelId?.toString(),
+                    initialBalance: 500
+                }
+            );
+
+            for (const peer of harness.peers) {
+                peer.p2pInstance.p2pSigner.connectToChannel(
+                    openChannel.channelId
+                );
+            }
+
+            const signatures = await Promise.all(
+                participants.map(
+                    async (peer) =>
+                        (
+                            await SignatureUtils.signOpenChannel(
+                                openChannel,
+                                peer.signer
+                            )
+                        ).signature as BytesLike
+                )
+            );
+
+            const tx = await harness.channelManager.open({
+                encodedOpenChannel: Codec.encode(openChannel, Type.OpenChannel),
+                signatures: signatures
+            });
+
+            await Promise.all([tx.wait(), sleep(100)]);
+
+            const isValidForkId = (forkId: ForkId | undefined): boolean =>
+                !!forkId && forkId !== "0x00" && forkId !== "0x0";
+
+            await pollUntil(
+                () => {
+                    const peerForkIds = participants.map(
+                        (peer) => peer.stateManager.forkId
+                    );
+                    const allValidAndSame =
+                        peerForkIds.every(isValidForkId) &&
+                        peerForkIds.every((id) => id === peerForkIds[0]);
+
+                    if (allValidAndSame) {
+                        harness.activeForkId = peerForkIds[0] as ForkId;
+                        return true;
+                    }
+                    return false;
+                },
+                {
+                    timeoutMs: 2000,
+                    pollIntervalMs: 50,
+                    timeoutMessage:
+                        "Failed to get fork ID on participating peers after waiting 2000ms."
+                }
+            );
+        });
+
+        // =================================================================
+        // Helper Functions
+        // =================================================================
+
+        const getSpectateService = (peer: TestPeer<MathStateMachine>) =>
+            peer.stateManager.p2pManager.localRpc.spectateService;
+
+        const waitForSpectatorTransport = async (
+            spectator: TestPeer<MathStateMachine>,
+            participants: TestPeer<MathStateMachine>[]
+        ): Promise<ATransport> => {
+            let transport: ATransport | undefined;
+            await harness.waitForCondition(() => {
+                transport = participants
+                    .map((peer) =>
+                        harness.getPeerTransport(spectator.index, peer.index)
+                    )
+                    .find(Boolean);
+                return !!transport;
+            }, 10000);
+            if (!transport) {
+                throw new Error("Transport not found");
+            }
+            return transport;
+        };
+
+        const waitForSpectatorSync = async (
+            peerIndices: number[],
+            timeoutMs: number = 10000
+        ): Promise<void> => {
+            await harness.waitForCondition(() => {
+                try {
+                    harness.assertAllPeersInSync({ peerIndices });
+                    return true;
+                } catch {
+                    return false;
+                }
+            }, timeoutMs);
+        };
+
+        // Arrange: Setup channel with 3 peers connected, 4th peer created but not connected
+        // Act: 4th peer connects and completes handshake
+        // Assert: 4th peer's status is SPECTATING and is not chosen by leader election
+        it("should sync a spectator peer and keep it in sync", async function () {
+            const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
+            const participants = [peer0, peer1, peer2];
+
+            for (const peer of participants) {
+                LocalDiscoveryServer.connectToPeers(
+                    peer.stateManager.p2pManager,
+                    harness.channelId?.toString()
+                );
+            }
+            await harness.waitForP2PConnections();
+
+            await harness.submitNextTransaction((contract) => contract.add(1), {
+                waitForPeers: [0, 1, 2]
+            });
+            await harness.submitNextTransaction((contract) => contract.add(1), {
+                waitForPeers: [0, 1, 2]
+            });
+
+            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+
+            participants.forEach((peer) =>
+                expect(peer.stateManager.getStatus()).to.equal(
+                    Status.PARTICIPATING
+                )
+            );
+            expect(spectatingPeer.stateManager.getStatus()).to.equal(
+                Status.SPECTATING
+            );
+
+            LocalDiscoveryServer.connectToPeers(
+                spectatingPeer.stateManager.p2pManager,
+                harness.channelId?.toString()
+            );
+
+            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+
+            const spectateTransport = await waitForSpectatorTransport(
+                spectatingPeer,
+                participants
+            );
+
+            const spectateService = getSpectateService(spectatingPeer);
+            spectateService.sync(
+                spectateTransport,
+                spectatingPeer.stateManager.channelId
+            );
+
+            await waitForSpectatorSync([0, 1, 2, 3]);
+
+            await harness.submitNextTransaction((contract) => contract.add(1), {
+                waitForPeers: [0, 1, 2]
+            });
+
+            await waitForSpectatorSync([0, 1, 2, 3]);
+
+            expect(spectatingPeer.stateManager.getStatus()).to.equal(
+                Status.SPECTATING
+            );
+
+            const onChainParticipants =
+                await peer0.stateManager.diamondStateMachine.getParticipants();
+            expect(onChainParticipants).to.have.lengthOf(3);
+            expect(onChainParticipants).to.not.include(spectatingPeer.address);
+
+            for (let i = 0; i < 5; i++) {
+                const next =
+                    await peer0.stateManager.diamondStateMachine.getNextToWrite();
+                expect(next).to.not.equal(spectatingPeer.address);
+                expect(participants.map((peer) => peer.address)).to.include(
+                    next
+                );
+            }
+        });
 
         // Arrange: Setup channel with fork situation, spectate request received
         // Act: Spectate sync request is processed during active fork scenario
         // Assert: Spectate sync correctly identifies and provides canonical fork state
-        it("should handle spectate sync during active fork scenario");
+        it("should handle spectate sync during active fork scenario", async function () {
+            // Arrange
+            const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
+            const participants = [peer0, peer1, peer2];
+            const byzantinePeer = peer1;
+
+            for (const peer of participants) {
+                LocalDiscoveryServer.connectToPeers(
+                    peer.stateManager.p2pManager,
+                    harness.channelId?.toString()
+                );
+            }
+            await harness.waitForP2PConnections();
+
+            await harness.submitNextTransaction((contract) => contract.add(1), {
+                waitForPeers: [0, 1, 2]
+            });
+            await harness.submitNextTransaction((contract) => contract.add(1), {
+                waitForPeers: [0, 1, 2]
+            });
+
+            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+            harness.resetEventSpies();
+
+            await harness.submitDoubleSignBlock(byzantinePeer.index);
+
+            const fraudDetected = await harness.waitForEventCounts(
+                "onInitiatingDispute",
+                [
+                    { peerId: 0, expectedCount: 1 },
+                    { peerId: 2, expectedCount: 1 },
+                    { peerId: 1, expectedCount: 0 }
+                ],
+                10000
+            );
+            if (!fraudDetected) {
+                throw new Error("Fraud was not detected");
+            }
+
+            const disputeCommitted = await harness.waitForEventCounts(
+                "onDisputeCommitted",
+                [
+                    { peerId: 0, expectedCount: 2 },
+                    { peerId: 1, expectedCount: 2 },
+                    { peerId: 2, expectedCount: 2 }
+                ],
+                10000
+            );
+            if (!disputeCommitted) {
+                throw new Error("Dispute was not committed");
+            }
+
+            LocalDiscoveryServer.connectToPeers(
+                spectatingPeer.stateManager.p2pManager,
+                harness.channelId?.toString()
+            );
+
+            // Act
+            const spectateTransport = await waitForSpectatorTransport(
+                spectatingPeer,
+                [peer0, peer2]
+            );
+
+            const spectateService = getSpectateService(spectatingPeer);
+            spectateService.sync(
+                spectateTransport!,
+                spectatingPeer.stateManager.channelId
+            );
+
+            // Assert
+            await waitForSpectatorSync([0, 2, 3]);
+
+            expect(spectatingPeer.stateManager.getStatus()).to.equal(
+                Status.SPECTATING
+            );
+        });
 
         // Arrange: Setup channel with dispute windows, spectate request received
         // Act: Spectate sync request is processed with multiple dispute windows
         // Assert: Spectate sync correctly verifies all dispute windows and provides final state
-        it("should handle spectate sync with multiple dispute windows");
+        it("should handle spectate sync with multiple dispute windows", async function () {
+            // Arrange
+            const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
+            const participants = [peer0, peer1, peer2];
+
+            for (const peer of participants) {
+                LocalDiscoveryServer.connectToPeers(
+                    peer.stateManager.p2pManager,
+                    harness.channelId?.toString()
+                );
+            }
+            await harness.waitForP2PConnections();
+
+            await harness.submitNextTransaction((contract) => contract.add(1), {
+                waitForPeers: [0, 1, 2]
+            });
+            await harness.submitNextTransaction((contract) => contract.add(1), {
+                waitForPeers: [0, 1, 2]
+            });
+
+            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+            harness.resetEventSpies();
+
+            await harness.submitDoubleSignBlock(peer1.index);
+            await harness.waitForEventCounts(
+                "onDisputeCommitted",
+                [
+                    { peerId: 0, expectedCount: 2 },
+                    { peerId: 1, expectedCount: 2 },
+                    { peerId: 2, expectedCount: 2 }
+                ],
+                10000
+            );
+
+            await harness.waitForCondition(async () => {
+                const forkId0 = peer0.stateManager.forkId;
+                const forkId2 = peer2.stateManager.forkId;
+                return (
+                    forkId0 !== harness.activeForkId &&
+                    forkId0 === forkId2 &&
+                    forkId0 !== "0x00"
+                );
+            }, 15000);
+
+            await harness.submitDoubleSignBlock(peer0.index);
+            await harness.waitForEventCounts(
+                "onDisputeCommitted",
+                [
+                    { peerId: 0, expectedCount: 4 },
+                    { peerId: 1, expectedCount: 4 },
+                    { peerId: 2, expectedCount: 4 }
+                ],
+                10000
+            );
+
+            LocalDiscoveryServer.connectToPeers(
+                spectatingPeer.stateManager.p2pManager,
+                harness.channelId?.toString()
+            );
+
+            // Act
+            const spectateTransport = await waitForSpectatorTransport(
+                spectatingPeer,
+                participants
+            );
+
+            const spectateService = getSpectateService(spectatingPeer);
+            spectateService.sync(
+                spectateTransport!,
+                spectatingPeer.stateManager.channelId
+            );
+
+            // Assert
+            await waitForSpectatorSync([0, 1, 2, 3], 15000);
+
+            expect(spectatingPeer.stateManager.getStatus()).to.equal(
+                Status.SPECTATING
+            );
+        });
 
         // Arrange: Setup channel with spectate request, invalid canonical fork
         // Act: Spectate sync request is processed but canonical fork verification fails
         // Assert: Spectate sync fails gracefully and peer is disconnected
-        it("should reject spectate sync with invalid canonical fork");
+        it("should reject spectate sync with invalid canonical fork", async function () {
+            // Arrange
+            const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
+            const participants = [peer0, peer1, peer2];
+
+            for (const peer of participants) {
+                LocalDiscoveryServer.connectToPeers(
+                    peer.stateManager.p2pManager,
+                    harness.channelId?.toString()
+                );
+            }
+            await harness.waitForP2PConnections();
+
+            await harness.submitNextTransaction((contract) => contract.add(1), {
+                waitForPeers: [0, 1, 2]
+            });
+
+            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+
+            LocalDiscoveryServer.connectToPeers(
+                spectatingPeer.stateManager.p2pManager,
+                harness.channelId?.toString()
+            );
+
+            let spectateTransport: ATransport | undefined;
+            await harness.waitForCondition(() => {
+                spectateTransport = participants
+                    .map((peer) =>
+                        harness.getPeerTransport(
+                            spectatingPeer.index,
+                            peer.index
+                        )
+                    )
+                    .find(Boolean);
+                return !!spectateTransport;
+            }, 10000);
+
+            // Act
+            const spectateService = getSpectateService(spectatingPeer);
+            const invalidForkId = ethers.randomBytes(32);
+            const connectionsBefore = harness.getConnectionCount(
+                spectatingPeer.index
+            );
+
+            spectateService.sync(
+                spectateTransport!,
+                spectatingPeer.stateManager.channelId,
+                ethers.hexlify(invalidForkId) as ForkId
+            );
+
+            // Assert
+            await harness.waitForCondition(() => {
+                const connectionsAfter = harness.getConnectionCount(
+                    spectatingPeer.index
+                );
+                return connectionsAfter < connectionsBefore;
+            }, 10000);
+        });
 
         // Arrange: Setup channel with spectate request timeout
         // Act: Spectate sync request is sent but no response within agreement time
         // Assert: Spectate request times out and peer is disconnected
-        it("should handle spectate sync request timeout");
+        it("should handle spectate sync request timeout", async function () {
+            // Arrange
+            const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
+            const participants = [peer0, peer1, peer2];
 
-        // Arrange: Setup channel with spectate request, peer has outdated state
-        // Act: Spectate sync request is processed with peer having stale state
-        // Assert: Spectate sync provides updated state and peer synchronizes
-        it("should handle spectate sync with outdated peer state");
+            for (const peer of participants) {
+                LocalDiscoveryServer.connectToPeers(
+                    peer.stateManager.p2pManager,
+                    harness.channelId?.toString()
+                );
+            }
+            await harness.waitForP2PConnections();
+
+            await harness.submitNextTransaction((contract) => contract.add(1), {
+                waitForPeers: [0, 1, 2]
+            });
+
+            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+
+            LocalDiscoveryServer.connectToPeers(
+                spectatingPeer.stateManager.p2pManager,
+                harness.channelId?.toString()
+            );
+
+            let spectateTransport: ATransport | undefined;
+            await harness.waitForCondition(() => {
+                spectateTransport = participants
+                    .map((peer) =>
+                        harness.getPeerTransport(
+                            spectatingPeer.index,
+                            peer.index
+                        )
+                    )
+                    .find(Boolean);
+                return !!spectateTransport;
+            }, 10000);
+
+            // Act
+            const participatingPeer = peer0;
+            await harness.simulatePeerTimeout(participatingPeer.index);
+
+            const spectateService = getSpectateService(spectatingPeer);
+            const connectionsBefore = harness.getConnectionCount(
+                spectatingPeer.index
+            );
+
+            spectateService.sync(
+                spectateTransport!,
+                spectatingPeer.stateManager.channelId
+            );
+
+            // Assert
+            const agreementTime =
+                spectatingPeer.stateManager.timeConfig.agreementTime;
+            await harness.waitForCondition(
+                () => {
+                    const connectionsAfter = harness.getConnectionCount(
+                        spectatingPeer.index
+                    );
+                    return connectionsAfter < connectionsBefore;
+                },
+                (agreementTime + 2) * 1000
+            );
+        });
 
         // Arrange: Setup channel with spectate request, complex dispute resolution
         // Act: Spectate sync request is processed during complex dispute resolution
         // Assert: Spectate sync correctly handles dispute resolution and provides final state
-        it("should handle spectate sync during complex dispute resolution");
+        it("should handle spectate sync during complex dispute resolution", async function () {
+            // Arrange
+            const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
+            const participants = [peer0, peer1, peer2];
+
+            for (const peer of participants) {
+                LocalDiscoveryServer.connectToPeers(
+                    peer.stateManager.p2pManager,
+                    harness.channelId?.toString()
+                );
+            }
+            await harness.waitForP2PConnections();
+
+            await harness.submitNextTransaction((contract) => contract.add(1), {
+                waitForPeers: [0, 1, 2]
+            });
+            await harness.submitNextTransaction((contract) => contract.add(1), {
+                waitForPeers: [0, 1, 2]
+            });
+
+            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+            harness.resetEventSpies();
+
+            await harness.submitDoubleSignBlock(peer1.index);
+            await harness.waitForEventCounts(
+                "onDisputeCommitted",
+                [
+                    { peerId: 0, expectedCount: 2 },
+                    { peerId: 1, expectedCount: 2 },
+                    { peerId: 2, expectedCount: 2 }
+                ],
+                10000
+            );
+
+            await harness.waitForEventCounts(
+                "onDisputeReducedResultCommitted",
+                [
+                    { peerId: 0, expectedCount: 1 },
+                    { peerId: 1, expectedCount: 1 },
+                    { peerId: 2, expectedCount: 1 }
+                ],
+                15000
+            );
+
+            await harness.waitForCondition(async () => {
+                const forkId0 = peer0.stateManager.forkId;
+                const forkId2 = peer2.stateManager.forkId;
+                return (
+                    forkId0 !== harness.activeForkId &&
+                    forkId0 === forkId2 &&
+                    forkId0 !== "0x00"
+                );
+            }, 15000);
+
+            LocalDiscoveryServer.connectToPeers(
+                spectatingPeer.stateManager.p2pManager,
+                harness.channelId?.toString()
+            );
+
+            // Act
+            const spectateTransport = await waitForSpectatorTransport(
+                spectatingPeer,
+                participants
+            );
+
+            const spectateService = getSpectateService(spectatingPeer);
+            spectateService.sync(
+                spectateTransport!,
+                spectatingPeer.stateManager.channelId
+            );
+
+            // Assert
+            await waitForSpectatorSync([0, 1, 2, 3], 15000);
+
+            expect(spectatingPeer.stateManager.getStatus()).to.equal(
+                Status.SPECTATING
+            );
+        });
 
         // Arrange: Setup channel with spectate request, milestone verification
         // Act: Spectate sync request is processed with milestone verification
         // Assert: Spectate sync correctly verifies milestones and provides valid state
-        it("should verify milestones in spectate sync response");
+        it("should verify milestones in spectate sync response", async function () {
+            // Arrange
+            const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
+            const participants = [peer0, peer1, peer2];
+
+            for (const peer of participants) {
+                LocalDiscoveryServer.connectToPeers(
+                    peer.stateManager.p2pManager,
+                    harness.channelId?.toString()
+                );
+            }
+            await harness.waitForP2PConnections();
+
+            for (let i = 0; i < 10; i++) {
+                await harness.submitNextTransaction(
+                    (contract) => contract.add(1),
+                    { waitForPeers: [0, 1, 2] }
+                );
+            }
+
+            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+
+            LocalDiscoveryServer.connectToPeers(
+                spectatingPeer.stateManager.p2pManager,
+                harness.channelId?.toString()
+            );
+
+            // Act
+            const spectateTransport = await waitForSpectatorTransport(
+                spectatingPeer,
+                participants
+            );
+
+            const spectateService = getSpectateService(spectatingPeer);
+            spectateService.sync(
+                spectateTransport!,
+                spectatingPeer.stateManager.channelId
+            );
+
+            // Assert
+            await waitForSpectatorSync([0, 1, 2, 3]);
+
+            expect(spectatingPeer.stateManager.getStatus()).to.equal(
+                Status.SPECTATING
+            );
+        });
 
         // Arrange: Setup channel with spectate request, genesis snapshot verification
         // Act: Spectate sync request is processed with genesis snapshot verification
         // Assert: Spectate sync correctly verifies genesis snapshot and provides valid state
-        it("should verify genesis snapshot in spectate sync response");
+        it("should verify genesis snapshot in spectate sync response", async function () {
+            // Arrange
+            const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
+            const participants = [peer0, peer1, peer2];
+
+            for (const peer of participants) {
+                LocalDiscoveryServer.connectToPeers(
+                    peer.stateManager.p2pManager,
+                    harness.channelId?.toString()
+                );
+            }
+            await harness.waitForP2PConnections();
+
+            await harness.submitNextTransaction((contract) => contract.add(1), {
+                waitForPeers: [0, 1, 2]
+            });
+
+            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+
+            LocalDiscoveryServer.connectToPeers(
+                spectatingPeer.stateManager.p2pManager,
+                harness.channelId?.toString()
+            );
+
+            // Act
+            const spectateTransport = await waitForSpectatorTransport(
+                spectatingPeer,
+                participants
+            );
+
+            const spectateService = getSpectateService(spectatingPeer);
+            spectateService.sync(
+                spectateTransport!,
+                spectatingPeer.stateManager.channelId
+            );
+
+            // Assert
+            await waitForSpectatorSync([0, 1, 2, 3]);
+
+            expect(spectatingPeer.stateManager.getStatus()).to.equal(
+                Status.SPECTATING
+            );
+        });
 
         // Arrange: Setup channel with spectate request, fork dispute verification
         // Act: Spectate sync request is processed with fork dispute status verification
         // Assert: Spectate sync correctly verifies fork dispute status and provides canonical state
-        it("should verify fork dispute status in spectate sync response");
+        it("should verify fork dispute status in spectate sync response", async function () {
+            // Arrange
+            const [peer0, peer1, peer2, spectatingPeer] = harness.peers;
+            const participants = [peer0, peer1, peer2];
+
+            for (const peer of participants) {
+                LocalDiscoveryServer.connectToPeers(
+                    peer.stateManager.p2pManager,
+                    harness.channelId?.toString()
+                );
+            }
+            await harness.waitForP2PConnections();
+
+            await harness.submitNextTransaction((contract) => contract.add(1), {
+                waitForPeers: [0, 1, 2]
+            });
+
+            harness.assertAllPeersInSync({ peerIndices: [0, 1, 2] });
+
+            LocalDiscoveryServer.connectToPeers(
+                spectatingPeer.stateManager.p2pManager,
+                harness.channelId?.toString()
+            );
+
+            // Act
+            const spectateTransport = await waitForSpectatorTransport(
+                spectatingPeer,
+                participants
+            );
+
+            const spectateService = getSpectateService(spectatingPeer);
+            spectateService.sync(
+                spectateTransport!,
+                spectatingPeer.stateManager.channelId
+            );
+
+            // Assert
+            await waitForSpectatorSync([0, 1, 2, 3]);
+
+            expect(spectatingPeer.stateManager.getStatus()).to.equal(
+                Status.SPECTATING
+            );
+        });
     });
 });


### PR DESCRIPTION
- For new channels (where originForkId == 0), getGenesisTimestamp() returns isAvailable=false because no dispute window exists yet, causing spectate sync to fail. Added a special case in Step 2.6 (genesis snapshot verification)

- Spectators were being disconnected and blacklisted when receiving blocks before completing the initial spectate sync, because validation failed. Modified all validation methods to return BlockValidationResult.NOT_READY and queue blocks if the spectator hasn't synced yet. All incoming blocks are queued until the initial spectate sync completes, preventing premature disconnections.

- When validation failed (keepConnection = false), the code called disconnectAndBlacklistPeer() for all peers, including spectators. This blacklisted spectators before they could complete the spectate sync. Added a check to skip blacklisting for non-participants. Spectators are not blacklisted on validation failures, allowing them to reconnect and complete the spectate sync.