### PR TITLE
very minor touch ups to Dispute manager tests

### DIFF
--- a/src/disputeManager/DisputeManager.ts
+++ b/src/disputeManager/DisputeManager.ts
@@ -162,14 +162,21 @@ class DisputeManager {
             );
             await txResponse.wait();
         } catch (error) {
-            const success = tryHandleEvmError(error, {
+            const success = await tryHandleEvmError(error, {
                 tx: txResponse,
                 logger: this.logger,
                 forkId,
                 signer: this.signer,
                 handlers: {
                     ErrorCantParticipateInDispute: () => {
-                        // No op -> malcious peer
+                        this.logger.info(
+                            "Dispute upload reverted: ErrorCantParticipateInDispute",
+                            {
+                                forkId: LoggerUtils.formatHash(forkId),
+                                signerAddress: this.signerAddress,
+                                channelId: this.channelId
+                            }
+                        );
                     }
                 }
             });
@@ -180,7 +187,7 @@ class DisputeManager {
                     signerAddress: this.signerAddress,
                     error:
                         error instanceof Error ? error.message : String(error),
-                    customErrorHandles: success
+                    evmErrorHandled: success
                 });
 
             this.storage.disputes.storeDisputedFork(forkId, false);

--- a/src/disputeManager/DisputeManager.ts
+++ b/src/disputeManager/DisputeManager.ts
@@ -173,8 +173,16 @@ class DisputeManager {
                             "Dispute upload reverted: ErrorCantParticipateInDispute",
                             {
                                 forkId: LoggerUtils.formatHash(forkId),
-                                signerAddress: this.signerAddress,
-                                channelId: this.channelId
+                                signerAddress: this.signerAddress
+                            }
+                        );
+                    },
+                    RaceConditionDisputeEvidencePeriodExpired: () => {
+                        this.logger.info(
+                            "Dispute upload reverted: RaceConditionDisputeEvidencePeriodExpired",
+                            {
+                                forkId: LoggerUtils.formatHash(forkId),
+                                signerAddress: this.signerAddress
                             }
                         );
                     }

--- a/src/eventHandlers/EventHandler.ts
+++ b/src/eventHandlers/EventHandler.ts
@@ -662,36 +662,46 @@ export class EventHandler {
         reducedForkId: ForkId,
         _reductionTimestamp: Timestamp
     ): Promise<void> {
-        // enough for now - this will change later
-        if (this.stateManager.forkId == forkId) {
-            // Get the latest state snapshot - it should be reduced locally if not we'll reduce it on the spot
-            const latestStateSnapshot =
-                this.storage.stateSnapshots.getGenesisSnapshotByForkId(
-                    reducedForkId
-                );
-            if (!latestStateSnapshot) {
-                // TODO reduce localy
-                return;
-            }
-            const genesisStateMachineState =
-                this.storage.stateMachineStates.getStateMachineState(
-                    latestStateSnapshot.stateMachineStateHash
-                );
-
-            if (!genesisStateMachineState) {
-                // we need to compute it - should have computed it above while reducing
-                // TODO - solidity code that returns the encodedState
-            }
-            // Set fork and start building on it
-            // TODO
-            throw new Error(
-                "Not implemented yet - set fork for reduceCommitment"
-            );
-            // await this.stateManager.setGenesisState(
-            //     genesisStateMachineState!,
-            //     reducedForkId,
-            //     reductionTimestamp
-            // );
+        if (this.stateManager.forkId !== forkId) {
+            return;
         }
+
+        const latestStateSnapshot =
+            this.storage.stateSnapshots.getGenesisSnapshotByForkId(
+                reducedForkId
+            );
+
+        if (!latestStateSnapshot) {
+            // We haven't reduced locally yet. The local diamond still has the dispute
+            // window data at this point — onChannelStorageCleared fires after
+            // onDisputeReducedResultCommitted in the same block, so we can still read
+            // commitments and run reduce.staticCall against the local EVM.
+            const channelId = this.stateManager.channelId;
+            const { killPeriodEnd } =
+                await this.diamondStateMachine.localDiamondContract.isKillPeriodExpired(
+                    channelId,
+                    forkId
+                );
+            const genesisTimestamp =
+                Number(killPeriodEnd) +
+                this.stateManager.timeConfig.evidenceTime;
+
+            this.logger.info(
+                `setForkIfLatestAndCurrent: reducing locally for fork ${forkId} → ${reducedForkId}`,
+                { genesisTimestamp }
+            );
+            await this.stateManager.performReduction(
+                forkId,
+                genesisTimestamp,
+                this.diamondStateMachine.localDiamondContract
+            );
+            return;
+        }
+
+        // Genesis snapshot already in storage (we reduced before the event fired).
+        // setGenesisState was already called by performReduction — nothing left to do.
+        this.logger.debug(
+            `setForkIfLatestAndCurrent: genesis snapshot already present for ${reducedForkId}`
+        );
     }
 }

--- a/src/eventHandlers/EventHandler.ts
+++ b/src/eventHandlers/EventHandler.ts
@@ -439,6 +439,33 @@ export class EventHandler {
         reductionTimestamp: Timestamp,
         reducer: Address
     ): Promise<void> {
+        const isRelevant = this.stateManager.forkId === forkId;
+
+        // Capture dispute window from local diamond BEFORE syncing it.
+        // localDiamondContract.onDisputeReducedResultCommitted clears the window,
+        // so we must read commitments first if we may need to run a local reduction.
+        let cachedDisputes: DisputeStruct[] | undefined;
+        if (
+            isRelevant &&
+            !this.storage.stateSnapshots.getGenesisSnapshotByForkId(
+                reducedForkId
+            )
+        ) {
+            try {
+                cachedDisputes =
+                    await this.stateManager.agreementManager.getForkDisputes(
+                        channelId,
+                        forkId,
+                        this.diamondStateMachine.localDiamondContract
+                    );
+            } catch (e) {
+                this.logger.warn(
+                    "onDisputeReducedResultCommitted: could not pre-cache disputes; local reduction will fall back to empty-window handling",
+                    { error: e instanceof Error ? e.message : String(e) }
+                );
+            }
+        }
+
         // sync LocalDiamond state
         await this.diamondStateMachine.localDiamondContract.onDisputeReducedResultCommitted(
             channelId,
@@ -448,8 +475,6 @@ export class EventHandler {
             reducer
         );
 
-        // if it's not part of the fork choice rule, ignore it - it's spam
-        const isRelevant = this.stateManager.forkId === forkId;
         if (!isRelevant) {
             return;
         }
@@ -465,7 +490,8 @@ export class EventHandler {
             await this.setForkIfLatestAndCurrent(
                 forkId,
                 reducedForkId,
-                reductionTimestamp
+                reductionTimestamp,
+                cachedDisputes
             );
             return;
         }
@@ -490,7 +516,8 @@ export class EventHandler {
         await this.setForkIfLatestAndCurrent(
             forkId,
             reducedForkId,
-            reductionTimestamp
+            reductionTimestamp,
+            cachedDisputes
         );
     }
 
@@ -660,7 +687,8 @@ export class EventHandler {
     private async setForkIfLatestAndCurrent(
         forkId: ForkId,
         reducedForkId: ForkId,
-        _reductionTimestamp: Timestamp
+        _reductionTimestamp: Timestamp,
+        cachedDisputes?: DisputeStruct[]
     ): Promise<void> {
         if (this.stateManager.forkId !== forkId) {
             return;
@@ -672,10 +700,6 @@ export class EventHandler {
             );
 
         if (!latestStateSnapshot) {
-            // We haven't reduced locally yet. The local diamond still has the dispute
-            // window data at this point — onChannelStorageCleared fires after
-            // onDisputeReducedResultCommitted in the same block, so we can still read
-            // commitments and run reduce.staticCall against the local EVM.
             const channelId = this.stateManager.channelId;
             const { killPeriodEnd } =
                 await this.diamondStateMachine.localDiamondContract.isKillPeriodExpired(
@@ -693,7 +717,7 @@ export class EventHandler {
             await this.stateManager.performReduction(
                 forkId,
                 genesisTimestamp,
-                this.diamondStateMachine.localDiamondContract
+                cachedDisputes
             );
             return;
         }

--- a/src/eventHandlers/EventHandler.ts
+++ b/src/eventHandlers/EventHandler.ts
@@ -717,7 +717,8 @@ export class EventHandler {
             await this.stateManager.performReduction(
                 forkId,
                 genesisTimestamp,
-                cachedDisputes
+                cachedDisputes,
+                true // skip on-chain submission — another peer already committed this reduction
             );
             return;
         }

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -468,7 +468,8 @@ class StateManager {
     public async performReduction(
         forkId: ForkId,
         genesisTimestamp: Timestamp,
-        cachedDisputes?: DisputeStruct[]
+        cachedDisputes?: DisputeStruct[],
+        skipOnChainSubmission?: boolean
     ) {
         const now = Clock.getTimeInSeconds();
         this.logger.info(
@@ -547,75 +548,87 @@ class StateManager {
                 ]
             );
 
-        this.logger.info("Reduction transaction submit", {
-            reducedForkId: expectedReducedForkId,
-            channelId: this.channelId
-        });
+        if (skipOnChainSubmission) {
+            this.logger.debug(
+                `Skipping on-chain submission for fork ${LoggerUtils.formatHash(forkId)} — reduction already committed by another peer`
+            );
+        } else {
+            this.logger.info("Reduction transaction submit", {
+                reducedForkId: expectedReducedForkId,
+                channelId: this.channelId
+            });
+        }
 
         let txResponse: TransactionResponse;
-        this.logger.debug(
-            `Submitting reduction transaction for fork ${LoggerUtils.formatHash(forkId)}`,
-            {
-                disputes: disputes.map((d) =>
-                    LoggerUtils.getDisputeMetadata(d)
-                ),
-                reduceData: {
-                    latestStateSnapshot: LoggerUtils.getSnapshotMetadata(
-                        StateSnapshot.from(reduceData.latestStateSnapshot)
+        if (!skipOnChainSubmission) {
+            this.logger.debug(
+                `Submitting reduction transaction for fork ${LoggerUtils.formatHash(forkId)}`,
+                {
+                    disputes: disputes.map((d) =>
+                        LoggerUtils.getDisputeMetadata(d)
                     ),
-                    encodedStateMachineState:
-                        reduceData.encodedStateMachineState,
-                    inboundMessageBlocks: reduceData.inboundMessageBlocks.map(
-                        (b) => LoggerUtils.getMessageBlockMetadata(b)
-                    )
+                    reduceData: {
+                        latestStateSnapshot: LoggerUtils.getSnapshotMetadata(
+                            StateSnapshot.from(reduceData.latestStateSnapshot)
+                        ),
+                        encodedStateMachineState:
+                            reduceData.encodedStateMachineState,
+                        inboundMessageBlocks:
+                            reduceData.inboundMessageBlocks.map((b) =>
+                                LoggerUtils.getMessageBlockMetadata(b)
+                            )
+                    }
                 }
-            }
-        );
+            );
 
-        const txResponsePromise = this.stateChannelManagerContract
-            .multicall([reduceCalldata, forkCalldata], { gasLimit: 10_000_000 })
-            .then((tx: TransactionResponse) => {
-                txResponse = tx;
-                const txReceiptPromise = tx.wait();
-                DetachedPromises.collect(txReceiptPromise);
-                return txReceiptPromise;
-            })
-            .then(() => {
-                this.logger.info(
-                    `Reduction complete (on-chain): transitioning from fork ${LoggerUtils.formatHash(forkId)}`
-                );
-            })
-            .catch(async (error: any) => {
-                const success = await tryHandleEvmError(error, {
-                    tx: txResponse!,
-                    forkId,
-                    logger: this.logger,
-                    handlers: {
-                        RaceConditionDisputeAlreadyReduced: () => {
-                            this.logger.debug(
-                                `Reduction already completed by another peer for fork ${LoggerUtils.formatHash(forkId)} - RaceConditionDisputeAlreadyReduced`
-                            );
+            const txResponsePromise = this.stateChannelManagerContract
+                .multicall([reduceCalldata, forkCalldata], {
+                    gasLimit: 10_000_000
+                })
+                .then((tx: TransactionResponse) => {
+                    txResponse = tx;
+                    const txReceiptPromise = tx.wait();
+                    DetachedPromises.collect(txReceiptPromise);
+                    return txReceiptPromise;
+                })
+                .then(() => {
+                    this.logger.info(
+                        `Reduction complete (on-chain): transitioning from fork ${LoggerUtils.formatHash(forkId)}`
+                    );
+                })
+                .catch(async (error: any) => {
+                    const success = await tryHandleEvmError(error, {
+                        tx: txResponse!,
+                        forkId,
+                        logger: this.logger,
+                        handlers: {
+                            RaceConditionDisputeAlreadyReduced: () => {
+                                this.logger.debug(
+                                    `Reduction already completed by another peer for fork ${LoggerUtils.formatHash(forkId)} - RaceConditionDisputeAlreadyReduced`
+                                );
+                            },
+                            RaceConditionReductionExpectationDoesntMatch:
+                                () => {
+                                    this.logger.error(
+                                        `Reduction expectation mismatch for fork ${LoggerUtils.formatHash(forkId)} -> expected ${LoggerUtils.formatHash(expectedReducedForkId)}`
+                                    );
+                                },
+                            RaceConditionBlockHeightTooOld: () => {
+                                this.logger.error(
+                                    `Update of on-chain snapshot already completed by another peer for fork ${LoggerUtils.formatHash(forkId)} - RaceConditionBlockHeightTooOld`
+                                );
+                            },
+                            ErrorCantParticipateInDispute: () => {
+                                // TODO -> ignore -> malicious peer
+                            }
                         },
-                        RaceConditionReductionExpectationDoesntMatch: () => {
-                            this.logger.error(
-                                `Reduction expectation mismatch for fork ${LoggerUtils.formatHash(forkId)} -> expected ${LoggerUtils.formatHash(expectedReducedForkId)}`
-                            );
-                        },
-                        RaceConditionBlockHeightTooOld: () => {
-                            this.logger.error(
-                                `Update of on-chain snapshot already completed by another peer for fork ${LoggerUtils.formatHash(forkId)} - RaceConditionBlockHeightTooOld`
-                            );
-                        },
-                        ErrorCantParticipateInDispute: () => {
-                            // TODO -> ignore -> malicious peer
-                        }
-                    },
-                    signer: this.signer
+                        signer: this.signer
+                    });
+
+                    if (!success) throw error;
                 });
-
-                if (!success) throw error;
-            });
-        DetachedPromises.collect(txResponsePromise);
+            DetachedPromises.collect(txResponsePromise);
+        }
 
         try {
             // Compute local state after reduction (optimistic - assume tx will succeed)

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -598,6 +598,11 @@ class StateManager {
                                 `Reduction expectation mismatch for fork ${LoggerUtils.formatHash(forkId)} -> expected ${LoggerUtils.formatHash(expectedReducedForkId)}`
                             );
                         },
+                        RaceConditionBlockHeightTooOld: () => {
+                            this.logger.error(
+                                `Update of on-chain snapshot already completed by another peer for fork ${LoggerUtils.formatHash(forkId)} - RaceConditionBlockHeightTooOld`
+                            );
+                        },
                         ErrorCantParticipateInDispute: () => {
                             // TODO -> ignore -> malicious peer
                         }

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -361,7 +361,7 @@ class StateManager {
         const handle = this.timeoutManager.scheduleTask(
             () => {
                 // Don't call reductionTriggerMap.delete(forkId) - race condition problem
-                this.tryReduce(forkId);
+                return this.tryReduce(forkId);
             },
             Math.max(0, (localTriggerTimestamp - now) * 1000),
             `reduction-${forkId}`
@@ -465,9 +465,11 @@ class StateManager {
         await this.performReduction(forkId, genesisTimestamp);
     }
 
-    private async performReduction(
+    public async performReduction(
         forkId: ForkId,
-        genesisTimestamp: Timestamp
+        genesisTimestamp: Timestamp,
+        diamondContract: StateChannelManagerProxy = this
+            .stateChannelManagerContract
     ) {
         const now = Clock.getTimeInSeconds();
         this.logger.info(
@@ -476,7 +478,7 @@ class StateManager {
         const disputes = await this.agreementManager.getForkDisputes(
             this.channelId,
             forkId,
-            this.stateChannelManagerContract
+            diamondContract
         );
 
         this.logger.debug(
@@ -485,8 +487,7 @@ class StateManager {
                 disputes: disputes.map((d) => LoggerUtils.getDisputeMetadata(d))
             }
         );
-        const reducedOutput =
-            await this.stateChannelManagerContract.reduce.staticCall(disputes);
+        const reducedOutput = await diamondContract.reduce.staticCall(disputes);
 
         const reduceData = await this.agreementManager.getReduceData(
             forkId,

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -468,18 +468,19 @@ class StateManager {
     public async performReduction(
         forkId: ForkId,
         genesisTimestamp: Timestamp,
-        diamondContract: StateChannelManagerProxy = this
-            .stateChannelManagerContract
+        cachedDisputes?: DisputeStruct[]
     ) {
         const now = Clock.getTimeInSeconds();
         this.logger.info(
             `Performing reduction for fork ${forkId} with genesis timestamp ${genesisTimestamp}, in (${genesisTimestamp - now}s)`
         );
-        const disputes = await this.agreementManager.getForkDisputes(
-            this.channelId,
-            forkId,
-            diamondContract
-        );
+        const disputes =
+            cachedDisputes ??
+            (await this.agreementManager.getForkDisputes(
+                this.channelId,
+                forkId,
+                this.stateChannelManagerContract
+            ));
 
         this.logger.debug(
             `Performing reduction on disputes for fork ${LoggerUtils.formatHash(forkId)}`,
@@ -487,7 +488,8 @@ class StateManager {
                 disputes: disputes.map((d) => LoggerUtils.getDisputeMetadata(d))
             }
         );
-        const reducedOutput = await diamondContract.reduce.staticCall(disputes);
+        const reducedOutput =
+            await this.stateChannelManagerContract.reduce.staticCall(disputes);
 
         const reduceData = await this.agreementManager.getReduceData(
             forkId,
@@ -1464,21 +1466,22 @@ class StateManager {
                     DetachedPromises.collect(txReceiptPromise);
                     return txReceiptPromise;
                 })
-                .catch((error) => {
-                    const custom = tryHandleEvmError(error, {
+                .catch(async (error) => {
+                    const success = await tryHandleEvmError(error, {
                         tx: transactionResponse!,
                         logger: this.logger,
                         signer: this.signer,
                         forkId
                     });
-                    this.logger.error("Error posting state snapshot", {
-                        error:
-                            error instanceof Error
-                                ? error.message
-                                : String(error)
-                    });
-
-                    throw error;
+                    if (!success) {
+                        this.logger.error("Error posting state snapshot", {
+                            error:
+                                error instanceof Error
+                                    ? error.message
+                                    : String(error)
+                        });
+                        throw error;
+                    }
                 });
             DetachedPromises.collect(txResponsePromise);
             return expectedSnapshot;

--- a/test/e2e/E2E-DisputeManager.test.ts
+++ b/test/e2e/E2E-DisputeManager.test.ts
@@ -19,7 +19,7 @@ describe("E2E: Dispute Manager", function () {
     describe("Dispute Resolution and Fork Management", function () {
         it("should reduce invalid state transition disputes and create new fork", async function () {
             const h = TestSession.getHarness();
-            await h.scenario.preDisputeSetup(4);
+            await h.scenario.preDisputeSetup({ peerCount: 4 });
             const nextPeer = await h.query.getNextPeerToWrite();
             await h.byzantine.submitInvalidStateTransitionBlock(nextPeer.index);
             await h.assert.dispute.initiatedAndCommitedWait();
@@ -28,14 +28,10 @@ describe("E2E: Dispute Manager", function () {
 
         it("should post updated state snapshot after fork resolution", async function () {
             const h = TestSession.getHarness();
-            await h.scenario.fourPeersDisputeResolutionAndSnapshotUpdateDetached();
-
-            await h.transition.fromHonestPeersOnly((c) => c.add(1));
-            await h.transition.fromHonestPeersOnly((c) => c.leaveChannel());
-            await h.transition.fromHonestPeersOnly((c) => c.add(3));
+            await h.scenario.fourPeersDisputeResolutionAndSnapshotUpdateWait();
 
             await h.assert.sync.onlyHonestPeersInSync();
-            await await h.assert.sync.onChainSnapshotAndPeersSameForkWait(); // await this to be sure that the post snapshot event bellow is not triggered by the detached update from above
+            await h.transition.fromHonestPeersOnly((c) => c.add(1));
             h.event.resetEventSpies();
             const expectedSnapshot2 = await h.transition.postSnapshot({
                 peerIndex: 0
@@ -51,8 +47,9 @@ describe("E2E: Dispute Manager", function () {
     describe("Fraud Proof Detection", function () {
         it("should kill a spam dispute with no legitimate enforcement basis", async function () {
             const h = TestSession.getHarness();
-            await h.scenario.preDisputeSetup();
-            h.contextApi.markMaliciousPeer({ maliciousPeerIndex: 1 });
+            await h.scenario.preDisputeSetup({
+                timeConfig: { evidenceTime: 6 }
+            });
 
             // Post a dispute from peer 1 that is internally valid but has no legitimate
             // enforcement basis: no timeout, no on-chain slashes, no self-removal.
@@ -77,7 +74,9 @@ describe("E2E: Dispute Manager", function () {
 
         it("a dispute submitted with no calldata should not be killed even if the auditing data hash is tampered", async function () {
             const h = TestSession.getHarness();
-            await h.scenario.preDisputeSetup();
+            await h.scenario.preDisputeSetup({
+                timeConfig: { evidenceTime: 6 }
+            });
 
             h.tamper.stubConstructDispute(
                 0,
@@ -140,7 +139,7 @@ describe("E2E: Dispute Manager", function () {
 
         it("should reject dispute when full auditing data reconstructed but both commitment and state proof are invalid", async function () {
             const h = TestSession.getHarness();
-            await h.scenario.preDisputeSetup(3, {
+            await h.scenario.preDisputeSetup({
                 timeConfig: { evidenceTime: 6 }
             });
             await h.byzantine.tamperedDisputeDoubleFault(1);

--- a/test/e2e/E2E-DisputeManager.test.ts
+++ b/test/e2e/E2E-DisputeManager.test.ts
@@ -72,7 +72,7 @@ describe("E2E: Dispute Manager", function () {
                     DisputeFraudProofType.InvalidDisputeReason
             });
 
-            await h.dispute.resolveDisputeWait();
+            await h.dispute.resolveDisputeWait({ forkSettleTimeoutMs: 15000 });
         });
 
         it("a dispute submitted with no calldata should not be killed even if the auditing data hash is tampered", async function () {
@@ -135,20 +135,20 @@ describe("E2E: Dispute Manager", function () {
                 mode: "atLeast"
             });
             await h.assert.storage.honestPeersStoredDisputeFraudProofDetached();
-            await h.dispute.resolveDisputeWait();
-            await h.assert.sync.forkChangedWait();
+            await h.dispute.resolveDisputeWait({ forkSettleTimeoutMs: 15000 });
         });
 
         it("should reject dispute when full auditing data reconstructed but both commitment and state proof are invalid", async function () {
             const h = TestSession.getHarness();
-            await h.scenario.preDisputeSetup();
+            await h.scenario.preDisputeSetup(3, {
+                timeConfig: { evidenceTime: 6 }
+            });
             await h.byzantine.tamperedDisputeDoubleFault(1);
             await h.event.waitForAllPeers("onDisputeKilled", 1, {
                 mode: "atLeast"
             });
             await h.assert.storage.honestPeersStoredDisputeFraudProofDetached();
-            await h.dispute.resolveDisputeWait();
-            await h.assert.sync.forkChangedWait();
+            await h.dispute.resolveDisputeWait({ forkSettleTimeoutMs: 20000 });
         });
     });
 

--- a/test/e2e/E2E-DisputeValidationPipeline.test.ts
+++ b/test/e2e/E2E-DisputeValidationPipeline.test.ts
@@ -152,8 +152,10 @@ describe("E2E: Dispute Validation Pipeline", function () {
             const h = TestSession.getHarness();
             await h.scenario.preDisputeSetupCalldataPath();
 
-
-            h.tamper.stubConstructDispute(3, DisputeTampering.tamperInvalidStateProof);
+            h.tamper.stubConstructDispute(
+                3,
+                DisputeTampering.tamperInvalidStateProof
+            );
 
             await h.byzantine.submitDoubleSignBlock(0);
 
@@ -360,7 +362,8 @@ describe("E2E: Dispute Validation Pipeline", function () {
         describe("milestone blockConfirmations path", function () {
             it("should kill dispute when a milestone's last confirmation encodes an inconsistent block (re-dispute / wrong txn count)", async function () {
                 const h = TestSession.getHarness();
-                await h.scenario.preDisputeSetup(4, {
+                await h.scenario.preDisputeSetup({
+                    peerCount: 4,
                     timeConfig: { evidenceTime: 6 }
                 });
                 await h.byzantine.disconnect(3);
@@ -595,7 +598,7 @@ describe("E2E: Dispute Validation Pipeline", function () {
             });
 
             // Post the dispute immediately
-            await h.tamper.postTamperedDispute(0, () => { });
+            await h.tamper.postTamperedDispute(0, () => {});
 
             await h.event.waitForPeers("onDisputeKilled", [1], 1, {
                 mode: "atLeast"

--- a/test/e2e/E2E-FraudProofsBlockConfirmation.test.ts
+++ b/test/e2e/E2E-FraudProofsBlockConfirmation.test.ts
@@ -7,8 +7,8 @@ PeerTestHarness.setDefaultLogLevel("debug");
  * E2E Tests: Fraud Proofs — onBlockConfirmation (BlockValidationStrategy)
  */
 
-describe("E2E: Fraud Proofs - onBlockConfirmation pipeline — dispute-creating fraud proofs", function () {
-    it("onBlockConfirmation pipeline: doubleSignDetected creates dispute with BlockDoubleSign", async function () {
+describe("E2E: Fraud Proofs - onBlockConfirmation pipeline", function () {
+    it("doubleSignDetected creates dispute with BlockDoubleSign", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(3, 2);
         const maliciousPeerIndex = 1;
@@ -24,7 +24,7 @@ describe("E2E: Fraud Proofs - onBlockConfirmation pipeline — dispute-creating 
         await h.assert.sync.onlyHonestPeersInSync();
     });
 
-    it("onBlockConfirmation pipeline: wrongGenesisDetected creates dispute with WrongGenesis", async function () {
+    it("wrongGenesisDetected creates dispute with WrongGenesis", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(3, 2);
 
@@ -42,7 +42,7 @@ describe("E2E: Fraud Proofs - onBlockConfirmation pipeline — dispute-creating 
         await h.assert.sync.onlyHonestPeersInSync();
     });
 
-    it("onBlockConfirmation pipeline: invalidStateTransitionDetected (unexpected next leader) creates dispute with BlockInvalidStateTransition", async function () {
+    it("invalidStateTransitionDetected (unexpected next leader) creates dispute with BlockInvalidStateTransition", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(3, 3);
 
@@ -59,7 +59,7 @@ describe("E2E: Fraud Proofs - onBlockConfirmation pipeline — dispute-creating 
         await h.assert.sync.onlyHonestPeersInSync();
     });
 
-    it("onBlockConfirmation pipeline: objectiveInvalidTimestampDetected creates dispute with InvalidTimestamp", async function () {
+    it("objectiveInvalidTimestampDetected creates dispute with InvalidTimestamp", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(3, 2);
 
@@ -78,7 +78,7 @@ describe("E2E: Fraud Proofs - onBlockConfirmation pipeline — dispute-creating 
         await h.assert.sync.onlyHonestPeersInSync();
     });
 
-    it("onBlockConfirmation pipeline: findBrokenInboundMessageChainBlock creates dispute with BlockInvalidStateTransition", async function () {
+    it("findBrokenInboundMessageChainBlock creates dispute with BlockInvalidStateTransition", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(3, 2);
 
@@ -99,7 +99,7 @@ describe("E2E: Fraud Proofs - onBlockConfirmation pipeline — dispute-creating 
         await h.assert.sync.onlyHonestPeersInSync();
     });
 
-    it("onBlockConfirmation pipeline: forgedInboundMessageBlockDetected creates dispute with ForgedInboundMessageBlock", async function () {
+    it("forgedInboundMessageBlockDetected creates dispute with ForgedInboundMessageBlock", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(3, 2);
 
@@ -120,7 +120,7 @@ describe("E2E: Fraud Proofs - onBlockConfirmation pipeline — dispute-creating 
         await h.assert.sync.onlyHonestPeersInSync();
     });
 
-    it("onBlockConfirmation pipeline: applyTransaction failure creates dispute with BlockInvalidStateTransition", async function () {
+    it("applyTransaction failure creates dispute with BlockInvalidStateTransition", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(3, 2);
 
@@ -140,7 +140,7 @@ describe("E2E: Fraud Proofs - onBlockConfirmation pipeline — dispute-creating 
         await h.assert.sync.onlyHonestPeersInSync();
     });
 
-    it("onBlockConfirmation pipeline: stateSnapshotHash mismatch creates dispute with BlockInvalidStateTransition", async function () {
+    it("stateSnapshotHash mismatch creates dispute with BlockInvalidStateTransition", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(3, 2);
 

--- a/test/e2e/E2E-FraudProofsBlockConfirmation.test.ts
+++ b/test/e2e/E2E-FraudProofsBlockConfirmation.test.ts
@@ -7,7 +7,7 @@ PeerTestHarness.setDefaultLogLevel("debug");
  * E2E Tests: Fraud Proofs — onBlockConfirmation (BlockValidationStrategy)
  */
 
-describe("E2E: Fraud Proofs - onBlockConfirmation pipeline", function () {
+describe("E2E: Fraud Proofs", function () {
     it("doubleSignDetected creates dispute with BlockDoubleSign", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(3, 2);

--- a/test/e2e/E2E-StateSnapshots.test.ts
+++ b/test/e2e/E2E-StateSnapshots.test.ts
@@ -25,11 +25,8 @@ describe("E2E: State Snapshots", function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(3);
 
-        await h.transition.advanceState();
-        await h.transition.advanceState({ txFn: (c) => c.leaveChannel() });
-        await h.transition.advanceState();
+        await h.transition.advanceState({ count: 3 });
 
-        await h.assert.sync.peersInSyncWait();
         h.event.resetEventSpies();
         await h.contextApi.capturePrePostSnapshotContext();
         await h.assert.snapshot.verifyOnChainChannelBalanceInvariant();
@@ -52,7 +49,6 @@ describe("E2E: State Snapshots", function () {
         });
 
         await h.transition.fromHonestPeersOnly((c) => c.add(1));
-        await h.transition.fromHonestPeersOnly((c) => c.leaveChannel());
         await h.transition.fromHonestPeersOnly((c) => c.add(3));
         await h.assert.sync.onlyHonestPeersInSync();
         h.event.resetEventSpies();

--- a/test/harness/actions/ScenarioActions.ts
+++ b/test/harness/actions/ScenarioActions.ts
@@ -16,11 +16,10 @@ export class ScenarioActions {
             chainFallbackTime?: number;
             evidenceTime?: number;
         };
-    }) {
+    }): Promise<CreateAndResolveDisputeResult> {
         await this.harness.lifecycle.start(4, 2, options);
         await this.harness.assert.sync.peersInSyncWait();
-        await this.disputeWithReduction({ maliciousPeerIndex: 2 });
-        await this.harness.assert.sync.forkChangedWait();
+        return this.disputeWithReduction({ maliciousPeerIndex: 2 });
     }
 
     async fourPeersDisputeResolutionAndSnapshotUpdateDetached(options?: {
@@ -31,12 +30,9 @@ export class ScenarioActions {
             evidenceTime?: number;
         };
     }) {
-        await this.fourPeersDisputeResolution(options);
-        const expectedSnapshot = await this.harness.transition.postSnapshot({
-            peerIndex: 0
-        });
-        await this.harness.assert.snapshot.onChainSnapshotChangedDetached({
-            expectedSnapshot
+        const { newForkId } = await this.fourPeersDisputeResolution(options);
+        this.harness.assert.snapshot.onChainSnapshotChangedDetached({
+            expectedForkId: newForkId as string
         });
     }
 
@@ -48,27 +44,26 @@ export class ScenarioActions {
             evidenceTime?: number;
         };
     }) {
-        await this.fourPeersDisputeResolution(options);
-        const expectedSnapshot = await this.harness.transition.postSnapshot({
-            peerIndex: 0
-        });
+        const { newForkId } = await this.fourPeersDisputeResolution(options);
         await this.harness.assert.snapshot.onChainSnapshotChangedWait({
-            expectedSnapshot
+            expectedForkId: newForkId as string
         });
     }
 
-    async preDisputeSetup(
-        peerCount: number = 3,
-        options?: {
-            timeConfig?: {
-                p2pTime?: number;
-                agreementTime?: number;
-                chainFallbackTime?: number;
-                evidenceTime?: number;
-            };
-        }
-    ) {
-        await this.harness.lifecycle.timeoutSetup(peerCount, 2, options);
+    async preDisputeSetup(options?: {
+        peerCount?: number;
+        timeConfig?: {
+            p2pTime?: number;
+            agreementTime?: number;
+            chainFallbackTime?: number;
+            evidenceTime?: number;
+        };
+    }) {
+        await this.harness.lifecycle.timeoutSetup(
+            options?.peerCount ?? 3,
+            2,
+            options
+        );
         await this.harness.assert.sync.peersInSyncWait();
         this.harness.event.resetEventSpies();
         this.harness.contextApi.captureOriginalFork();
@@ -89,7 +84,7 @@ export class ScenarioActions {
             ...options?.timeConfig
         };
 
-        await this.preDisputeSetup(4, { timeConfig, ...options });
+        await this.preDisputeSetup({ peerCount: 4, timeConfig });
         await this.harness.transition.participantLeaveDetached();
         await this.harness.transition.advanceState({
             waitForPeers: [0, 1, 3],

--- a/test/harness/actions/assert/AssertSnapshotActions.ts
+++ b/test/harness/actions/assert/AssertSnapshotActions.ts
@@ -1,4 +1,5 @@
 import { StateSnapshot } from "@/models";
+import { ForkId } from "@/types";
 import { DetachedPromises } from "@/utils";
 import { LoggerUtils } from "@/utils/LoggerUtils";
 import { PeerTestHarness } from "@test/fixtures/PeerTestHarness";
@@ -28,12 +29,14 @@ export class AssertSnapshotActions {
         }
     }
     async onChainSnapshotChangedWait(options?: {
-        expectedForkId?: string;
+        expectedForkId?: ForkId;
+        previousForkId?: ForkId;
         expectedSnapshot?: StateSnapshot;
         timeoutMs?: number;
     }): Promise<void> {
         const {
             expectedForkId,
+            previousForkId,
             expectedSnapshot,
             timeoutMs = 8000
         } = options || {};
@@ -59,6 +62,8 @@ export class AssertSnapshotActions {
                     localSnapshot.forkID !== expectedForkId
                 )
                     return false;
+                if (previousForkId && localSnapshot.forkID === previousForkId)
+                    return false;
             }
 
             return true; // all honest peers observed a snapshot update event
@@ -69,6 +74,7 @@ export class AssertSnapshotActions {
             timeoutMessage: `On-chain snapshot did not change within ${timeoutMs}ms`,
             timeoutMeta: {
                 expectedForkId,
+                previousForkId,
                 expectedSnapshot: expectedSnapshot
                     ? LoggerUtils.getSnapshotMetadata(expectedSnapshot)
                     : undefined,
@@ -80,11 +86,11 @@ export class AssertSnapshotActions {
         return promise;
     }
 
-    async onChainSnapshotChangedDetached(options?: {
+    onChainSnapshotChangedDetached(options?: {
         expectedForkId?: string;
         expectedSnapshot?: StateSnapshot;
         timeoutMs?: number;
-    }): Promise<void> {
+    }): void {
         const detachedPromise = this.onChainSnapshotChangedWait(options);
         DetachedPromises.collect(detachedPromise);
     }


### PR DESCRIPTION
@lukastanisic99 

some modification to SDK code here, not only tests.

the theme is trying to handle race condition that arise since the dispute reduction update the on chain state snapshot

one yet unresolved test case that triggers a race condition  is

"should kill dispute and store DisputeInvalidStateProof when a milestone has no blockConfirmations"


I am pretty sure the race condition triggers a revert from `site=StateSnapshotFacet.updateStateSnapshotFork`


Error: transaction execution reverted (action="sendTransaction"...



quite likely from StateManager.postStateSnapshot


but I am not sure what is the correct way to fix it


if you have time to look at it, I'd appreciate that.




