### PR TITLE
tiny fix to `setGenesisState` tests in `StateManager.new.test.ts`

### DIFF
--- a/test/stateManager/StateManager.new.test.ts
+++ b/test/stateManager/StateManager.new.test.ts
@@ -15,6 +15,7 @@ import {
 } from "@typechain-types/contracts/V1/types/DataTypes";
 import { ForkId, Timestamp, Address, Hash } from "@/types/types";
 import { Codec, Type } from "@/utils";
+import Clock from "@/Clock";
 import { ethers } from "ethers";
 import StateManager from "@/stateManager";
 
@@ -596,11 +597,11 @@ describe("StateManager - Refactored", () => {
             // Arrange
             stateManager = createDefaultBuilder().build();
             const encodedState = hexString(32) as any;
-            const timestamp = defaults.defaultTimestamp as Timestamp;
+            const timestamp = Clock.getTimeInSeconds() as Timestamp;
             const participant = hexString(20) as Address;
             const snapshotDataObj = snapshotData({
                 originForkId: defaults.forkId,
-                stateMachineStateHash: hexString(32),
+                stateMachineStateHash: ethers.keccak256(encodedState),
                 participants: [participant],
                 totalDeposits: { amount: 100n, data: "0x" }
             });


### PR DESCRIPTION
the test "should set genesis state and trigger onTurn event when initializing new fork"
threw an error
the error was dues to an un intended timeout dispute from  `setGenesisState`, which in turn was due to a bad timestamp value in the test
fixed the timestamp => error gone