### PR TITLE
fix lower/upper, add guard

### DIFF
--- a/src/rpc/services/spectate/SpectateRpcMethods.ts
+++ b/src/rpc/services/spectate/SpectateRpcMethods.ts
@@ -4,7 +4,7 @@ import SpectateService, { SyncRequest } from "./SpectateService";
 import { Bytes, ChannelId } from "@/types";
 import Clock from "@/Clock";
 import { Codec, hash, Type } from "@/utils";
-import { Block } from "@/models";
+import { Block, StateSnapshot } from "@/models";
 import type { DisputeWindowVerification } from "@/types";
 
 class SpectateServiceRpcMethods extends ARpcMethods {
@@ -224,12 +224,22 @@ class SpectateServiceRpcMethods extends ARpcMethods {
             if (!isCorrectGenesis) return this.service.abort(peerAddress);
 
             // 2.7) verify outboundMessageBlocks from onChainSnapshot (lower/older) to final genesisSnapshot (upper/newer)
+            const genesisSnapshot = StateSnapshot.from(
+                syncPayload.latestForkGenesisSnapshot
+            );
+            const { lowerOutboundSnapshot, upperOutboundSnapshot } =
+                SpectateService.orderOutboundSnapshots(
+                    onChainSnapshot,
+                    genesisSnapshot
+                );
+
             let areValidExitBlocks =
                 await diamondStateMachine.localDiamondContract.verifyOutboundMessageBlocks(
                     syncPayload.outboundMessageBlocksUpToLatestGenesis,
-                    onChainSnapshot.snapshotData,
-                    syncPayload.latestForkGenesisSnapshot.snapshotData
+                    lowerOutboundSnapshot.toStruct().snapshotData,
+                    upperOutboundSnapshot.toStruct().snapshotData
                 );
+
             if (!areValidExitBlocks) return this.service.abort(peerAddress);
 
             // 2.8) Depending are we syncing to the 'latest state' (spectating) or some requested state (forkId,blockHeight), verify that:
@@ -264,6 +274,20 @@ class SpectateServiceRpcMethods extends ARpcMethods {
                 syncPayload.milestoneSnapshots.length > 0
                     ? syncPayload.milestoneSnapshots.at(-1)!
                     : syncPayload.latestForkGenesisSnapshot;
+
+            // if the on-chain snapshot is on the same fork but more advanced
+            // than what peers proved → abort.
+            if (
+                onChainSnapshot.forkID ===
+                    syncPayload.latestForkGenesisSnapshot.forkId &&
+                onChainSnapshot.blockHeight >
+                    Number(latestFinalizedSnapshot.blockHeight)
+            ) {
+                this.service.logger.debug(
+                    `onSpectateResponse - on-chain block height (${onChainSnapshot.blockHeight}) exceeds proved height (${Number(latestFinalizedSnapshot.blockHeight)}); aborting`
+                );
+                return this.service.abort(peerAddress);
+            }
 
             if (
                 latestFinalizedSnapshot.snapshotData.stateMachineStateHash !=

--- a/src/rpc/services/spectate/SpectateService.ts
+++ b/src/rpc/services/spectate/SpectateService.ts
@@ -226,12 +226,18 @@ class SpectateService extends ARpcService<SpectateServiceRpcMethods> {
             );
         }
 
+        const { lowerOutboundSnapshot, upperOutboundSnapshot } =
+            SpectateService.orderOutboundSnapshots(
+                currentOnChainSnapshot,
+                latestForkGenesisSnapshot
+            );
+
         const outboundMessageBlocksUpToLatestGenesis =
             stateManager.storage.outboundMessages.getMessageBlocksInRange({
                 upperBlockHash:
-                    latestForkGenesisSnapshot.latestOutboundMessageBlockHash,
+                    upperOutboundSnapshot.latestOutboundMessageBlockHash,
                 lowerBlockHash:
-                    currentOnChainSnapshot.latestOutboundMessageBlockHash
+                    lowerOutboundSnapshot.latestOutboundMessageBlockHash
             });
 
         const latestBlockHeight =
@@ -515,6 +521,19 @@ class SpectateService extends ARpcService<SpectateServiceRpcMethods> {
             );
         }
     }
+    public static orderOutboundSnapshots(
+        a: StateSnapshot,
+        b: StateSnapshot
+    ): {
+        lowerOutboundSnapshot: StateSnapshot;
+        upperOutboundSnapshot: StateSnapshot;
+    } {
+        return a.latestOutboundMessageBlockHeight <=
+            b.latestOutboundMessageBlockHeight
+            ? { lowerOutboundSnapshot: a, upperOutboundSnapshot: b }
+            : { lowerOutboundSnapshot: b, upperOutboundSnapshot: a };
+    }
+
     public abort(peerAddress: string) {
         // HandshakeCompletedGuard guarantees stable peer identity.
         // If we're not actively participating, treat this as a fatal sync failure.

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -507,6 +507,48 @@ class StateManager {
         const expectedReducedForkId = ethers.keccak256(
             Codec.encode(reducedSnapshotData, Type.SnapshotData)
         );
+
+        // Pre-store the outbound message block so buildForkSnapshotCalldata can
+        // find it via getMessageBlocksInRange.
+        if (reducedOutboundMessageBlock) {
+            this.storage.outboundMessages.store(reducedOutboundMessageBlock, {
+                justPersist: true
+            });
+        }
+
+        const currentOnChainSnapshot = StateSnapshot.from(
+            await this.stateChannelManagerContract.getStateSnapshot(
+                this.channelId
+            )
+        );
+        const reducedGenesisSnapshot = StateSnapshot.from({
+            forkId: expectedReducedForkId,
+            blockHeight: 0,
+            timestamp: Number(genesisTimestamp),
+            snapshotData: reducedSnapshotData
+        });
+        const { calldata: forkCalldata } = this.buildForkSnapshotCalldata(
+            reducedGenesisSnapshot,
+            currentOnChainSnapshot
+        );
+
+        const reduceCalldata =
+            this.stateChannelManagerContract.interface.encodeFunctionData(
+                "reduceAndFinalize",
+                [
+                    disputes,
+                    reduceData.latestStateSnapshot,
+                    reduceData.encodedStateMachineState,
+                    reduceData.inboundMessageBlocks,
+                    expectedReducedForkId
+                ]
+            );
+
+        this.logger.info("Reduction transaction submit", {
+            reducedForkId: expectedReducedForkId,
+            channelId: this.channelId
+        });
+
         let txResponse: TransactionResponse;
         this.logger.debug(
             `Submitting reduction transaction for fork ${LoggerUtils.formatHash(forkId)}`,
@@ -528,16 +570,7 @@ class StateManager {
         );
 
         const txResponsePromise = this.stateChannelManagerContract
-            .reduceAndFinalize(
-                disputes,
-                reduceData.latestStateSnapshot,
-                reduceData.encodedStateMachineState,
-                reduceData.inboundMessageBlocks,
-                expectedReducedForkId,
-                {
-                    gasLimit: 10_000_000
-                }
-            )
+            .multicall([reduceCalldata, forkCalldata], { gasLimit: 10_000_000 })
             .then((tx: TransactionResponse) => {
                 txResponse = tx;
                 const txReceiptPromise = tx.wait();
@@ -616,6 +649,30 @@ class StateManager {
             });
             throw error;
         }
+    }
+
+    private buildForkSnapshotCalldata(
+        reducedGenesisSnapshot: StateSnapshot,
+        currentOnChainSnapshot: StateSnapshot
+    ): { calldata: string; outboundMessageBlocks: MessageBlockStruct[] } {
+        // reducedGenesisSnapshot is  newer than currentOnChainSnapshot,
+        const outboundMessageBlocks =
+            this.storage.outboundMessages.getMessageBlocksInRange({
+                lowerBlockHash:
+                    currentOnChainSnapshot.latestOutboundMessageBlockHash,
+                upperBlockHash:
+                    reducedGenesisSnapshot.latestOutboundMessageBlockHash
+            });
+        const calldata =
+            this.stateChannelManagerContract.interface.encodeFunctionData(
+                "updateStateSnapshotFork",
+                [
+                    this.channelId,
+                    reducedGenesisSnapshot.toStruct(),
+                    outboundMessageBlocks
+                ]
+            );
+        return { calldata, outboundMessageBlocks };
     }
     public getSignerAddress(): Address {
         return this.signerAddress;
@@ -1778,43 +1835,26 @@ class StateManager {
                 );
             }
 
-            // Build exit blocks
-            const latestOutboundBlockHash =
-                genesisSnapshot.snapshotData.latestOutboundMessageBlockHash;
-            const currentOnChainOutboundBlockHash =
-                currentOnChainSnapshot.snapshotData
-                    .latestOutboundMessageBlockHash;
-            const outboundMessageBlocks =
-                this.storage.outboundMessages.getMessageBlocksInRange({
-                    upperBlockHash: latestOutboundBlockHash,
-                    lowerBlockHash: currentOnChainOutboundBlockHash
-                });
-
-            this.logger.debug(
-                "prepareUpdateStateSnapshotFork - outbound message block range",
-                {
-                    forkId: currentForkId,
-                    upperBlockHash: latestOutboundBlockHash,
-                    lowerBlockHash: currentOnChainOutboundBlockHash,
-                    blocksCount: outboundMessageBlocks.length
-                }
-            );
-
             if (genesisSnapshot.forkID !== this.forkId) {
                 throw new Error(
                     `Fork mismatch: update will result in fork ${genesisSnapshot.forkID}, but target fork is ${this.forkId}.`
                 );
             }
 
-            const forkCalldata =
-                this.stateChannelManagerContract.interface.encodeFunctionData(
-                    "updateStateSnapshotFork",
-                    [
-                        this.channelId,
-                        genesisSnapshot.toStruct(),
-                        outboundMessageBlocks
-                    ]
+            const { calldata: forkCalldata, outboundMessageBlocks } =
+                this.buildForkSnapshotCalldata(
+                    genesisSnapshot,
+                    currentOnChainSnapshot
                 );
+
+            this.logger.debug(
+                "prepareUpdateStateSnapshotFork - outbound message block range",
+                {
+                    forkId: currentForkId,
+                    blocksCount: outboundMessageBlocks.length
+                }
+            );
+
             callData.push(forkCalldata);
 
             if (callData.length === 0) {

--- a/test/e2e/E2E-SpectateStaleProofGuard.test.ts
+++ b/test/e2e/E2E-SpectateStaleProofGuard.test.ts
@@ -8,7 +8,7 @@ import { SyncPayload } from "@/types";
 PeerTestHarness.setDefaultLogLevel("error");
 
 describe("E2E: Spectate stale-proof guard", function () {
-    it.only("aborts sync when on-chain snapshot is more advanced than what participant proved", async function () {
+    it("aborts sync when on-chain snapshot is more advanced than what participant proved", async function () {
         const h = TestSession.getHarness();
 
         await h.lifecycle.start(2, 0, {

--- a/test/e2e/E2E-SpectateStaleProofGuard.test.ts
+++ b/test/e2e/E2E-SpectateStaleProofGuard.test.ts
@@ -1,0 +1,86 @@
+import { TestSession, PeerTestHarness } from "@test/harness";
+import { expect } from "chai";
+import { SyncRequest } from "@/rpc/services/spectate/SpectateService";
+import { Codec, Type } from "@/utils";
+import SpectateServiceRpcMethods from "@/rpc/services/spectate/SpectateRpcMethods";
+import { SyncPayload } from "@/types";
+
+PeerTestHarness.setDefaultLogLevel("error");
+
+describe("E2E: Spectate stale-proof guard", function () {
+    it.only("aborts sync when on-chain snapshot is more advanced than what participant proved", async function () {
+        const h = TestSession.getHarness();
+
+        await h.lifecycle.start(2, 0, {
+            timeConfig: {
+                p2pTime: 5,
+                agreementTime: 2,
+                chainFallbackTime: 2,
+                evidenceTime: 10
+            }
+        });
+
+        await h.transition.advanceState({
+            count: 4,
+            waitForFinalization: true
+        });
+        await h.transition.postSnapshot();
+
+        const staleBlockHeight = 1;
+
+        // Stub both participants to respond with a stale proof regardless of what
+        // was actually requested by the spectator.
+        for (const peerIndex of [0, 1]) {
+            h.rpcStub.stubServiceCreateRpcMethod({
+                peerIndex,
+                serviceName: "spectateService",
+                methodName: "onSpectateRequest",
+                stubbedMethod: async function (
+                    this: SpectateServiceRpcMethods,
+                    syncRequest: SyncRequest
+                ) {
+                    const senderTransport = this.senderTransport;
+                    const peerAddress = senderTransport.peerAddress;
+                    if (!peerAddress) return;
+
+                    const syncPayload = (await this.service.generateSyncPayload(
+                        syncRequest.channelId,
+                        syncRequest.forkId,
+                        //  STALE BLOCK HEIGHT
+                        staleBlockHeight
+                    )!) as SyncPayload;
+
+                    const encodedSyncPayload = Codec.encode(
+                        syncPayload,
+                        Type.SyncPayload
+                    );
+                    this.remoteRpc.spectateService
+                        .onSpectateResponse(
+                            syncRequest.channelId,
+                            encodedSyncPayload
+                        )
+                        .sendOne(peerAddress);
+                }
+            });
+        }
+
+        // addPeerWait throws if the spectator doesn't reach SYNCED within the timeout.
+        // With stale proofs, the guard aborts every sync attempt, so SYNCED is never reached.
+        let threwTimeout = false;
+        try {
+            await h.join.addPeerWait({ statusTimeoutMs: 5000 });
+        } catch (e: any) {
+            threwTimeout = true;
+        }
+
+        expect(threwTimeout).to.equal(
+            true,
+            "Spectator should not have reached SYNCED with stale proofs"
+        );
+
+        const spectator = h.getPeer(2);
+        expect(
+            spectator.stateManager.p2pManager.openConnections.length
+        ).to.equal(0, "Spectator should have 0 open connections after abort");
+    });
+});

--- a/test/e2e/E2E-StateSnapshots.test.ts
+++ b/test/e2e/E2E-StateSnapshots.test.ts
@@ -1,4 +1,6 @@
 import { TestSession, PeerTestHarness } from "@test/harness";
+import { StateSnapshot } from "@/models";
+import { expect } from "chai";
 
 PeerTestHarness.setDefaultLogLevel("error");
 
@@ -131,5 +133,39 @@ describe("E2E: State Snapshots", function () {
         await h.assert.snapshot.verifyOnChainChannelBalanceInvariant();
         await h.assert.snapshot.snapshotMatchesLocal();
         await h.assert.sync.blockHeight({ expectedHeight: 0 });
+    });
+
+    it.only("should update on-chain snapshot to a new fork genesis after dispute resolution", async function () {
+        const h = TestSession.getHarness();
+
+        await h.lifecycle.start(4, 2);
+
+        await h.byzantine.submitDoubleSignBlock(1);
+        await h.dispute.resolveDisputeWait();
+
+        const honest = [0, 2, 3];
+        await h.event.waitForEventCounts(
+            "onStateSnapshotUpdated",
+            honest.map((peerId) => ({ peerId, expectedCount: 1 })),
+            10000,
+            { mode: "atLeast" }
+        );
+
+        const snapshotAfter = StateSnapshot.from(
+            await h.channelManager.getStateSnapshot(h.channelId)
+        );
+
+        // After updateStateSnapshotFork the on-chain snapshot is the genesis of the
+        // new fork: its forkId must equal keccak256(snapshotData).
+        expect(snapshotAfter.isGenesis).to.be.true,
+            "On-chain snapshot must be a genesis snapshot";
+
+        // Fork ID on-chain must match what honest peers converged on.
+        expect(snapshotAfter.forkID).to.equal(
+            h.activeForkId,
+            "On-chain forkId must match local active fork"
+        );
+
+        await h.assert.snapshot.snapshotMatchesLocal();
     });
 });

--- a/test/harness/actions/assert/AssertSnapshotActions.ts
+++ b/test/harness/actions/assert/AssertSnapshotActions.ts
@@ -125,10 +125,13 @@ export class AssertSnapshotActions {
                 `No local snapshot found at height ${blockHeight} on fork ${forkId}`
             );
         }
+        //  at genesis, onChainSnapshot.blockHeight is 0, but blockHeight is -1
+        //  normalize blockHeight to 0 at genesis
+        const normalizedBlockHeight = Math.max(blockHeight, 0);
 
-        if (onChainSnapshot.blockHeight !== blockHeight) {
+        if (onChainSnapshot.blockHeight !== normalizedBlockHeight) {
             throw new Error(
-                `Expected on-chain snapshot height ${blockHeight}, but found ${onChainSnapshot.blockHeight}`
+                `Expected on-chain snapshot height ${normalizedBlockHeight}, but found ${onChainSnapshot.blockHeight}`
             );
         }
 


### PR DESCRIPTION

## 📋 Description

in PR #308 i flipped the order, which made 
- "Spectators before and after dispute" PASS
-  "join/leave sequence and fork resolution" FAIL

in this PR,:
- introduce `orderOutboundSnapshots` to select the order
- add guard to abort sync  if  on-chain snapshot is on the same fork but more advanced

- add test to assert that





