### PR TITLE
Thread-partitioned logging: SDK ↔ EVM worker crash-log uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS
+.DS_Store
+
 node_modules
 .vscode
 .env
@@ -38,3 +41,6 @@ src/utils/GeneratedArtifacts.ts
 *.tsbuildinfo
 
 /profiles
+
+# local design specs / plans — never commit (per project convention)
+docs/superpowers/

--- a/src/evm/EvmDiamondStateMachine.ts
+++ b/src/evm/EvmDiamondStateMachine.ts
@@ -27,6 +27,7 @@ import {
     type AContractExecutor,
     type ContractExecutionLog
 } from "./contractExecutor";
+import WorkerContractExecutor from "./contractExecutor/WorkerContractExecutor";
 import { Address, Bytes } from "@/types/types";
 import {
     BalanceStruct,
@@ -377,6 +378,13 @@ class EvmDiamondStateMachine extends ADiamondStateMachine {
             customPrecompiles,
             logger
         });
+
+        // The worker logger is a sibling of this logger; forward context updates
+        // (e.g. channelId, learned only after the channel opens) and report-bug
+        // uploads across the thread boundary.
+        if (contractExecutor instanceof WorkerContractExecutor) {
+            logger.setRemoteSibling(contractExecutor);
+        }
 
         const localSigner = new LocalDiamondSigner(signer, contractExecutor);
 

--- a/src/evm/EvmDiamondStateMachine.ts
+++ b/src/evm/EvmDiamondStateMachine.ts
@@ -379,9 +379,8 @@ class EvmDiamondStateMachine extends ADiamondStateMachine {
             logger
         });
 
-        // The worker logger is a gossip neighbour of this logger: wire the SDK
-        // logger into the worker client's gossip node so flush/context ops fan out
-        // across the thread tree in both directions.
+        // Wire the SDK logger into the worker client's gossip node so flush/context
+        // ops fan out across threads.
         if (contractExecutor instanceof WorkerContractExecutor) {
             contractExecutor.attachLogger(logger);
         }

--- a/src/evm/EvmDiamondStateMachine.ts
+++ b/src/evm/EvmDiamondStateMachine.ts
@@ -458,7 +458,8 @@ class EvmDiamondStateMachine extends ADiamondStateMachine {
             createLogger(
                 {
                     peerId: pid,
-                    peerAddress: signerAddress
+                    peerAddress: signerAddress,
+                    threadName: config.LOG_THREAD_NAME
                 },
                 { component: "ClientApp" },
                 { attachErrorListener: true }

--- a/src/evm/EvmDiamondStateMachine.ts
+++ b/src/evm/EvmDiamondStateMachine.ts
@@ -27,7 +27,6 @@ import {
     type AContractExecutor,
     type ContractExecutionLog
 } from "./contractExecutor";
-import WorkerContractExecutor from "./contractExecutor/WorkerContractExecutor";
 import { Address, Bytes } from "@/types/types";
 import {
     BalanceStruct,
@@ -379,11 +378,7 @@ class EvmDiamondStateMachine extends ADiamondStateMachine {
             logger
         });
 
-        // Wire the SDK logger into the worker client's gossip node so flush/context
-        // ops fan out across threads.
-        if (contractExecutor instanceof WorkerContractExecutor) {
-            contractExecutor.attachLogger(logger);
-        }
+        contractExecutor.attachLogger(logger); // no-op unless it's a worker executor
 
         const localSigner = new LocalDiamondSigner(signer, contractExecutor);
 

--- a/src/evm/EvmDiamondStateMachine.ts
+++ b/src/evm/EvmDiamondStateMachine.ts
@@ -378,8 +378,6 @@ class EvmDiamondStateMachine extends ADiamondStateMachine {
             logger
         });
 
-        contractExecutor.attachLogger(logger); // no-op unless it's a worker executor
-
         const localSigner = new LocalDiamondSigner(signer, contractExecutor);
 
         const stateMachineAddress = await deployStateMachine(localSigner);

--- a/src/evm/EvmDiamondStateMachine.ts
+++ b/src/evm/EvmDiamondStateMachine.ts
@@ -379,11 +379,11 @@ class EvmDiamondStateMachine extends ADiamondStateMachine {
             logger
         });
 
-        // The worker logger is a sibling of this logger; forward context updates
-        // (e.g. channelId, learned only after the channel opens) and report-bug
-        // uploads across the thread boundary.
+        // The worker logger is a gossip neighbour of this logger: wire the SDK
+        // logger into the worker client's gossip node so flush/context ops fan out
+        // across the thread tree in both directions.
         if (contractExecutor instanceof WorkerContractExecutor) {
-            logger.setRemoteSibling(contractExecutor);
+            contractExecutor.attachLogger(logger);
         }
 
         const localSigner = new LocalDiamondSigner(signer, contractExecutor);

--- a/src/evm/P2pSigner.ts
+++ b/src/evm/P2pSigner.ts
@@ -124,6 +124,12 @@ class P2pSigner<TCustomRpc extends MainRpcService = MainRpcService>
         await this.p2pManager.stateManager.setChannelId(channelId);
     }
 
+    // Report-bug entry point: flushes this peer's logs. The logger fans the
+    // upload out to its worker sibling, so both threads' logs are sent.
+    async uploadLogs(message: string = "report-bug"): Promise<void> {
+        await this.logger.uploadLogs(message);
+    }
+
     public setIsLeader(value: boolean) {
         this.isLeader = value;
     }

--- a/src/evm/P2pSigner.ts
+++ b/src/evm/P2pSigner.ts
@@ -124,12 +124,6 @@ class P2pSigner<TCustomRpc extends MainRpcService = MainRpcService>
         await this.p2pManager.stateManager.setChannelId(channelId);
     }
 
-    // Report-bug entry point: flushes this peer's logs. The logger fans the
-    // upload out to its worker sibling, so both threads' logs are sent.
-    async uploadLogs(message: string = "report-bug"): Promise<void> {
-        await this.logger.uploadLogs(message);
-    }
-
     public setIsLeader(value: boolean) {
         this.isLeader = value;
     }

--- a/src/evm/contractExecutor/AContractExecutor.ts
+++ b/src/evm/contractExecutor/AContractExecutor.ts
@@ -1,4 +1,5 @@
 import type { Address, Bytes } from "@/types/types";
+import type { Logger } from "@/utils/logging/Logger";
 
 export type ContractExecutionLog = {
     address: Address;
@@ -24,6 +25,9 @@ abstract class AContractExecutor {
     ): Promise<ContractExecutionResult>;
 
     dispose(): Promise<void> | void {}
+
+    // Wire the SDK logger into a worker executor's gossip node; no-op for the inline one.
+    attachLogger(_logger: Logger): void {}
 }
 
 export default AContractExecutor;

--- a/src/evm/contractExecutor/AContractExecutor.ts
+++ b/src/evm/contractExecutor/AContractExecutor.ts
@@ -1,5 +1,4 @@
 import type { Address, Bytes } from "@/types/types";
-import type { Logger } from "@/utils/logging/Logger";
 
 export type ContractExecutionLog = {
     address: Address;
@@ -25,9 +24,6 @@ abstract class AContractExecutor {
     ): Promise<ContractExecutionResult>;
 
     dispose(): Promise<void> | void {}
-
-    // Wire the SDK logger into a worker executor's gossip node; no-op for the inline one.
-    attachLogger(_logger: Logger): void {}
 }
 
 export default AContractExecutor;

--- a/src/evm/contractExecutor/ContractExecutorFactory.ts
+++ b/src/evm/contractExecutor/ContractExecutorFactory.ts
@@ -33,7 +33,7 @@ export async function createContractExecutorFactory(
         options.customPrecompiles,
         options.logger?.toSerializableConfig({ threadName: "evm" })
     );
-    // Single site that builds the worker, so attach the logger's gossip edge here.
-    if (options.logger) workerExecutor.attachLogger(options.logger);
+    // Single site that builds the worker, so wire the logger to its gossip edge here.
+    options.logger?.setGossipNode(workerExecutor.gossipNode);
     return workerExecutor;
 }

--- a/src/evm/contractExecutor/ContractExecutorFactory.ts
+++ b/src/evm/contractExecutor/ContractExecutorFactory.ts
@@ -29,8 +29,11 @@ export async function createContractExecutorFactory(
 
         return new InlineContractExecutor(evm, logger);
     }
-    return WorkerContractExecutor.create(
+    const workerExecutor = await WorkerContractExecutor.create(
         options.customPrecompiles,
         options.logger?.toSerializableConfig({ threadName: "evm" })
     );
+    // Single site that builds the worker, so attach the logger's gossip edge here.
+    if (options.logger) workerExecutor.attachLogger(options.logger);
+    return workerExecutor;
 }

--- a/src/evm/contractExecutor/ContractExecutorFactory.ts
+++ b/src/evm/contractExecutor/ContractExecutorFactory.ts
@@ -29,5 +29,8 @@ export async function createContractExecutorFactory(
 
         return new InlineContractExecutor(evm, logger);
     }
-    return WorkerContractExecutor.create(options.customPrecompiles);
+    return WorkerContractExecutor.create(
+        options.customPrecompiles,
+        options.logger?.toSerializableConfig({ threadName: "evm" })
+    );
 }

--- a/src/evm/contractExecutor/ContractExecutorWorkerHostCore.ts
+++ b/src/evm/contractExecutor/ContractExecutorWorkerHostCore.ts
@@ -56,7 +56,7 @@ export class ContractExecutorWorkerHost extends AWorkerHost<
               )
             : noOpLogger;
         // Only wire gossip with a real logger; the no-op sink would swallow the ops.
-        if (loggerConfig) this.attachLogger(this.workerLogger);
+        if (loggerConfig) this.workerLogger.setGossipNode(this.gossipNode);
 
         this.evm = await createEvm(
             {

--- a/src/evm/contractExecutor/ContractExecutorWorkerHostCore.ts
+++ b/src/evm/contractExecutor/ContractExecutorWorkerHostCore.ts
@@ -2,6 +2,8 @@ import { Buffer } from "buffer";
 import ContractExecutor from "./ContractExecutor";
 import { createEvm } from "../EvmFactory";
 import noOpLogger from "./NoOpLogger";
+import { createLogger } from "@platform/createLogger";
+import type { Logger, LogLevel } from "@/utils/logging/Logger";
 import type {
     WorkerRequest,
     WorkerRequestPayload,
@@ -20,8 +22,28 @@ workerGlobal.window ||= globalThis;
 
 let evm: Awaited<ReturnType<typeof createEvm>> | undefined;
 let executor: ContractExecutor | undefined;
+let workerLogger: Logger = noOpLogger;
 
 async function init(request: Extract<WorkerRequestPayload, { type: "init" }>) {
+    const loggerConfig = request.loggerConfig;
+    // The worker's own config singleton is DEFAULT_CONFIG (createConfig only
+    // runs on the main thread), so logger config must be injected explicitly.
+    workerLogger = loggerConfig
+        ? createLogger(
+              loggerConfig.sharedContext,
+              { component: "ContractExecutorWorker" },
+              {
+                  logUploaderConfig: {
+                      uploadEndpoint: loggerConfig.uploadEndpoint,
+                      apiToken: loggerConfig.apiToken
+                  },
+                  level: loggerConfig.level as LogLevel | undefined,
+                  skipWriting: loggerConfig.skipWriting,
+                  attachErrorListener: true
+              }
+          )
+        : noOpLogger;
+
     evm = await createEvm(
         {
             allowUnlimitedContractSize: true,
@@ -34,9 +56,9 @@ async function init(request: Extract<WorkerRequestPayload, { type: "init" }>) {
                 })
             )
         },
-        noOpLogger
+        workerLogger
     );
-    executor = new ContractExecutor(evm, noOpLogger);
+    executor = new ContractExecutor(evm, workerLogger);
     return null;
 }
 

--- a/src/evm/contractExecutor/ContractExecutorWorkerHostCore.ts
+++ b/src/evm/contractExecutor/ContractExecutorWorkerHostCore.ts
@@ -63,6 +63,19 @@ async function init(request: Extract<WorkerRequestPayload, { type: "init" }>) {
     return null;
 }
 
+function diagnostics(
+    request: Extract<WorkerRequestPayload, { type: "diagnostics" }>
+): void {
+    if (request.op === "updateContext") {
+        workerLogger.updateSharedContext(request.context);
+    } else {
+        // Fire-and-forget: ack immediately, let the upload run detached.
+        void workerLogger.uploadLogs(
+            request.message ?? "worker report-bug flush"
+        );
+    }
+}
+
 function getExecutor(): ContractExecutor {
     if (!executor) {
         throw new Error("Contract executor worker has not been initialized");
@@ -96,9 +109,8 @@ async function handleRequest(request: WorkerRequest): Promise<WorkerResponse> {
             case "init":
                 result = await init(workerRequestPayload);
                 break;
-            case "uploadLogs":
-                // Fire-and-forget: ack immediately, let the upload run detached.
-                void workerLogger.uploadLogs("worker report-bug flush");
+            case "diagnostics":
+                diagnostics(workerRequestPayload);
                 result = null;
                 break;
             default:

--- a/src/evm/contractExecutor/ContractExecutorWorkerHostCore.ts
+++ b/src/evm/contractExecutor/ContractExecutorWorkerHostCore.ts
@@ -5,145 +5,93 @@ import { createEvm } from "../EvmFactory";
 import noOpLogger from "./NoOpLogger";
 import { createLogger } from "@platform/createLogger";
 import type { Logger, LogLevel } from "@/utils/logging/Logger";
-import type {
-    WorkerRequest,
-    WorkerRequestPayload,
-    WorkerResponse
-} from "./types";
+import { AWorkerHost } from "@/utils/worker/AWorkerHost";
+import type { WorkerRequestPayload } from "./types";
 
 const workerGlobal = globalThis as unknown as {
     Buffer?: typeof Buffer;
     global?: typeof globalThis;
     window?: typeof globalThis;
 };
-
 workerGlobal.Buffer ||= Buffer;
 workerGlobal.global ||= globalThis;
 workerGlobal.window ||= globalThis;
 
-let evm: Awaited<ReturnType<typeof createEvm>> | undefined;
-let executor: ContractExecutor | undefined;
-let workerLogger: Logger = noOpLogger;
+export class ContractExecutorWorkerHost extends AWorkerHost<
+    WorkerRequestPayload,
+    ContractExecutionResult | null
+> {
+    private evm?: Awaited<ReturnType<typeof createEvm>>;
+    private executor?: ContractExecutor;
+    private workerLogger: Logger = noOpLogger;
 
-async function init(request: Extract<WorkerRequestPayload, { type: "init" }>) {
-    const loggerConfig = request.loggerConfig;
-    // The worker's own config singleton is DEFAULT_CONFIG (createConfig only
-    // runs on the main thread), so logger config must be injected explicitly.
-    workerLogger = loggerConfig
-        ? createLogger(
-              loggerConfig.sharedContext,
-              { component: "ContractExecutorWorker" },
-              {
-                  logUploaderConfig: {
-                      uploadEndpoint: loggerConfig.uploadEndpoint,
-                      apiToken: loggerConfig.apiToken
-                  },
-                  level: loggerConfig.level as LogLevel | undefined,
-                  skipWriting: loggerConfig.skipWriting,
-                  attachErrorListener: true
-              }
-          )
-        : noOpLogger;
-
-    evm = await createEvm(
-        {
-            allowUnlimitedContractSize: true,
-            customPrecompiles: request.customPrecompiles.map(
-                ({ address, module, exportName, options }) => ({
-                    address,
-                    module,
-                    exportName,
-                    options
-                })
-            )
-        },
-        workerLogger
-    );
-    executor = new ContractExecutor(evm, workerLogger);
-    return null;
-}
-
-function diagnostics(
-    request: Extract<WorkerRequestPayload, { type: "diagnostics" }>
-): void {
-    if (request.op === "updateContext") {
-        workerLogger.updateSharedContext(request.context);
-    } else {
-        // Fire-and-forget: ack immediately, let the upload run detached.
-        void workerLogger.uploadLogs(
-            request.message ?? "worker report-bug flush"
-        );
-    }
-}
-
-function getExecutor(): ContractExecutor {
-    if (!executor) {
-        throw new Error("Contract executor worker has not been initialized");
-    }
-    return executor;
-}
-
-async function call(request: Extract<WorkerRequestPayload, { type: "call" }>) {
-    const executor = getExecutor();
-    const result =
-        request.method === "deploy"
-            ? await executor.deploy(request.data)
-            : request.method === "executeCall"
-              ? await executor.executeCall(
-                    request.data,
-                    request.contractAddress
-                )
-              : await executor.simulateCall(
-                    request.data,
-                    request.contractAddress
-                );
-
-    return result;
-}
-
-async function handleRequest(request: WorkerRequest): Promise<WorkerResponse> {
-    const { requestId, workerRequestPayload } = request;
-    try {
-        let result: null | ContractExecutionResult;
-        switch (workerRequestPayload.type) {
+    protected async handle(
+        payload: WorkerRequestPayload
+    ): Promise<ContractExecutionResult | null> {
+        switch (payload.type) {
             case "init":
-                result = await init(workerRequestPayload);
-                break;
-            case "diagnostics":
-                diagnostics(workerRequestPayload);
-                result = null;
-                break;
+                return this.init(payload);
             default:
-                result = await call(workerRequestPayload);
+                return this.call(payload);
         }
-
-        return {
-            requestId,
-            ok: true,
-            result
-        };
-    } catch (error) {
-        const err = error instanceof Error ? error : new Error(String(error));
-        return {
-            requestId,
-            ok: false,
-            error: {
-                message: err.message,
-                data: (err as any).data,
-                name: err.name,
-                stack: err.stack
-            }
-        };
     }
-}
 
-export function startContractExecutorWorkerHost(
-    post: (response: WorkerResponse) => void,
-    onMessage: (handler: (message: WorkerRequest) => void) => void
-): void {
-    onMessage((request) => {
-        void handleRequest(request).then(post);
-    });
+    private async init(
+        request: Extract<WorkerRequestPayload, { type: "init" }>
+    ): Promise<null> {
+        const loggerConfig = request.loggerConfig;
+        this.workerLogger = loggerConfig
+            ? createLogger(
+                  loggerConfig.sharedContext,
+                  { component: "ContractExecutorWorker" },
+                  {
+                      logUploaderConfig: {
+                          uploadEndpoint: loggerConfig.uploadEndpoint,
+                          apiToken: loggerConfig.apiToken
+                      },
+                      level: loggerConfig.level as LogLevel | undefined,
+                      skipWriting: loggerConfig.skipWriting,
+                      attachErrorListener: true
+                  }
+              )
+            : noOpLogger;
+        this.attachLogger(this.workerLogger);
 
-    post({ type: "ready" });
+        this.evm = await createEvm(
+            {
+                allowUnlimitedContractSize: true,
+                customPrecompiles: request.customPrecompiles.map(
+                    ({ address, module, exportName, options }) => ({
+                        address,
+                        module,
+                        exportName,
+                        options
+                    })
+                )
+            },
+            this.workerLogger
+        );
+        this.executor = new ContractExecutor(this.evm, this.workerLogger);
+        return null;
+    }
+
+    private getExecutor(): ContractExecutor {
+        if (!this.executor) {
+            throw new Error(
+                "Contract executor worker has not been initialized"
+            );
+        }
+        return this.executor;
+    }
+
+    private async call(
+        request: Extract<WorkerRequestPayload, { type: "call" }>
+    ): Promise<ContractExecutionResult | null> {
+        const executor = this.getExecutor();
+        return request.method === "deploy"
+            ? executor.deploy(request.data)
+            : request.method === "executeCall"
+              ? executor.executeCall(request.data, request.contractAddress)
+              : executor.simulateCall(request.data, request.contractAddress);
+    }
 }

--- a/src/evm/contractExecutor/ContractExecutorWorkerHostCore.ts
+++ b/src/evm/contractExecutor/ContractExecutorWorkerHostCore.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "buffer";
 import ContractExecutor from "./ContractExecutor";
+import type { ContractExecutionResult } from "./AContractExecutor";
 import { createEvm } from "../EvmFactory";
 import noOpLogger from "./NoOpLogger";
 import { createLogger } from "@platform/createLogger";
@@ -90,10 +91,19 @@ async function call(request: Extract<WorkerRequestPayload, { type: "call" }>) {
 async function handleRequest(request: WorkerRequest): Promise<WorkerResponse> {
     const { requestId, workerRequestPayload } = request;
     try {
-        const result =
-            workerRequestPayload.type === "init"
-                ? await init(workerRequestPayload)
-                : await call(workerRequestPayload);
+        let result: null | ContractExecutionResult;
+        switch (workerRequestPayload.type) {
+            case "init":
+                result = await init(workerRequestPayload);
+                break;
+            case "uploadLogs":
+                // Fire-and-forget: ack immediately, let the upload run detached.
+                void workerLogger.uploadLogs("worker report-bug flush");
+                result = null;
+                break;
+            default:
+                result = await call(workerRequestPayload);
+        }
 
         return {
             requestId,

--- a/src/evm/contractExecutor/ContractExecutorWorkerHostCore.ts
+++ b/src/evm/contractExecutor/ContractExecutorWorkerHostCore.ts
@@ -55,7 +55,9 @@ export class ContractExecutorWorkerHost extends AWorkerHost<
                   }
               )
             : noOpLogger;
-        this.attachLogger(this.workerLogger);
+        // Only wire gossip when there's a real logger; the no-op sink would just
+        // route flush/context ops into a black hole.
+        if (loggerConfig) this.attachLogger(this.workerLogger);
 
         this.evm = await createEvm(
             {

--- a/src/evm/contractExecutor/ContractExecutorWorkerHostCore.ts
+++ b/src/evm/contractExecutor/ContractExecutorWorkerHostCore.ts
@@ -55,8 +55,7 @@ export class ContractExecutorWorkerHost extends AWorkerHost<
                   }
               )
             : noOpLogger;
-        // Only wire gossip when there's a real logger; the no-op sink would just
-        // route flush/context ops into a black hole.
+        // Only wire gossip with a real logger; the no-op sink would swallow the ops.
         if (loggerConfig) this.attachLogger(this.workerLogger);
 
         this.evm = await createEvm(

--- a/src/evm/contractExecutor/NoOpLogger.ts
+++ b/src/evm/contractExecutor/NoOpLogger.ts
@@ -8,7 +8,9 @@ const noOpLogger = {
     warn: noop,
     info: noop,
     error: noop,
-    verbose: noop
+    verbose: noop,
+    updateSharedContext: noop,
+    uploadLogs: noop
 } as unknown as Logger;
 
 export default noOpLogger;

--- a/src/evm/contractExecutor/NoOpLogger.ts
+++ b/src/evm/contractExecutor/NoOpLogger.ts
@@ -10,7 +10,9 @@ const noOpLogger = {
     error: noop,
     verbose: noop,
     updateSharedContext: noop,
-    uploadLogs: noop
+    uploadLogs: noop,
+    applyOp: noop,
+    setGossipNode: noop
 } as unknown as Logger;
 
 export default noOpLogger;

--- a/src/evm/contractExecutor/NoOpLogger.ts
+++ b/src/evm/contractExecutor/NoOpLogger.ts
@@ -8,11 +8,7 @@ const noOpLogger = {
     warn: noop,
     info: noop,
     error: noop,
-    verbose: noop,
-    updateSharedContext: noop,
-    uploadLogs: noop,
-    applyOp: noop,
-    setGossipNode: noop
+    verbose: noop
 } as unknown as Logger;
 
 export default noOpLogger;

--- a/src/evm/contractExecutor/WorkerContractExecutor.ts
+++ b/src/evm/contractExecutor/WorkerContractExecutor.ts
@@ -50,7 +50,6 @@ export default class WorkerContractExecutor extends AContractExecutor {
         this.client = new WorkerClient(createContractExecutorTransport());
     }
 
-    // Wire the SDK logger's gossip into the worker client (composition root).
     attachLogger(logger: Logger): void {
         this.client.attachLogger(logger);
     }

--- a/src/evm/contractExecutor/WorkerContractExecutor.ts
+++ b/src/evm/contractExecutor/WorkerContractExecutor.ts
@@ -99,6 +99,10 @@ export default class WorkerContractExecutor extends AContractExecutor {
         return this.callWorker("simulateCall", data, contractAddress);
     }
 
+    async uploadLogs(): Promise<void> {
+        await this.request({ type: "uploadLogs" });
+    }
+
     async dispose(): Promise<void> {
         this.rejectAll(new Error("Contract executor worker disposed"));
         await this.worker.terminate?.();

--- a/src/evm/contractExecutor/WorkerContractExecutor.ts
+++ b/src/evm/contractExecutor/WorkerContractExecutor.ts
@@ -9,7 +9,8 @@ import type {
     WorkerCustomPrecompile,
     WorkerRequestPayload
 } from "./types";
-import type { SerializableLoggerConfig, Logger } from "@/utils/logging/Logger";
+import type { SerializableLoggerConfig } from "@/utils/logging/Logger";
+import type { GossipNode } from "@/utils/GossipNode";
 import { WorkerClient } from "@/utils/worker/WorkerClient";
 import { createContractExecutorTransport } from "@platform/contractExecutorWorkerRuntime";
 
@@ -50,8 +51,8 @@ export default class WorkerContractExecutor extends AContractExecutor {
         this.client = new WorkerClient(createContractExecutorTransport());
     }
 
-    attachLogger(logger: Logger): void {
-        this.client.attachLogger(logger);
+    get gossipNode(): GossipNode {
+        return this.client.gossipNode;
     }
 
     async deploy(data: Bytes): Promise<ContractExecutionResult> {

--- a/src/evm/contractExecutor/WorkerContractExecutor.ts
+++ b/src/evm/contractExecutor/WorkerContractExecutor.ts
@@ -7,28 +7,11 @@ import AContractExecutor, {
 import type {
     WorkerCallMethod,
     WorkerCustomPrecompile,
-    WorkerRequestPayload,
-    WorkerResponse
+    WorkerRequestPayload
 } from "./types";
-import type {
-    SerializableLoggerConfig,
-    SharedLoggerContext
-} from "@/utils/logging/Logger";
-import {
-    createContractExecutorWorker,
-    type WorkerLike
-} from "@platform/contractExecutorWorkerRuntime";
-
-type PendingRequest = {
-    resolve: (result: null | ContractExecutionResult) => void;
-    reject: (error: Error) => void;
-};
-
-function isWorkerReadyResponse(
-    response: WorkerResponse
-): response is Extract<WorkerResponse, { type: "ready" }> {
-    return "type" in response && response.type === "ready";
-}
+import type { SerializableLoggerConfig, Logger } from "@/utils/logging/Logger";
+import { WorkerClient } from "@/utils/worker/WorkerClient";
+import { createContractExecutorTransport } from "@platform/contractExecutorWorkerRuntime";
 
 function serializePrecompileManifest(
     precompile: EvmCustomPrecompileManifest
@@ -42,20 +25,17 @@ function serializePrecompileManifest(
 }
 
 export default class WorkerContractExecutor extends AContractExecutor {
-    private nextRequestId = 1;
-    private readonly pending = new Map<number, PendingRequest>();
-    private readonly worker: WorkerLike;
-    private readonly workerReady: Promise<void>;
-    private rejectWorkerReady!: (error: Error) => void;
-    private resolveWorkerReady!: () => void;
+    private readonly client: WorkerClient<
+        WorkerRequestPayload,
+        ContractExecutionResult | null
+    >;
 
     static async create(
         customPrecompiles: readonly EvmCustomPrecompileManifest[] = [],
         loggerConfig?: SerializableLoggerConfig
     ): Promise<WorkerContractExecutor> {
         const executor = new WorkerContractExecutor();
-        await executor.workerReady;
-        await executor.request({
+        await executor.client.request({
             type: "init",
             customPrecompiles: customPrecompiles.map(
                 serializePrecompileManifest
@@ -67,21 +47,16 @@ export default class WorkerContractExecutor extends AContractExecutor {
 
     private constructor() {
         super();
-        this.workerReady = new Promise((resolve, reject) => {
-            this.resolveWorkerReady = resolve;
-            this.rejectWorkerReady = reject;
-        });
-        this.worker = createContractExecutorWorker(
-            (message) => this.handleResponse(message),
-            (error) => {
-                this.rejectWorkerReady(error);
-                this.rejectAll(error);
-            }
-        );
+        this.client = new WorkerClient(createContractExecutorTransport());
+    }
+
+    // Wire the SDK logger's gossip into the worker client (composition root).
+    attachLogger(logger: Logger): void {
+        this.client.attachLogger(logger);
     }
 
     async deploy(data: Bytes): Promise<ContractExecutionResult> {
-        return (await this.request({
+        return (await this.client.request({
             type: "call",
             method: "deploy",
             data: ethers.hexlify(data)
@@ -102,31 +77,8 @@ export default class WorkerContractExecutor extends AContractExecutor {
         return this.callWorker("simulateCall", data, contractAddress);
     }
 
-    // Best-effort diagnostics: the worker may be gone (disposed/crashed). These
-    // mirror RemoteLoggerSibling's fire-and-forget contract, so they never throw.
-    async updateSharedContext(context: SharedLoggerContext): Promise<void> {
-        try {
-            await this.request({
-                type: "diagnostics",
-                op: "updateContext",
-                context
-            });
-        } catch {
-            /* swallow */
-        }
-    }
-
-    async uploadLogs(message?: string): Promise<void> {
-        try {
-            await this.request({ type: "diagnostics", op: "upload", message });
-        } catch {
-            /* swallow */
-        }
-    }
-
     async dispose(): Promise<void> {
-        this.rejectAll(new Error("Contract executor worker disposed"));
-        await this.worker.terminate?.();
+        await this.client.dispose();
     }
 
     private async callWorker(
@@ -134,63 +86,11 @@ export default class WorkerContractExecutor extends AContractExecutor {
         data: Bytes,
         contractAddress: Address
     ): Promise<ContractExecutionResult> {
-        return (await this.request({
+        return (await this.client.request({
             type: "call",
             method,
             data: ethers.hexlify(data),
             contractAddress: contractAddress.toString()
         })) as ContractExecutionResult;
-    }
-
-    private request(message: WorkerRequestPayload) {
-        const request = {
-            requestId: this.nextRequestId++,
-            workerRequestPayload: message
-        };
-
-        return new Promise<null | ContractExecutionResult>(
-            (resolve, reject) => {
-                this.pending.set(request.requestId, { resolve, reject });
-                try {
-                    this.worker.postMessage(request);
-                } catch (error) {
-                    this.pending.delete(request.requestId);
-                    reject(
-                        error instanceof Error
-                            ? error
-                            : new Error(String(error))
-                    );
-                }
-            }
-        );
-    }
-
-    private handleResponse(response: WorkerResponse): void {
-        if (isWorkerReadyResponse(response)) {
-            this.resolveWorkerReady();
-            return;
-        }
-
-        const pending = this.pending.get(response.requestId);
-        if (!pending) return;
-        this.pending.delete(response.requestId);
-
-        if (response.ok) {
-            pending.resolve(response.result);
-            return;
-        }
-
-        const error = new Error(response.error.message);
-        error.name = response.error.name || error.name;
-        error.stack = response.error.stack || error.stack;
-        (error as any).data = response.error.data;
-        pending.reject(error);
-    }
-
-    private rejectAll(error: Error): void {
-        for (const pending of this.pending.values()) {
-            pending.reject(error);
-        }
-        this.pending.clear();
     }
 }

--- a/src/evm/contractExecutor/WorkerContractExecutor.ts
+++ b/src/evm/contractExecutor/WorkerContractExecutor.ts
@@ -10,6 +10,7 @@ import type {
     WorkerRequestPayload,
     WorkerResponse
 } from "./types";
+import type { SerializableLoggerConfig } from "@/utils/logging/Logger";
 import {
     createContractExecutorWorker,
     type WorkerLike
@@ -46,7 +47,8 @@ export default class WorkerContractExecutor extends AContractExecutor {
     private resolveWorkerReady!: () => void;
 
     static async create(
-        customPrecompiles: readonly EvmCustomPrecompileManifest[] = []
+        customPrecompiles: readonly EvmCustomPrecompileManifest[] = [],
+        loggerConfig?: SerializableLoggerConfig
     ): Promise<WorkerContractExecutor> {
         const executor = new WorkerContractExecutor();
         await executor.workerReady;
@@ -54,7 +56,8 @@ export default class WorkerContractExecutor extends AContractExecutor {
             type: "init",
             customPrecompiles: customPrecompiles.map(
                 serializePrecompileManifest
-            )
+            ),
+            loggerConfig
         });
         return executor;
     }

--- a/src/evm/contractExecutor/WorkerContractExecutor.ts
+++ b/src/evm/contractExecutor/WorkerContractExecutor.ts
@@ -10,7 +10,10 @@ import type {
     WorkerRequestPayload,
     WorkerResponse
 } from "./types";
-import type { SerializableLoggerConfig } from "@/utils/logging/Logger";
+import type {
+    SerializableLoggerConfig,
+    SharedLoggerContext
+} from "@/utils/logging/Logger";
 import {
     createContractExecutorWorker,
     type WorkerLike
@@ -99,8 +102,26 @@ export default class WorkerContractExecutor extends AContractExecutor {
         return this.callWorker("simulateCall", data, contractAddress);
     }
 
-    async uploadLogs(): Promise<void> {
-        await this.request({ type: "uploadLogs" });
+    // Best-effort diagnostics: the worker may be gone (disposed/crashed). These
+    // mirror RemoteLoggerSibling's fire-and-forget contract, so they never throw.
+    async updateSharedContext(context: SharedLoggerContext): Promise<void> {
+        try {
+            await this.request({
+                type: "diagnostics",
+                op: "updateContext",
+                context
+            });
+        } catch {
+            /* swallow */
+        }
+    }
+
+    async uploadLogs(message?: string): Promise<void> {
+        try {
+            await this.request({ type: "diagnostics", op: "upload", message });
+        } catch {
+            /* swallow */
+        }
     }
 
     async dispose(): Promise<void> {

--- a/src/evm/contractExecutor/browser/ContractExecutorWorkerHost.ts
+++ b/src/evm/contractExecutor/browser/ContractExecutorWorkerHost.ts
@@ -4,8 +4,7 @@ import {
 } from "@platform/workerTransport";
 import { ContractExecutorWorkerHost } from "../ContractExecutorWorkerHostCore";
 
-// The first inbound message carries the transferred gossip port; build the host
-// from it. createWorkerHostTransport then rebinds globalThis.onmessage for RPC.
+// First inbound message carries the transferred gossip port; build the host from it.
 globalThis.onmessage = (event: MessageEvent<GossipInitMessage>) => {
     const init = event.data;
     if (!init || init.__gossipInit !== true) {

--- a/src/evm/contractExecutor/browser/ContractExecutorWorkerHost.ts
+++ b/src/evm/contractExecutor/browser/ContractExecutorWorkerHost.ts
@@ -1,13 +1,15 @@
-import { startContractExecutorWorkerHost } from "../ContractExecutorWorkerHostCore";
-import type { WorkerRequest, WorkerResponse } from "../types";
+import {
+    createWorkerHostTransport,
+    type GossipInitMessage
+} from "@platform/workerTransport";
+import { ContractExecutorWorkerHost } from "../ContractExecutorWorkerHostCore";
 
-startContractExecutorWorkerHost(
-    (response: WorkerResponse) => {
-        globalThis.postMessage(response);
-    },
-    (handler: (message: WorkerRequest) => void) => {
-        globalThis.onmessage = (event: MessageEvent<WorkerRequest>) => {
-            handler(event.data);
-        };
+// The first inbound message carries the transferred gossip port; build the host
+// from it. createWorkerHostTransport then rebinds globalThis.onmessage for RPC.
+globalThis.onmessage = (event: MessageEvent<GossipInitMessage>) => {
+    const init = event.data;
+    if (!init || init.__gossipInit !== true) {
+        throw new Error("Contract executor worker host expected gossip init");
     }
-);
+    new ContractExecutorWorkerHost(createWorkerHostTransport(init.port));
+};

--- a/src/evm/contractExecutor/browser/ContractExecutorWorkerRuntime.ts
+++ b/src/evm/contractExecutor/browser/ContractExecutorWorkerRuntime.ts
@@ -1,41 +1,8 @@
-import type {
-    ContractExecutorWorkerErrorHandler,
-    ContractExecutorWorkerMessageHandler,
-    WorkerLike,
-    WorkerResponse
-} from "../types";
+import { createWorkerClientTransport } from "@platform/workerTransport";
+import type { WorkerClientTransport } from "@/utils/worker/types";
 
-export type {
-    ContractExecutorWorkerErrorHandler,
-    ContractExecutorWorkerMessageHandler,
-    WorkerLike
-};
-
-export function createContractExecutorWorker(
-    onMessage: ContractExecutorWorkerMessageHandler,
-    onError: ContractExecutorWorkerErrorHandler
-): WorkerLike {
-    const worker = new Worker(
-        new URL("./ContractExecutorWorkerHost.js", import.meta.url),
-        { type: "module" }
-    );
-
-    worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
-        onMessage(event.data);
-    };
-    worker.onerror = (event: ErrorEvent) => {
-        const details = [
-            event.message || "Contract executor worker failed",
-            event.filename ? `file: ${event.filename}` : undefined,
-            event.lineno ? `line: ${event.lineno}` : undefined,
-            event.colno ? `column: ${event.colno}` : undefined
-        ].filter(Boolean);
-        onError(new Error(details.join(" ")));
-    };
-    worker.onmessageerror = () => {
-        onError(
-            new Error("Contract executor worker message could not be cloned")
-        );
-    };
-    return worker;
+export function createContractExecutorTransport(): WorkerClientTransport {
+    return createWorkerClientTransport({
+        url: new URL("./ContractExecutorWorkerHost.js", import.meta.url)
+    });
 }

--- a/src/evm/contractExecutor/node/ContractExecutorWorkerHost.ts
+++ b/src/evm/contractExecutor/node/ContractExecutorWorkerHost.ts
@@ -1,16 +1,4 @@
-import { parentPort } from "node:worker_threads";
-import { startContractExecutorWorkerHost } from "../ContractExecutorWorkerHostCore";
-import type { WorkerRequest, WorkerResponse } from "../types";
+import { createWorkerHostTransport } from "@platform/workerTransport";
+import { ContractExecutorWorkerHost } from "../ContractExecutorWorkerHostCore";
 
-if (!parentPort) {
-    throw new Error("Contract executor worker host requires a parent port");
-}
-
-const port = parentPort;
-
-startContractExecutorWorkerHost(
-    (response: WorkerResponse) => port.postMessage(response),
-    (handler: (message: WorkerRequest) => void) => {
-        port.on("message", handler);
-    }
-);
+new ContractExecutorWorkerHost(createWorkerHostTransport());

--- a/src/evm/contractExecutor/node/ContractExecutorWorkerRuntime.ts
+++ b/src/evm/contractExecutor/node/ContractExecutorWorkerRuntime.ts
@@ -1,46 +1,9 @@
-import type {
-    ContractExecutorWorkerErrorHandler,
-    ContractExecutorWorkerMessageHandler,
-    WorkerLike
-} from "../types";
+import { createWorkerClientTransport } from "@platform/workerTransport";
+import type { WorkerClientTransport } from "@/utils/worker/types";
 
-export type {
-    ContractExecutorWorkerErrorHandler,
-    ContractExecutorWorkerMessageHandler,
-    WorkerLike
-};
-
-export function createContractExecutorWorker(
-    onMessage: ContractExecutorWorkerMessageHandler,
-    onError: ContractExecutorWorkerErrorHandler
-): WorkerLike {
-    const nodeRequire = typeof require === "function" ? require : undefined;
-    if (!nodeRequire) {
-        throw new Error("Node worker_threads require() is unavailable");
-    }
-
-    const path = nodeRequire("node:path") as typeof import("node:path");
-    const fs = nodeRequire("node:fs") as typeof import("node:fs");
-    const { Worker } = nodeRequire(
-        "node:worker_threads"
-    ) as typeof import("node:worker_threads");
-
-    const jsWorkerPath = path.join(__dirname, "ContractExecutorWorkerHost.js");
-    const tsWorkerPath = path.join(__dirname, "ContractExecutorWorkerHost.ts");
-    const workerPath = fs.existsSync(jsWorkerPath)
-        ? jsWorkerPath
-        : tsWorkerPath;
-    const execArgv = workerPath.endsWith(".ts")
-        ? ["-r", "ts-node/register", "-r", "tsconfig-paths/register"]
-        : undefined;
-
-    const worker = new Worker(workerPath, { execArgv });
-    worker.on("message", onMessage);
-    worker.on("error", onError);
-    worker.on("exit", (code: number) => {
-        if (code !== 0) {
-            onError(new Error(`Contract executor worker exited with ${code}`));
-        }
+export function createContractExecutorTransport(): WorkerClientTransport {
+    return createWorkerClientTransport({
+        dir: __dirname,
+        basename: "ContractExecutorWorkerHost"
     });
-    return worker;
 }

--- a/src/evm/contractExecutor/types.ts
+++ b/src/evm/contractExecutor/types.ts
@@ -1,4 +1,5 @@
 import type { ContractExecutionResult } from "./AContractExecutor";
+import type { SerializableLoggerConfig } from "@/utils/logging/Logger";
 
 export type WorkerCustomPrecompile = {
     address: string;
@@ -13,6 +14,7 @@ export type WorkerRequestPayload =
     | {
           type: "init";
           customPrecompiles: WorkerCustomPrecompile[];
+          loggerConfig?: SerializableLoggerConfig;
       }
     | {
           type: "call";

--- a/src/evm/contractExecutor/types.ts
+++ b/src/evm/contractExecutor/types.ts
@@ -26,6 +26,9 @@ export type WorkerRequestPayload =
           contractAddress: string;
           method: WorkerCallMethod;
           data: string;
+      }
+    | {
+          type: "uploadLogs";
       };
 
 export type WorkerRequest = {

--- a/src/evm/contractExecutor/types.ts
+++ b/src/evm/contractExecutor/types.ts
@@ -1,8 +1,4 @@
-import type { ContractExecutionResult } from "./AContractExecutor";
-import type {
-    SerializableLoggerConfig,
-    SharedLoggerContext
-} from "@/utils/logging/Logger";
+import type { SerializableLoggerConfig } from "@/utils/logging/Logger";
 
 export type WorkerCustomPrecompile = {
     address: string;
@@ -29,50 +25,4 @@ export type WorkerRequestPayload =
           contractAddress: string;
           method: WorkerCallMethod;
           data: string;
-      }
-    | {
-          type: "diagnostics";
-          op: "updateContext";
-          context: SharedLoggerContext;
-      }
-    | {
-          type: "diagnostics";
-          op: "upload";
-          message?: string;
       };
-
-export type WorkerRequest = {
-    requestId: number;
-    workerRequestPayload: WorkerRequestPayload;
-};
-
-export type WorkerResponse =
-    | {
-          type: "ready";
-      }
-    | {
-          requestId: number;
-          ok: true;
-          result: null | ContractExecutionResult;
-      }
-    | {
-          requestId: number;
-          ok: false;
-          error: {
-              message: string;
-              data?: string;
-              name?: string;
-              stack?: string;
-          };
-      };
-
-export type WorkerLike = {
-    postMessage(message: WorkerRequest): void;
-    terminate?: () => Promise<unknown> | unknown;
-};
-
-export type ContractExecutorWorkerMessageHandler = (
-    message: WorkerResponse
-) => void;
-
-export type ContractExecutorWorkerErrorHandler = (error: Error) => void;

--- a/src/evm/contractExecutor/types.ts
+++ b/src/evm/contractExecutor/types.ts
@@ -1,5 +1,8 @@
 import type { ContractExecutionResult } from "./AContractExecutor";
-import type { SerializableLoggerConfig } from "@/utils/logging/Logger";
+import type {
+    SerializableLoggerConfig,
+    SharedLoggerContext
+} from "@/utils/logging/Logger";
 
 export type WorkerCustomPrecompile = {
     address: string;
@@ -28,7 +31,14 @@ export type WorkerRequestPayload =
           data: string;
       }
     | {
-          type: "uploadLogs";
+          type: "diagnostics";
+          op: "updateContext";
+          context: SharedLoggerContext;
+      }
+    | {
+          type: "diagnostics";
+          op: "upload";
+          message?: string;
       };
 
 export type WorkerRequest = {

--- a/src/utils/GossipNode.ts
+++ b/src/utils/GossipNode.ts
@@ -1,16 +1,12 @@
-// A single edge to a neighbouring thread in the gossip tree. `post` sends a
-// message out over the edge; `subscribe` registers the inbound handler. Both are
-// closures over a dedicated MessagePort, built at the @platform entry — the node
-// never touches a raw port.
+// One edge to a neighbouring thread: `post` sends outbound, `subscribe` registers
+// the inbound handler. Built over a dedicated MessagePort at the @platform entry.
 export type Neighbour = {
     post: (msg: unknown) => void;
     subscribe: (handler: (msg: unknown) => void) => void;
 };
 
-// A participant in the bidirectional thread-gossip tree. Generic over payload
-// (carries `unknown`); knows nothing about logs. Precondition: the thread topology
-// is a TREE, which makes skip-sender forwarding provably loop-free with no ids or
-// dedupe. Hand it a non-tree and it will loop — out of contract.
+// A node in the thread-gossip tree, generic over payload. Precondition: topology is
+// a TREE — skip-sender forwarding is then loop-free with no ids/dedupe; a non-tree loops.
 export class GossipNode {
     private readonly neighbours = new Set<Neighbour>();
     private readonly onLocal?: (msg: unknown) => void;
@@ -21,19 +17,16 @@ export class GossipNode {
         this.onLocal = onLocal;
     }
 
-    // The ONE routing primitive: forward to every neighbour except `exclude`.
-    // Local origin calls it with no exclude (forward to all); inbound forwarding
-    // excludes the sender.
+    // Forward to every neighbour except `exclude` (the sender on inbound; none on local origin).
     broadcast(msg: unknown, exclude?: Neighbour): void {
         for (const neighbour of this.neighbours) {
             if (neighbour !== exclude) neighbour.post(msg);
         }
     }
 
-    // Registering a neighbour also wires its inbound path: deliver locally, then
-    // forward to all OTHER neighbours (skip-sender). There is no separate receive().
+    // Wire inbound: deliver locally, then forward to all OTHER neighbours (skip-sender).
     addNeighbour(neighbour: Neighbour): void {
-        // Idempotent: Set.add dedupes, but a second subscribe would double-deliver.
+        // Idempotent: a second subscribe would double-deliver.
         if (this.neighbours.has(neighbour)) return;
         this.neighbours.add(neighbour);
         neighbour.subscribe((msg) => {

--- a/src/utils/GossipNode.ts
+++ b/src/utils/GossipNode.ts
@@ -10,10 +10,15 @@ export type Neighbour = {
 export class GossipNode {
     // neighbour → its unsubscribe, so removal can un-wire the inbound listener.
     private readonly neighbours = new Map<Neighbour, () => void>();
-    private readonly onLocal?: (msg: unknown) => void;
+    private onLocal?: (msg: unknown) => void;
 
     // `onLocal` interprets messages reaching this node (e.g. Logger.applyOp); optional for a pure relay.
     constructor(onLocal?: (msg: unknown) => void) {
+        this.onLocal = onLocal;
+    }
+
+    // Point local delivery at the thread's one root logger (a node may be shared across edges).
+    setLocalHandler(onLocal: (msg: unknown) => void): void {
         this.onLocal = onLocal;
     }
 

--- a/src/utils/GossipNode.ts
+++ b/src/utils/GossipNode.ts
@@ -1,0 +1,44 @@
+// A single edge to a neighbouring thread in the gossip tree. `post` sends a
+// message out over the edge; `subscribe` registers the inbound handler. Both are
+// closures over a dedicated MessagePort, built at the @platform entry — the node
+// never touches a raw port.
+export type Neighbour = {
+    post: (msg: unknown) => void;
+    subscribe: (handler: (msg: unknown) => void) => void;
+};
+
+// A participant in the bidirectional thread-gossip tree. Generic over payload
+// (carries `unknown`); knows nothing about logs. Precondition: the thread topology
+// is a TREE, which makes skip-sender forwarding provably loop-free with no ids or
+// dedupe. Hand it a non-tree and it will loop — out of contract.
+export class GossipNode {
+    private readonly neighbours = new Set<Neighbour>();
+    private readonly onLocal?: (msg: unknown) => void;
+
+    // `onLocal` is the consumer's interpreter for messages that reach this node
+    // (e.g. Logger.applyOp). Optional so a pure relay node is possible.
+    constructor(onLocal?: (msg: unknown) => void) {
+        this.onLocal = onLocal;
+    }
+
+    // The ONE routing primitive: forward to every neighbour except `exclude`.
+    // Local origin calls it with no exclude (forward to all); inbound forwarding
+    // excludes the sender.
+    broadcast(msg: unknown, exclude?: Neighbour): void {
+        for (const neighbour of this.neighbours) {
+            if (neighbour !== exclude) neighbour.post(msg);
+        }
+    }
+
+    // Registering a neighbour also wires its inbound path: deliver locally, then
+    // forward to all OTHER neighbours (skip-sender). There is no separate receive().
+    addNeighbour(neighbour: Neighbour): void {
+        // Idempotent: Set.add dedupes, but a second subscribe would double-deliver.
+        if (this.neighbours.has(neighbour)) return;
+        this.neighbours.add(neighbour);
+        neighbour.subscribe((msg) => {
+            this.onLocal?.(msg);
+            this.broadcast(msg, neighbour);
+        });
+    }
+}

--- a/src/utils/GossipNode.ts
+++ b/src/utils/GossipNode.ts
@@ -1,13 +1,15 @@
-// One edge to a neighbouring thread: `post` = outbound, `subscribe` = inbound handler.
+// One edge to a neighbouring thread: `post` = outbound, `subscribe` = inbound handler
+// returning its own unsubscribe (the transport still owns the port; gossip only un-wires).
 export type Neighbour = {
     post: (msg: unknown) => void;
-    subscribe: (handler: (msg: unknown) => void) => void;
+    subscribe: (handler: (msg: unknown) => void) => () => void;
 };
 
 // A node in the thread-gossip tree, generic over payload. Precondition: topology is
 // a TREE — skip-sender forwarding is then loop-free with no ids/dedupe; a non-tree loops.
 export class GossipNode {
-    private readonly neighbours = new Set<Neighbour>();
+    // neighbour → its unsubscribe, so removal can un-wire the inbound listener.
+    private readonly neighbours = new Map<Neighbour, () => void>();
     private readonly onLocal?: (msg: unknown) => void;
 
     // `onLocal` interprets messages reaching this node (e.g. Logger.applyOp); optional for a pure relay.
@@ -17,7 +19,7 @@ export class GossipNode {
 
     // Forward to every neighbour except `exclude` (the sender on inbound; none on local origin).
     broadcast(msg: unknown, exclude?: Neighbour): void {
-        for (const neighbour of this.neighbours) {
+        for (const neighbour of this.neighbours.keys()) {
             if (neighbour !== exclude) neighbour.post(msg);
         }
     }
@@ -26,10 +28,25 @@ export class GossipNode {
     addNeighbour(neighbour: Neighbour): void {
         // Idempotent: a second subscribe would double-deliver.
         if (this.neighbours.has(neighbour)) return;
-        this.neighbours.add(neighbour);
-        neighbour.subscribe((msg) => {
+        const unsubscribe = neighbour.subscribe((msg) => {
             this.onLocal?.(msg);
             this.broadcast(msg, neighbour);
         });
+        this.neighbours.set(neighbour, unsubscribe);
+    }
+
+    // Inverse of addNeighbour: un-wire the inbound listener and drop the edge. Idempotent.
+    removeNeighbour(neighbour: Neighbour): void {
+        const unsubscribe = this.neighbours.get(neighbour);
+        if (!unsubscribe) return;
+        unsubscribe();
+        this.neighbours.delete(neighbour);
+    }
+
+    // Tear down every edge, leaving the node inert and reusable. Snapshot keys: removeNeighbour mutates.
+    close(): void {
+        for (const neighbour of [...this.neighbours.keys()]) {
+            this.removeNeighbour(neighbour);
+        }
     }
 }

--- a/src/utils/GossipNode.ts
+++ b/src/utils/GossipNode.ts
@@ -1,5 +1,4 @@
-// One edge to a neighbouring thread: `post` sends outbound, `subscribe` registers
-// the inbound handler. Built over a dedicated MessagePort at the @platform entry.
+// One edge to a neighbouring thread: `post` = outbound, `subscribe` = inbound handler.
 export type Neighbour = {
     post: (msg: unknown) => void;
     subscribe: (handler: (msg: unknown) => void) => void;
@@ -11,8 +10,7 @@ export class GossipNode {
     private readonly neighbours = new Set<Neighbour>();
     private readonly onLocal?: (msg: unknown) => void;
 
-    // `onLocal` is the consumer's interpreter for messages that reach this node
-    // (e.g. Logger.applyOp). Optional so a pure relay node is possible.
+    // `onLocal` interprets messages reaching this node (e.g. Logger.applyOp); optional for a pure relay.
     constructor(onLocal?: (msg: unknown) => void) {
         this.onLocal = onLocal;
     }

--- a/src/utils/browser/workerTransport.ts
+++ b/src/utils/browser/workerTransport.ts
@@ -5,11 +5,9 @@ import type {
     WorkerResult
 } from "@/utils/worker/types";
 
-// The sentinel first message that hands the worker its transferred gossip port.
 export type GossipInitMessage = { __gossipInit: true; port: MessagePort };
 
-// Spawn a module worker; its gossip port is transferred via a sentinel init message
-// (the browser Worker ctor has no transferList). The host peels it off its first message.
+// Spawn a module worker; gossip port transferred via a sentinel init message (no transferList in the browser Worker ctor).
 export function createWorkerClientTransport(entry: {
     url: URL;
 }): WorkerClientTransport {

--- a/src/utils/browser/workerTransport.ts
+++ b/src/utils/browser/workerTransport.ts
@@ -8,9 +8,8 @@ import type {
 // The sentinel first message that hands the worker its transferred gossip port.
 export type GossipInitMessage = { __gossipInit: true; port: MessagePort };
 
-// Spawn a module worker from a URL, with a dedicated gossip MessageChannel whose
-// worker end is transferred via a sentinel init postMessage (the browser Worker
-// ctor has no transferList). The host peels that init off its first message.
+// Spawn a module worker; its gossip port is transferred via a sentinel init message
+// (the browser Worker ctor has no transferList). The host peels it off its first message.
 export function createWorkerClientTransport(entry: {
     url: URL;
 }): WorkerClientTransport {
@@ -54,8 +53,7 @@ export function createWorkerClientTransport(entry: {
     };
 }
 
-// The browser host entry peels the transferred gossip port off the first message,
-// then passes it here. RPC rides globalThis.onmessage/postMessage.
+// Host entry peels the gossip port off its first message and passes it here.
 export function createWorkerHostTransport(
     gossipPort: MessagePort
 ): WorkerHostTransport {

--- a/src/utils/browser/workerTransport.ts
+++ b/src/utils/browser/workerTransport.ts
@@ -1,0 +1,75 @@
+import type { Neighbour } from "@/utils/GossipNode";
+import type {
+    WorkerClientTransport,
+    WorkerHostTransport,
+    WorkerResult
+} from "@/utils/worker/types";
+
+// The sentinel first message that hands the worker its transferred gossip port.
+export type GossipInitMessage = { __gossipInit: true; port: MessagePort };
+
+// Spawn a module worker from a URL, with a dedicated gossip MessageChannel whose
+// worker end is transferred via a sentinel init postMessage (the browser Worker
+// ctor has no transferList). The host peels that init off its first message.
+export function createWorkerClientTransport(entry: {
+    url: URL;
+}): WorkerClientTransport {
+    const worker = new Worker(entry.url, { type: "module" });
+
+    const gossip = new MessageChannel();
+    const init: GossipInitMessage = { __gossipInit: true, port: gossip.port2 };
+    worker.postMessage(init, [gossip.port2]);
+
+    let errorHandler: ((e: Error) => void) | undefined;
+    worker.onerror = (event: ErrorEvent) => {
+        errorHandler?.(new Error(event.message || "Worker failed"));
+    };
+    worker.onmessageerror = () => {
+        errorHandler?.(new Error("Worker message could not be cloned"));
+    };
+
+    const port1 = gossip.port1;
+    const gossipNeighbour: Neighbour = {
+        post: (msg) => port1.postMessage(msg),
+        subscribe: (handler) => {
+            // assigning .onmessage auto-starts the port and replaces any prior handler
+            port1.onmessage = (event: MessageEvent) => handler(event.data);
+        }
+    };
+
+    return {
+        post: (envelope) => worker.postMessage(envelope),
+        onMessage: (handler) => {
+            worker.onmessage = (event: MessageEvent<WorkerResult<unknown>>) =>
+                handler(event.data);
+        },
+        onError: (handler) => {
+            errorHandler = handler;
+        },
+        terminate: () => {
+            port1.close();
+            return worker.terminate();
+        },
+        gossipNeighbour
+    };
+}
+
+// The browser host entry peels the transferred gossip port off the first message,
+// then passes it here. RPC rides globalThis.onmessage/postMessage.
+export function createWorkerHostTransport(
+    gossipPort: MessagePort
+): WorkerHostTransport {
+    const gossipNeighbour: Neighbour = {
+        post: (msg) => gossipPort.postMessage(msg),
+        subscribe: (handler) => {
+            gossipPort.onmessage = (event: MessageEvent) => handler(event.data);
+        }
+    };
+    return {
+        post: (result) => globalThis.postMessage(result),
+        onMessage: (handler) => {
+            globalThis.onmessage = (event: MessageEvent) => handler(event.data);
+        },
+        gossipNeighbour
+    };
+}

--- a/src/utils/browser/workerTransport.ts
+++ b/src/utils/browser/workerTransport.ts
@@ -29,8 +29,11 @@ export function createWorkerClientTransport(entry: {
     const gossipNeighbour: Neighbour = {
         post: (msg) => port1.postMessage(msg),
         subscribe: (handler) => {
-            // assigning .onmessage auto-starts the port and replaces any prior handler
-            port1.onmessage = (event: MessageEvent) => handler(event.data);
+            const listener = (event: MessageEvent) => handler(event.data);
+            // addEventListener (vs onmessage=) is removable; start() is required as it doesn't auto-start.
+            port1.addEventListener("message", listener);
+            port1.start();
+            return () => port1.removeEventListener("message", listener);
         }
     };
 
@@ -58,7 +61,10 @@ export function createWorkerHostTransport(
     const gossipNeighbour: Neighbour = {
         post: (msg) => gossipPort.postMessage(msg),
         subscribe: (handler) => {
-            gossipPort.onmessage = (event: MessageEvent) => handler(event.data);
+            const listener = (event: MessageEvent) => handler(event.data);
+            gossipPort.addEventListener("message", listener);
+            gossipPort.start();
+            return () => gossipPort.removeEventListener("message", listener);
         }
     };
     return {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -9,6 +9,7 @@ export type Config = {
     DEBUG_CHANNEL_CONTRACT: boolean;
     DEBUG_LOCAL_TRANSPORT: boolean;
     LOG_LEVEL: string;
+    LOG_THREAD_NAME: string;
     LOG_SKIP_WRITING: boolean;
     LOG_EXCLUDE_TAGS: string;
     EXCLUDE_LOG_TAGS: string;
@@ -30,6 +31,7 @@ const DEFAULT_CONFIG: Config = {
     DEBUG_CHANNEL_CONTRACT: false,
     DEBUG_LOCAL_TRANSPORT: false,
     LOG_LEVEL: "info",
+    LOG_THREAD_NAME: "sdk",
     LOG_SKIP_WRITING: false,
     LOG_EXCLUDE_TAGS: "",
     EXCLUDE_LOG_TAGS: "",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,6 +19,7 @@ export * from "./DetachedPromises";
 export * from "./logging";
 export * from "./EthersResultProxy";
 export * from "./address";
+export * from "./GossipNode";
 
 export function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/utils/logging/LogUploader.ts
+++ b/src/utils/logging/LogUploader.ts
@@ -45,6 +45,10 @@ export abstract class LogUploader {
     setLogger(logger: Logger) {
         this.logger = logger;
     }
+
+    public getConfig(): LogUploaderConfig {
+        return this.config;
+    }
     protected abstract attachListeners(): void;
     protected abstract detachListeners(): void;
 

--- a/src/utils/logging/LogUploader.ts
+++ b/src/utils/logging/LogUploader.ts
@@ -89,6 +89,7 @@ export abstract class LogUploader {
             const channelId = this.sharedContext.channelId || ethers.ZeroHash;
             const peerAddress =
                 this.sharedContext.peerAddress || ethers.ZeroAddress;
+            const threadName = this.sharedContext.threadName;
 
             if (!channelId || !peerAddress) {
                 return; // ignore
@@ -118,6 +119,7 @@ export abstract class LogUploader {
                         {
                             channelId,
                             peerAddress,
+                            threadName,
                             compressedLogs
                         },
                         {

--- a/src/utils/logging/Logger.ts
+++ b/src/utils/logging/Logger.ts
@@ -127,7 +127,7 @@ export abstract class Logger {
     }
 
     // Single interpreter for a LoggerOp on this thread; returns the flush promise to await/detach.
-    public applyOp(op: LoggerOp): Promise<void> | void {
+    public applyOp(op: LoggerOp): Promise<void> | undefined {
         switch (op.type) {
             case "flush":
                 return this.logUploader?.uploadLogs();
@@ -205,9 +205,7 @@ export abstract class Logger {
         // Flush only this thread's own store — NO cross-thread gossip (error() has
         // 60+ call sites; fanning out would re-upload every thread on every error).
         // The report-bug path (uploadLogs) is what pulls all threads.
-        const promise = this.applyOp({ type: "flush" }) as
-            | Promise<void>
-            | undefined;
+        const promise = this.applyOp({ type: "flush" });
         if (promise) DetachedPromises.collect(promise);
     }
     public verbose(message: any, ...meta: any[]): void {
@@ -232,7 +230,7 @@ export abstract class Logger {
 
     // Apply an op locally AND gossip it to the rest of the tree; returns the flush promise.
     private originate(op: LoggerOp): Promise<void> | undefined {
-        const result = this.applyOp(op) as Promise<void> | undefined;
+        const result = this.applyOp(op);
         this.resolveGossipNode()?.broadcast(op);
         return result;
     }

--- a/src/utils/logging/Logger.ts
+++ b/src/utils/logging/Logger.ts
@@ -20,17 +20,14 @@ export type SharedLoggerContext = {
     threadName?: string;
 };
 
-// The Logger's cross-thread vocabulary: operations every logger in the thread tree
-// applies to its OWN state. Type-discriminated like the worker's WorkerRequestPayload
-// (evm/contractExecutor/types.ts:16). Carried opaquely by the GossipNode.
+// Cross-thread ops every logger applies to its own state; carried opaquely by GossipNode.
 export type LoggerOp =
     | { type: "flush" }
     | { type: "updateContext"; context: SharedLoggerContext };
 
 export type LogLevel = "debug" | "info" | "warn" | "error" | "verbose";
 
-// Serializable recipe for rebuilding an equivalent logger on a worker thread,
-// where a live Logger can't cross the structured-clone boundary.
+// Recipe to rebuild an equivalent logger on a worker thread (a live Logger can't be cloned).
 export type SerializableLoggerConfig = {
     sharedContext: SharedLoggerContext;
     uploadEndpoint: string;
@@ -91,8 +88,6 @@ export abstract class Logger {
         this.skipWriting = skipWriting;
     }
 
-    // Project this logger into a serializable recipe so a worker thread can
-    // rebuild an equivalent sibling (a live Logger can't be structured-cloned).
     public toSerializableConfig(overrides: {
         threadName: string;
     }): SerializableLoggerConfig {
@@ -124,10 +119,8 @@ export abstract class Logger {
         this.node = node;
     }
 
-    // The node is registered on one logger in the chain; any descendant walks up
-    // to the nearest ancestor that has one. Broadcasting through it after the
-    // worker is disposed is a silent no-op (postMessage to a closed port does not
-    // throw), so the callers (updateSharedContext/flushUploads) need no guard.
+    // Walk up to the nearest ancestor holding the node. Posting to a disposed
+    // worker's port is a silent no-op, so callers need no guard.
     private resolveGossipNode(): GossipNode | undefined {
         let logger: Logger | undefined = this;
         while (logger) {
@@ -137,10 +130,8 @@ export abstract class Logger {
         return undefined;
     }
 
-    // The SINGLE interpreter of a LoggerOp, applied to THIS thread's logger. Used by
-    // both the local trigger path (flushUploads/updateSharedContext) and the inbound
-    // gossip path (GossipNode onLocal). Returns the flush promise so local callers can
-    // await/detach it; inbound callers ignore the return (fire-and-forget).
+    // Single interpreter for a LoggerOp on this thread; returns the flush promise
+    // so local callers can await/detach it.
     public applyOp(op: LoggerOp): Promise<void> | void {
         switch (op.type) {
             case "flush":
@@ -216,7 +207,12 @@ export abstract class Logger {
     }
     public error(message: any, ...meta: any[]): void {
         this.log("error", message, meta);
-        const promise = this.flushUploads();
+        // Flush only this thread's own store — NO cross-thread gossip (error() has
+        // 60+ call sites; fanning out would re-upload every thread on every error).
+        // The report-bug path (uploadLogs) is what pulls all threads.
+        const promise = this.applyOp({ type: "flush" }) as
+            | Promise<void>
+            | undefined;
         if (promise) DetachedPromises.collect(promise);
     }
     public verbose(message: any, ...meta: any[]): void {
@@ -228,8 +224,7 @@ export abstract class Logger {
     }
 
     public async uploadLogs(message: any, ...meta: any[]): Promise<void> {
-        // logTimestamp needs a live Clock; a worker thread has none, so don't let
-        // it abort the flush (log() guards Clock the same way).
+        // logTimestamp needs a live Clock; the worker has none — don't abort the flush.
         try {
             await LoggerUtils.logTimestamp(this);
         } catch {
@@ -240,8 +235,7 @@ export abstract class Logger {
         await this.flushUploads();
     }
 
-    // Single fan-out for error()/uploadLogs() so they can't diverge; returns the
-    // local promise so the caller can await (uploadLogs) or detach (error) it.
+    // Local flush + cross-thread gossip (report-bug path); returns the local promise.
     private flushUploads(): Promise<void> | undefined {
         const own = this.applyOp({ type: "flush" }) as
             | Promise<void>

--- a/src/utils/logging/Logger.ts
+++ b/src/utils/logging/Logger.ts
@@ -4,6 +4,7 @@ import type { LogUploader } from "./LogUploader";
 import type { LogStore } from "./logStore";
 import { LoggerUtils } from "../LoggerUtils";
 import { DetachedPromises } from "../DetachedPromises";
+import type { GossipNode } from "@/utils/GossipNode";
 
 // The context exclusive to each logger
 export type ExclusiveLoggerContext = {
@@ -18,6 +19,13 @@ export type SharedLoggerContext = {
     channelId?: string;
     threadName?: string;
 };
+
+// The Logger's cross-thread vocabulary: operations every logger in the thread tree
+// applies to its OWN state. Type-discriminated like the worker's WorkerRequestPayload
+// (evm/contractExecutor/types.ts:16). Carried opaquely by the GossipNode.
+export type LoggerOp =
+    | { type: "flush" }
+    | { type: "updateContext"; context: SharedLoggerContext };
 
 export type LogLevel = "debug" | "info" | "warn" | "error" | "verbose";
 
@@ -72,6 +80,7 @@ export abstract class Logger {
     protected parent?: Logger;
     protected readonly children: Set<Logger> = new Set();
     private remoteSibling?: RemoteLoggerSibling;
+    private node?: GossipNode;
     private destroyed = false;
     private performanceMonitorStop?: () => void;
 
@@ -134,6 +143,36 @@ export abstract class Logger {
             node = node.parent;
         }
         return undefined;
+    }
+
+    public setGossipNode(node: GossipNode): void {
+        this.node = node;
+    }
+
+    // The node is registered on one logger in the chain; any descendant walks up to
+    // the nearest ancestor that has one. (Mirror of resolveSibling; replaces it in
+    // the Task-4 cutover.)
+    private resolveGossipNode(): GossipNode | undefined {
+        let logger: Logger | undefined = this;
+        while (logger) {
+            if (logger.node) return logger.node;
+            logger = logger.parent;
+        }
+        return undefined;
+    }
+
+    // The SINGLE interpreter of a LoggerOp, applied to THIS thread's logger. Used by
+    // both the local trigger path (flushUploads/updateSharedContext) and the inbound
+    // gossip path (GossipNode onLocal). Returns the flush promise so local callers can
+    // await/detach it; inbound callers ignore the return (fire-and-forget).
+    public applyOp(op: LoggerOp): Promise<void> | void {
+        switch (op.type) {
+            case "flush":
+                return this.logUploader?.uploadLogs();
+            case "updateContext":
+                Object.assign(this.sharedContext, op.context);
+                return;
+        }
     }
 
     protected storeLog(logEntry: LogEntry): void {

--- a/src/utils/logging/Logger.ts
+++ b/src/utils/logging/Logger.ts
@@ -213,7 +213,13 @@ export abstract class Logger {
     }
 
     public async uploadLogs(message: any, ...meta: any[]): Promise<void> {
-        await LoggerUtils.logTimestamp(this);
+        // logTimestamp needs a live Clock; a worker thread has none, so don't let
+        // it abort the flush (log() guards Clock the same way).
+        try {
+            await LoggerUtils.logTimestamp(this);
+        } catch {
+            /* no Clock on this thread — skip the timestamp diagnostic */
+        }
         const localTime = new Date().getTime() / 1000;
         this.warn(message, ...meta, localTime);
         await this.flushUploads();

--- a/src/utils/logging/Logger.ts
+++ b/src/utils/logging/Logger.ts
@@ -111,8 +111,10 @@ export abstract class Logger {
         this.originate({ type: "updateContext", context: update });
     }
 
+    // Bind local delivery here so the generic base never imports Logger.
     public setGossipNode(node: GossipNode): void {
         this.node = node;
+        node.setLocalHandler((op) => this.applyOp(op as LoggerOp));
     }
 
     // Walk up to the nearest ancestor holding the node. Posting to a disposed

--- a/src/utils/logging/Logger.ts
+++ b/src/utils/logging/Logger.ts
@@ -29,14 +29,6 @@ export type LoggerOp =
 
 export type LogLevel = "debug" | "info" | "warn" | "error" | "verbose";
 
-// A logger living in another thread (e.g. the EVM worker) that mirrors this
-// logger's attribution and uploads its own store. Fire-and-forget: the owning
-// logger never awaits it.
-export interface RemoteLoggerSibling {
-    updateSharedContext(context: SharedLoggerContext): void;
-    uploadLogs(message?: string): void;
-}
-
 // Serializable recipe for rebuilding an equivalent logger on a worker thread,
 // where a live Logger can't cross the structured-clone boundary.
 export type SerializableLoggerConfig = {
@@ -79,7 +71,6 @@ export abstract class Logger {
     protected readonly skipWriting: boolean;
     protected parent?: Logger;
     protected readonly children: Set<Logger> = new Set();
-    private remoteSibling?: RemoteLoggerSibling;
     private node?: GossipNode;
     private destroyed = false;
     private performanceMonitorStop?: () => void;
@@ -122,36 +113,21 @@ export abstract class Logger {
     }
 
     public updateSharedContext(update: SharedLoggerContext): void {
-        const newSharedContext = { ...this.sharedContext, ...update };
-        Object.assign(this.sharedContext, newSharedContext);
-        // Forward only the delta: the sibling keeps its own base context (e.g. its
-        // own threadName) and merges the changed fields (e.g. channelId).
-        this.resolveSibling()?.updateSharedContext(update);
-    }
-
-    public setRemoteSibling(sibling: RemoteLoggerSibling): void {
-        this.remoteSibling = sibling;
-    }
-
-    // The sibling is registered on one logger in the chain (the SDK logger, which
-    // may sit mid-tree if a consumer passes their own peerLogger). Walk up to the
-    // nearest ancestor that has one.
-    private resolveSibling(): RemoteLoggerSibling | undefined {
-        let node: Logger | undefined = this;
-        while (node) {
-            if (node.remoteSibling) return node.remoteSibling;
-            node = node.parent;
-        }
-        return undefined;
+        this.applyOp({ type: "updateContext", context: update });
+        this.resolveGossipNode()?.broadcast({
+            type: "updateContext",
+            context: update
+        });
     }
 
     public setGossipNode(node: GossipNode): void {
         this.node = node;
     }
 
-    // The node is registered on one logger in the chain; any descendant walks up to
-    // the nearest ancestor that has one. (Mirror of resolveSibling; replaces it in
-    // the Task-4 cutover.)
+    // The node is registered on one logger in the chain; any descendant walks up
+    // to the nearest ancestor that has one. Broadcasting through it after the
+    // worker is disposed is a silent no-op (postMessage to a closed port does not
+    // throw), so the callers (updateSharedContext/flushUploads) need no guard.
     private resolveGossipNode(): GossipNode | undefined {
         let logger: Logger | undefined = this;
         while (logger) {
@@ -267,8 +243,11 @@ export abstract class Logger {
     // Single fan-out for error()/uploadLogs() so they can't diverge; returns the
     // local promise so the caller can await (uploadLogs) or detach (error) it.
     private flushUploads(): Promise<void> | undefined {
-        this.resolveSibling()?.uploadLogs();
-        return this.logUploader?.uploadLogs();
+        const own = this.applyOp({ type: "flush" }) as
+            | Promise<void>
+            | undefined;
+        this.resolveGossipNode()?.broadcast({ type: "flush" });
+        return own;
     }
 
     public startPerformanceMonitoring(

--- a/src/utils/logging/Logger.ts
+++ b/src/utils/logging/Logger.ts
@@ -108,11 +108,7 @@ export abstract class Logger {
     }
 
     public updateSharedContext(update: SharedLoggerContext): void {
-        this.applyOp({ type: "updateContext", context: update });
-        this.resolveGossipNode()?.broadcast({
-            type: "updateContext",
-            context: update
-        });
+        this.originate({ type: "updateContext", context: update });
     }
 
     public setGossipNode(node: GossipNode): void {
@@ -130,8 +126,7 @@ export abstract class Logger {
         return undefined;
     }
 
-    // Single interpreter for a LoggerOp on this thread; returns the flush promise
-    // so local callers can await/detach it.
+    // Single interpreter for a LoggerOp on this thread; returns the flush promise to await/detach.
     public applyOp(op: LoggerOp): Promise<void> | void {
         switch (op.type) {
             case "flush":
@@ -232,16 +227,14 @@ export abstract class Logger {
         }
         const localTime = new Date().getTime() / 1000;
         this.warn(message, ...meta, localTime);
-        await this.flushUploads();
+        await this.originate({ type: "flush" });
     }
 
-    // Local flush + cross-thread gossip (report-bug path); returns the local promise.
-    private flushUploads(): Promise<void> | undefined {
-        const own = this.applyOp({ type: "flush" }) as
-            | Promise<void>
-            | undefined;
-        this.resolveGossipNode()?.broadcast({ type: "flush" });
-        return own;
+    // Apply an op locally AND gossip it to the rest of the tree; returns the flush promise.
+    private originate(op: LoggerOp): Promise<void> | undefined {
+        const result = this.applyOp(op) as Promise<void> | undefined;
+        this.resolveGossipNode()?.broadcast(op);
+        return result;
     }
 
     public startPerformanceMonitoring(

--- a/src/utils/logging/Logger.ts
+++ b/src/utils/logging/Logger.ts
@@ -164,6 +164,8 @@ export abstract class Logger {
         }
 
         this.logUploader?.destroy();
+        // Drop the borrowed node (owned by WorkerClient/AWorkerHost); never close it here.
+        this.node = undefined;
         this.unlinkAll();
     }
 

--- a/src/utils/logging/Logger.ts
+++ b/src/utils/logging/Logger.ts
@@ -21,6 +21,14 @@ export type SharedLoggerContext = {
 
 export type LogLevel = "debug" | "info" | "warn" | "error" | "verbose";
 
+// A logger living in another thread (e.g. the EVM worker) that mirrors this
+// logger's attribution and uploads its own store. Fire-and-forget: the owning
+// logger never awaits it.
+export interface RemoteLoggerSibling {
+    updateSharedContext(context: SharedLoggerContext): void;
+    uploadLogs(message?: string): void;
+}
+
 // Serializable recipe for rebuilding an equivalent logger on a worker thread,
 // where a live Logger can't cross the structured-clone boundary.
 export type SerializableLoggerConfig = {
@@ -63,6 +71,7 @@ export abstract class Logger {
     protected readonly skipWriting: boolean;
     protected parent?: Logger;
     protected readonly children: Set<Logger> = new Set();
+    private remoteSibling?: RemoteLoggerSibling;
     private destroyed = false;
     private performanceMonitorStop?: () => void;
 
@@ -106,6 +115,25 @@ export abstract class Logger {
     public updateSharedContext(update: SharedLoggerContext): void {
         const newSharedContext = { ...this.sharedContext, ...update };
         Object.assign(this.sharedContext, newSharedContext);
+        // Forward only the delta: the sibling keeps its own base context (e.g. its
+        // own threadName) and merges the changed fields (e.g. channelId).
+        this.resolveSibling()?.updateSharedContext(update);
+    }
+
+    public setRemoteSibling(sibling: RemoteLoggerSibling): void {
+        this.remoteSibling = sibling;
+    }
+
+    // The sibling is registered on one logger in the chain (the SDK logger, which
+    // may sit mid-tree if a consumer passes their own peerLogger). Walk up to the
+    // nearest ancestor that has one.
+    private resolveSibling(): RemoteLoggerSibling | undefined {
+        let node: Logger | undefined = this;
+        while (node) {
+            if (node.remoteSibling) return node.remoteSibling;
+            node = node.parent;
+        }
+        return undefined;
     }
 
     protected storeLog(logEntry: LogEntry): void {
@@ -188,6 +216,9 @@ export abstract class Logger {
         await LoggerUtils.logTimestamp(this);
         const localTime = new Date().getTime() / 1000;
         this.warn(message, ...meta, localTime);
+        this.resolveSibling()?.uploadLogs(
+            typeof message === "string" ? message : undefined
+        );
         await this.logUploader?.uploadLogs();
     }
 

--- a/src/utils/logging/Logger.ts
+++ b/src/utils/logging/Logger.ts
@@ -201,8 +201,8 @@ export abstract class Logger {
     }
     public error(message: any, ...meta: any[]): void {
         this.log("error", message, meta);
-        const prommise = this.logUploader?.uploadLogs();
-        if (prommise) DetachedPromises.collect(prommise);
+        const promise = this.flushUploads();
+        if (promise) DetachedPromises.collect(promise);
     }
     public verbose(message: any, ...meta: any[]): void {
         this.log("verbose", message, meta);
@@ -216,10 +216,14 @@ export abstract class Logger {
         await LoggerUtils.logTimestamp(this);
         const localTime = new Date().getTime() / 1000;
         this.warn(message, ...meta, localTime);
-        this.resolveSibling()?.uploadLogs(
-            typeof message === "string" ? message : undefined
-        );
-        await this.logUploader?.uploadLogs();
+        await this.flushUploads();
+    }
+
+    // Single fan-out for error()/uploadLogs() so they can't diverge; returns the
+    // local promise so the caller can await (uploadLogs) or detach (error) it.
+    private flushUploads(): Promise<void> | undefined {
+        this.resolveSibling()?.uploadLogs();
+        return this.logUploader?.uploadLogs();
     }
 
     public startPerformanceMonitoring(

--- a/src/utils/logging/Logger.ts
+++ b/src/utils/logging/Logger.ts
@@ -16,6 +16,7 @@ export type SharedLoggerContext = {
     peerId?: number;
     peerAddress?: Address;
     channelId?: string;
+    threadName?: string;
 };
 
 export type LogLevel = "debug" | "info" | "warn" | "error" | "verbose";

--- a/src/utils/logging/Logger.ts
+++ b/src/utils/logging/Logger.ts
@@ -21,6 +21,16 @@ export type SharedLoggerContext = {
 
 export type LogLevel = "debug" | "info" | "warn" | "error" | "verbose";
 
+// Serializable recipe for rebuilding an equivalent logger on a worker thread,
+// where a live Logger can't cross the structured-clone boundary.
+export type SerializableLoggerConfig = {
+    sharedContext: SharedLoggerContext;
+    uploadEndpoint: string;
+    apiToken: string;
+    level?: string;
+    skipWriting?: boolean;
+};
+
 export type LogEntry = {
     time: string;
     level: LogLevel;
@@ -50,6 +60,7 @@ export abstract class Logger {
     protected readonly sharedContext: SharedLoggerContext; // shared among all child loggers - imutable reference
     protected logStore: LogStore;
     protected logUploader?: LogUploader;
+    protected readonly skipWriting: boolean;
     protected parent?: Logger;
     protected readonly children: Set<Logger> = new Set();
     private destroyed = false;
@@ -60,13 +71,30 @@ export abstract class Logger {
         sharedContext: SharedLoggerContext,
         level: LogLevel | undefined,
         logStore: LogStore,
-        logUploader?: LogUploader
+        logUploader?: LogUploader,
+        skipWriting: boolean = false
     ) {
         this.context = context;
         this.sharedContext = sharedContext;
         this.level = level;
         this.logStore = logStore;
         this.logUploader = logUploader;
+        this.skipWriting = skipWriting;
+    }
+
+    // Project this logger into a serializable recipe so a worker thread can
+    // rebuild an equivalent sibling (a live Logger can't be structured-cloned).
+    public toSerializableConfig(overrides: {
+        threadName: string;
+    }): SerializableLoggerConfig {
+        const uploaderConfig = this.logUploader?.getConfig();
+        return {
+            sharedContext: { ...this.sharedContext, ...overrides },
+            uploadEndpoint: uploaderConfig?.uploadEndpoint ?? "",
+            apiToken: uploaderConfig?.apiToken ?? "",
+            level: this.level,
+            skipWriting: this.skipWriting
+        };
     }
 
     public child(context: ExclusiveLoggerContext): Logger {

--- a/src/utils/logging/browser/BrowserLogger.ts
+++ b/src/utils/logging/browser/BrowserLogger.ts
@@ -20,7 +20,7 @@ export class BrowserLogger extends Logger {
         level: LogLevel | undefined,
         logStore: LogStore,
         logUploaderOptions?: LogUploaderOptions,
-        private readonly skipWriting: boolean = false
+        skipWriting: boolean = false
     ) {
         const logUploader =
             logUploaderOptions?.logUploader ||
@@ -34,7 +34,14 @@ export class BrowserLogger extends Logger {
                   )
                 : undefined);
 
-        super(context, sharedContext, level, logStore, logUploader);
+        super(
+            context,
+            sharedContext,
+            level,
+            logStore,
+            logUploader,
+            skipWriting
+        );
         logUploader?.setLogger(this);
     }
 

--- a/src/utils/logging/browser/createLogger.ts
+++ b/src/utils/logging/browser/createLogger.ts
@@ -15,10 +15,8 @@ export const createLogger = (
     exclusiveContext: ExclusiveLoggerContext = {},
     options: CreateLoggerOptions = {}
 ): Logger => {
-    const uploadEnabled = Boolean(config.CRASH_LOG_UPLOAD_ENDPOINT);
     const skipWriting = options.skipWriting ?? config.LOG_SKIP_WRITING;
     const maxSize = (config.CRASH_LOG_MAX_SIZE_MB || 10) * 1024 * 1024;
-    const logStore = new LogStore(maxSize, uploadEnabled);
 
     const logUploaderConfig: LogUploaderConfig =
         options.logUploaderConfig ||
@@ -26,6 +24,11 @@ export const createLogger = (
             uploadEndpoint: config.CRASH_LOG_UPLOAD_ENDPOINT,
             apiToken: config.CRASH_LOG_API_TOKEN || ""
         } as LogUploaderConfig);
+
+    // Store-enable follows the EFFECTIVE endpoint (injected recipe or global),
+    // so the worker — whose global config is DEFAULT_CONFIG — still collects logs.
+    const uploadEnabled = Boolean(logUploaderConfig.uploadEndpoint);
+    const logStore = new LogStore(maxSize, uploadEnabled);
 
     return new BrowserLogger(
         exclusiveContext,

--- a/src/utils/logging/index.ts
+++ b/src/utils/logging/index.ts
@@ -3,6 +3,7 @@ import type {
     SharedLoggerContext,
     LoggerDestroyOptions,
     LoggerPerformanceMonitorOptions,
+    LoggerOp,
     Logger
 } from "./Logger";
 import { decodeLogs, decompressFromBase64 } from "./logEncoder";
@@ -15,6 +16,7 @@ export type {
     SharedLoggerContext,
     LoggerDestroyOptions,
     LoggerPerformanceMonitorOptions,
+    LoggerOp,
     CreateLoggerOptions
 };
 export { decodeLogs, decompressFromBase64 };

--- a/src/utils/logging/node/NodeLogger.ts
+++ b/src/utils/logging/node/NodeLogger.ts
@@ -23,7 +23,7 @@ export class NodeLogger extends Logger {
         logStore: LogStore,
         logUploaderOptions?: LogUploaderOptions,
         excludedTags: Set<string> = new Set(),
-        private readonly skipWriting: boolean = false
+        skipWriting: boolean = false
     ) {
         const logUploader =
             logUploaderOptions?.logUploader ||
@@ -37,7 +37,14 @@ export class NodeLogger extends Logger {
                   )
                 : undefined);
 
-        super(context, sharedContext, level, logStore, logUploader);
+        super(
+            context,
+            sharedContext,
+            level,
+            logStore,
+            logUploader,
+            skipWriting
+        );
         this.excludedTags = excludedTags;
         logUploader?.setLogger(this);
     }

--- a/src/utils/logging/node/createLogger.ts
+++ b/src/utils/logging/node/createLogger.ts
@@ -15,10 +15,8 @@ export const createLogger = (
     exclusiveContext: ExclusiveLoggerContext = {},
     options: CreateLoggerOptions = {}
 ): Logger => {
-    const uploadEnabled = Boolean(config.CRASH_LOG_UPLOAD_ENDPOINT);
     const skipWriting = options.skipWriting ?? config.LOG_SKIP_WRITING;
     const maxSize = (config.CRASH_LOG_MAX_SIZE_MB || 10) * 1024 * 1024;
-    const logStore = new LogStore(maxSize, uploadEnabled);
 
     const logUploaderConfig: LogUploaderConfig =
         options.logUploaderConfig ||
@@ -26,6 +24,11 @@ export const createLogger = (
             uploadEndpoint: config.CRASH_LOG_UPLOAD_ENDPOINT,
             apiToken: config.CRASH_LOG_API_TOKEN || ""
         } as LogUploaderConfig);
+
+    // Store-enable follows the EFFECTIVE endpoint (injected recipe or global),
+    // so the worker — whose global config is DEFAULT_CONFIG — still collects logs.
+    const uploadEnabled = Boolean(logUploaderConfig.uploadEndpoint);
+    const logStore = new LogStore(maxSize, uploadEnabled);
 
     const logLevel = options.level ?? NodeLogger.parseLogLevelFromArgs();
     const excludedTags =

--- a/src/utils/node/workerTransport.ts
+++ b/src/utils/node/workerTransport.ts
@@ -49,7 +49,10 @@ export function createWorkerClientTransport(entry: {
     const port1 = gossip.port1;
     const gossipNeighbour: Neighbour = {
         post: (msg) => port1.postMessage(msg),
-        subscribe: (handler) => port1.on("message", handler)
+        subscribe: (handler) => {
+            port1.on("message", handler);
+            return () => port1.off("message", handler);
+        }
     };
 
     return {
@@ -85,7 +88,10 @@ export function createWorkerHostTransport(): WorkerHostTransport {
     ).gossipPort;
     const gossipNeighbour: Neighbour = {
         post: (msg) => gossipPort.postMessage(msg),
-        subscribe: (handler) => gossipPort.on("message", handler)
+        subscribe: (handler) => {
+            gossipPort.on("message", handler);
+            return () => gossipPort.off("message", handler);
+        }
     };
     let messageHandler:
         | ((envelope: WorkerEnvelope<unknown>) => void)

--- a/src/utils/node/workerTransport.ts
+++ b/src/utils/node/workerTransport.ts
@@ -1,0 +1,102 @@
+import type { Neighbour } from "@/utils/GossipNode";
+import type {
+    WorkerClientTransport,
+    WorkerEnvelope,
+    WorkerHostTransport,
+    WorkerResult
+} from "@/utils/worker/types";
+
+// Spawn a worker from a script directory + basename (the .js/.ts + ts-node
+// resolution mirrors the prior ContractExecutor runtime), with a dedicated gossip
+// MessageChannel whose worker end is transferred via workerData.
+export function createWorkerClientTransport(entry: {
+    dir: string;
+    basename: string;
+}): WorkerClientTransport {
+    const nodeRequire = typeof require === "function" ? require : undefined;
+    if (!nodeRequire) {
+        throw new Error("Node worker_threads require() is unavailable");
+    }
+    const path = nodeRequire("node:path") as typeof import("node:path");
+    const fs = nodeRequire("node:fs") as typeof import("node:fs");
+    const { Worker, MessageChannel } = nodeRequire(
+        "node:worker_threads"
+    ) as typeof import("node:worker_threads");
+
+    const jsPath = path.join(entry.dir, `${entry.basename}.js`);
+    const tsPath = path.join(entry.dir, `${entry.basename}.ts`);
+    const workerPath = fs.existsSync(jsPath) ? jsPath : tsPath;
+    const execArgv = workerPath.endsWith(".ts")
+        ? ["-r", "ts-node/register", "-r", "tsconfig-paths/register"]
+        : undefined;
+
+    const gossip = new MessageChannel();
+    const worker = new Worker(workerPath, {
+        execArgv,
+        workerData: { gossipPort: gossip.port2 },
+        transferList: [gossip.port2]
+    });
+
+    let messageHandler: ((r: WorkerResult<unknown>) => void) | undefined;
+    let errorHandler: ((e: Error) => void) | undefined;
+    worker.on("message", (m) => messageHandler?.(m as WorkerResult<unknown>));
+    worker.on("error", (e) => errorHandler?.(e));
+    worker.on("exit", (code: number) => {
+        if (code !== 0) {
+            errorHandler?.(new Error(`Worker exited with ${code}`));
+        }
+    });
+
+    const port1 = gossip.port1;
+    const gossipNeighbour: Neighbour = {
+        post: (msg) => port1.postMessage(msg),
+        subscribe: (handler) => port1.on("message", handler)
+    };
+
+    return {
+        post: (envelope) => worker.postMessage(envelope),
+        onMessage: (handler) => {
+            messageHandler = handler;
+        },
+        onError: (handler) => {
+            errorHandler = handler;
+        },
+        terminate: () => {
+            port1.close();
+            return worker.terminate();
+        },
+        gossipNeighbour
+    };
+}
+
+export function createWorkerHostTransport(): WorkerHostTransport {
+    const nodeRequire = typeof require === "function" ? require : undefined;
+    if (!nodeRequire) {
+        throw new Error("Node worker_threads require() is unavailable");
+    }
+    const { parentPort, workerData } = nodeRequire(
+        "node:worker_threads"
+    ) as typeof import("node:worker_threads");
+    if (!parentPort) {
+        throw new Error("Worker host requires a parent port");
+    }
+    const rpc = parentPort;
+    const gossipPort = (
+        workerData as { gossipPort: import("node:worker_threads").MessagePort }
+    ).gossipPort;
+    const gossipNeighbour: Neighbour = {
+        post: (msg) => gossipPort.postMessage(msg),
+        subscribe: (handler) => gossipPort.on("message", handler)
+    };
+    let messageHandler:
+        | ((envelope: WorkerEnvelope<unknown>) => void)
+        | undefined;
+    rpc.on("message", (m) => messageHandler?.(m as WorkerEnvelope<unknown>));
+    return {
+        post: (result) => rpc.postMessage(result),
+        onMessage: (handler) => {
+            messageHandler = handler;
+        },
+        gossipNeighbour
+    };
+}

--- a/src/utils/node/workerTransport.ts
+++ b/src/utils/node/workerTransport.ts
@@ -6,9 +6,8 @@ import type {
     WorkerResult
 } from "@/utils/worker/types";
 
-// Spawn a worker from a script directory + basename (the .js/.ts + ts-node
-// resolution mirrors the prior ContractExecutor runtime), with a dedicated gossip
-// MessageChannel whose worker end is transferred via workerData.
+// Spawn a worker from dir + basename (.js/.ts + ts-node resolution mirrors the prior
+// runtime); its gossip port is transferred via workerData.
 export function createWorkerClientTransport(entry: {
     dir: string;
     basename: string;

--- a/src/utils/worker/AWorkerHost.ts
+++ b/src/utils/worker/AWorkerHost.ts
@@ -2,9 +2,8 @@ import { GossipNode } from "@/utils/GossipNode";
 import type { Logger, LoggerOp } from "@/utils/logging/Logger";
 import type { WorkerEnvelope, WorkerHostTransport } from "./types";
 
-// Worker-side base: envelope framing (receive → handle → reply), a GossipNode
-// (neighbour = parent port), logger, and the ready post. Subclasses implement
-// `handle`. Posts {type:"ready"} at end of construction, so construction must be sync.
+// Worker-side base: envelope framing (receive → handle → reply), a GossipNode, logger,
+// ready post. Subclasses implement `handle`. Posts {type:"ready"} in ctor, so ctor must be sync.
 export abstract class AWorkerHost<TRequest, TResult> {
     private readonly transport: WorkerHostTransport;
     private readonly gossip: GossipNode;

--- a/src/utils/worker/AWorkerHost.ts
+++ b/src/utils/worker/AWorkerHost.ts
@@ -2,11 +2,9 @@ import { GossipNode } from "@/utils/GossipNode";
 import type { Logger, LoggerOp } from "@/utils/logging/Logger";
 import type { WorkerEnvelope, WorkerHostTransport } from "./types";
 
-// Worker-side base for a worker runtime: owns the envelope framing (receive →
-// handle → reply), a GossipNode (neighbour = parent port), logger attachment, and
-// the ready post. Abstract — subclasses implement `handle`. Note: this class posts
-// `{type:"ready"}` at the end of construction, so subclass construction must be
-// synchronous and the consumer's first request should be its `init`.
+// Worker-side base: envelope framing (receive → handle → reply), a GossipNode
+// (neighbour = parent port), logger, and the ready post. Subclasses implement
+// `handle`. Posts {type:"ready"} at end of construction, so construction must be sync.
 export abstract class AWorkerHost<TRequest, TResult> {
     private readonly transport: WorkerHostTransport;
     private readonly gossip: GossipNode;

--- a/src/utils/worker/AWorkerHost.ts
+++ b/src/utils/worker/AWorkerHost.ts
@@ -1,0 +1,55 @@
+import { GossipNode } from "@/utils/GossipNode";
+import type { Logger, LoggerOp } from "@/utils/logging/Logger";
+import type { WorkerEnvelope, WorkerHostTransport } from "./types";
+
+// Worker-side base for a worker runtime: owns the envelope framing (receive →
+// handle → reply), a GossipNode (neighbour = parent port), logger attachment, and
+// the ready post. Abstract — subclasses implement `handle`. Note: this class posts
+// `{type:"ready"}` at the end of construction, so subclass construction must be
+// synchronous and the consumer's first request should be its `init`.
+export abstract class AWorkerHost<TRequest, TResult> {
+    private readonly transport: WorkerHostTransport;
+    private readonly gossip: GossipNode;
+    private logger?: Logger;
+
+    constructor(transport: WorkerHostTransport) {
+        this.transport = transport;
+        this.gossip = new GossipNode((op) =>
+            this.logger?.applyOp(op as LoggerOp)
+        );
+        this.gossip.addNeighbour(transport.gossipNeighbour);
+        transport.onMessage((envelope) => {
+            void this.dispatch(envelope as WorkerEnvelope<TRequest>);
+        });
+        transport.post({ type: "ready" });
+    }
+
+    // Subclasses call this once their real logger exists (e.g. after init).
+    protected attachLogger(logger: Logger): void {
+        this.logger = logger;
+        logger.setGossipNode(this.gossip);
+    }
+
+    protected abstract handle(payload: TRequest): Promise<TResult>;
+
+    private async dispatch(envelope: WorkerEnvelope<TRequest>): Promise<void> {
+        const { requestId, payload } = envelope;
+        try {
+            const result = await this.handle(payload);
+            this.transport.post({ requestId, ok: true, result });
+        } catch (error) {
+            const err =
+                error instanceof Error ? error : new Error(String(error));
+            this.transport.post({
+                requestId,
+                ok: false,
+                error: {
+                    message: err.message,
+                    name: err.name,
+                    stack: err.stack,
+                    data: (err as { data?: string }).data
+                }
+            });
+        }
+    }
+}

--- a/src/utils/worker/AWorkerHost.ts
+++ b/src/utils/worker/AWorkerHost.ts
@@ -1,8 +1,7 @@
 import { GossipNode } from "@/utils/GossipNode";
-import type { Logger, LoggerOp } from "@/utils/logging/Logger";
 import type { WorkerEnvelope, WorkerHostTransport } from "./types";
 
-// Worker-side base: envelope framing (receive → handle → reply), a GossipNode, logger,
+// Worker-side base: envelope framing (receive → handle → reply), a GossipNode,
 // ready post. Subclasses implement `handle`. Posts {type:"ready"} in ctor, so ctor must be sync.
 export abstract class AWorkerHost<TRequest, TResult> {
     private readonly transport: WorkerHostTransport;
@@ -21,10 +20,9 @@ export abstract class AWorkerHost<TRequest, TResult> {
         transport.post({ type: "ready" });
     }
 
-    // Subclasses call this once their real logger exists (e.g. after init).
-    protected attachLogger(logger: Logger): void {
-        this.gossip.setLocalHandler((op) => logger.applyOp(op as LoggerOp));
-        logger.setGossipNode(this.gossip);
+    // Gossip edge to the parent; subclass self-wires (logger.setGossipNode).
+    protected get gossipNode(): GossipNode {
+        return this.gossip;
     }
 
     // Symmetric with the client end; a shared node stays up for siblings.

--- a/src/utils/worker/AWorkerHost.ts
+++ b/src/utils/worker/AWorkerHost.ts
@@ -7,13 +7,13 @@ import type { WorkerEnvelope, WorkerHostTransport } from "./types";
 export abstract class AWorkerHost<TRequest, TResult> {
     private readonly transport: WorkerHostTransport;
     private readonly gossip: GossipNode;
-    private logger?: Logger;
+    private readonly ownsGossip: boolean;
 
-    constructor(transport: WorkerHostTransport) {
+    // `gossip` injected → shared with sibling edges (caller owns lifecycle); omitted → owns a fresh node.
+    constructor(transport: WorkerHostTransport, gossip?: GossipNode) {
         this.transport = transport;
-        this.gossip = new GossipNode((op) =>
-            this.logger?.applyOp(op as LoggerOp)
-        );
+        this.ownsGossip = gossip === undefined;
+        this.gossip = gossip ?? new GossipNode();
         this.gossip.addNeighbour(transport.gossipNeighbour);
         transport.onMessage((envelope) => {
             void this.dispatch(envelope as WorkerEnvelope<TRequest>);
@@ -23,14 +23,14 @@ export abstract class AWorkerHost<TRequest, TResult> {
 
     // Subclasses call this once their real logger exists (e.g. after init).
     protected attachLogger(logger: Logger): void {
-        this.logger = logger;
+        this.gossip.setLocalHandler((op) => logger.applyOp(op as LoggerOp));
         logger.setGossipNode(this.gossip);
     }
 
-    // Symmetric with the client end; only load-bearing for a reused host (the thread is
-    // otherwise discarded on terminate).
+    // Symmetric with the client end; a shared node stays up for siblings.
     dispose(): void {
-        this.gossip.close();
+        if (this.ownsGossip) this.gossip.close();
+        else this.gossip.removeNeighbour(this.transport.gossipNeighbour);
     }
 
     protected abstract handle(payload: TRequest): Promise<TResult>;

--- a/src/utils/worker/AWorkerHost.ts
+++ b/src/utils/worker/AWorkerHost.ts
@@ -27,6 +27,12 @@ export abstract class AWorkerHost<TRequest, TResult> {
         logger.setGossipNode(this.gossip);
     }
 
+    // Symmetric with the client end; only load-bearing for a reused host (the thread is
+    // otherwise discarded on terminate).
+    dispose(): void {
+        this.gossip.close();
+    }
+
     protected abstract handle(payload: TRequest): Promise<TResult>;
 
     private async dispatch(envelope: WorkerEnvelope<TRequest>): Promise<void> {

--- a/src/utils/worker/WorkerClient.ts
+++ b/src/utils/worker/WorkerClient.ts
@@ -1,0 +1,97 @@
+import { GossipNode } from "@/utils/GossipNode";
+import type { Logger, LoggerOp } from "@/utils/logging/Logger";
+import type { WorkerClientTransport, WorkerResult } from "./types";
+
+// Main-side base for a worker runtime: owns the ready handshake, requestId/pending
+// request-response correlation, a GossipNode (its sole neighbour is the worker's
+// gossip port), logger attachment, and dispose. Concrete and composed (the EVM
+// executor already extends AContractExecutor, so it holds a WorkerClient).
+export class WorkerClient<TRequest, TResult> {
+    private nextRequestId = 1;
+    private readonly pending = new Map<
+        number,
+        { resolve: (result: TResult) => void; reject: (error: Error) => void }
+    >();
+    private readonly transport: WorkerClientTransport;
+    private readonly gossip: GossipNode;
+    private logger?: Logger;
+    private readonly ready: Promise<void>;
+    private resolveReady!: () => void;
+    private rejectReady!: (error: Error) => void;
+
+    constructor(transport: WorkerClientTransport) {
+        this.transport = transport;
+        this.gossip = new GossipNode((op) =>
+            this.logger?.applyOp(op as LoggerOp)
+        );
+        this.gossip.addNeighbour(transport.gossipNeighbour);
+        this.ready = new Promise<void>((resolve, reject) => {
+            this.resolveReady = resolve;
+            this.rejectReady = reject;
+        });
+        transport.onMessage((result) =>
+            this.handleResult(result as WorkerResult<TResult>)
+        );
+        transport.onError((error) => {
+            this.rejectReady(error);
+            this.rejectAll(error);
+        });
+    }
+
+    // Wire a logger's gossip into this client's node (main-side composition root).
+    attachLogger(logger: Logger): void {
+        this.logger = logger;
+        logger.setGossipNode(this.gossip);
+    }
+
+    // Send a request and resolve with the worker's result. Waits for the worker's
+    // ready handshake first, so callers never sequence it manually.
+    async request(payload: TRequest): Promise<TResult> {
+        await this.ready;
+        const requestId = this.nextRequestId++;
+        return new Promise<TResult>((resolve, reject) => {
+            this.pending.set(requestId, { resolve, reject });
+            try {
+                this.transport.post({ requestId, payload });
+            } catch (error) {
+                this.pending.delete(requestId);
+                reject(
+                    error instanceof Error ? error : new Error(String(error))
+                );
+            }
+        });
+    }
+
+    async dispose(): Promise<void> {
+        const error = new Error("Worker client disposed");
+        this.rejectReady(error);
+        this.rejectAll(error);
+        await this.transport.terminate();
+    }
+
+    private handleResult(result: WorkerResult<TResult>): void {
+        if ("type" in result) {
+            this.resolveReady();
+            return;
+        }
+        const pending = this.pending.get(result.requestId);
+        if (!pending) return;
+        this.pending.delete(result.requestId);
+        if (result.ok) {
+            pending.resolve(result.result);
+            return;
+        }
+        const error = new Error(result.error.message);
+        error.name = result.error.name || error.name;
+        error.stack = result.error.stack || error.stack;
+        (error as { data?: string }).data = result.error.data;
+        pending.reject(error);
+    }
+
+    private rejectAll(error: Error): void {
+        for (const pending of this.pending.values()) {
+            pending.reject(error);
+        }
+        this.pending.clear();
+    }
+}

--- a/src/utils/worker/WorkerClient.ts
+++ b/src/utils/worker/WorkerClient.ts
@@ -12,16 +12,16 @@ export class WorkerClient<TRequest, TResult> {
     >();
     private readonly transport: WorkerClientTransport;
     private readonly gossip: GossipNode;
-    private logger?: Logger;
+    private readonly ownsGossip: boolean;
     private readonly ready: Promise<void>;
     private resolveReady!: () => void;
     private rejectReady!: (error: Error) => void;
 
-    constructor(transport: WorkerClientTransport) {
+    // `gossip` injected → shared with sibling edges (caller owns lifecycle); omitted → owns a fresh node.
+    constructor(transport: WorkerClientTransport, gossip?: GossipNode) {
         this.transport = transport;
-        this.gossip = new GossipNode((op) =>
-            this.logger?.applyOp(op as LoggerOp)
-        );
+        this.ownsGossip = gossip === undefined;
+        this.gossip = gossip ?? new GossipNode();
         this.gossip.addNeighbour(transport.gossipNeighbour);
         this.ready = new Promise<void>((resolve, reject) => {
             this.resolveReady = resolve;
@@ -40,7 +40,7 @@ export class WorkerClient<TRequest, TResult> {
     }
 
     attachLogger(logger: Logger): void {
-        this.logger = logger;
+        this.gossip.setLocalHandler((op) => logger.applyOp(op as LoggerOp));
         logger.setGossipNode(this.gossip);
     }
 
@@ -65,8 +65,9 @@ export class WorkerClient<TRequest, TResult> {
         const error = new Error("Worker client disposed");
         this.rejectReady(error);
         this.rejectAll(error);
-        // Un-wire the gossip edge before the transport closes the port.
-        this.gossip.close();
+        // Un-wire this edge before the transport closes the port; a shared node stays up for siblings.
+        if (this.ownsGossip) this.gossip.close();
+        else this.gossip.removeNeighbour(this.transport.gossipNeighbour);
         await this.transport.terminate();
     }
 

--- a/src/utils/worker/WorkerClient.ts
+++ b/src/utils/worker/WorkerClient.ts
@@ -65,6 +65,8 @@ export class WorkerClient<TRequest, TResult> {
         const error = new Error("Worker client disposed");
         this.rejectReady(error);
         this.rejectAll(error);
+        // Un-wire the gossip edge before the transport closes the port.
+        this.gossip.close();
         await this.transport.terminate();
     }
 

--- a/src/utils/worker/WorkerClient.ts
+++ b/src/utils/worker/WorkerClient.ts
@@ -1,9 +1,8 @@
 import { GossipNode } from "@/utils/GossipNode";
-import type { Logger, LoggerOp } from "@/utils/logging/Logger";
 import type { WorkerClientTransport, WorkerResult } from "./types";
 
 // Main-side base for a worker runtime: ready handshake, requestId/pending
-// correlation, a GossipNode (neighbour = worker's gossip port), logger, dispose.
+// correlation, a GossipNode (neighbour = worker's gossip port), dispose.
 export class WorkerClient<TRequest, TResult> {
     private nextRequestId = 1;
     private readonly pending = new Map<
@@ -39,9 +38,9 @@ export class WorkerClient<TRequest, TResult> {
         });
     }
 
-    attachLogger(logger: Logger): void {
-        this.gossip.setLocalHandler((op) => logger.applyOp(op as LoggerOp));
-        logger.setGossipNode(this.gossip);
+    // Gossip edge to the worker; consumers self-wire (logger.setGossipNode).
+    get gossipNode(): GossipNode {
+        return this.gossip;
     }
 
     // Send a request; awaits the ready handshake first so callers needn't sequence it.

--- a/src/utils/worker/WorkerClient.ts
+++ b/src/utils/worker/WorkerClient.ts
@@ -2,10 +2,8 @@ import { GossipNode } from "@/utils/GossipNode";
 import type { Logger, LoggerOp } from "@/utils/logging/Logger";
 import type { WorkerClientTransport, WorkerResult } from "./types";
 
-// Main-side base for a worker runtime: owns the ready handshake, requestId/pending
-// request-response correlation, a GossipNode (its sole neighbour is the worker's
-// gossip port), logger attachment, and dispose. Concrete and composed (the EVM
-// executor already extends AContractExecutor, so it holds a WorkerClient).
+// Main-side base for a worker runtime: ready handshake, requestId/pending
+// correlation, a GossipNode (neighbour = worker's gossip port), logger, dispose.
 export class WorkerClient<TRequest, TResult> {
     private nextRequestId = 1;
     private readonly pending = new Map<
@@ -29,6 +27,9 @@ export class WorkerClient<TRequest, TResult> {
             this.resolveReady = resolve;
             this.rejectReady = reject;
         });
+        // dispose()/onError reject `ready`; mark it handled so a never-awaited
+        // rejection can't surface as an unhandledRejection.
+        void this.ready.catch(() => {});
         transport.onMessage((result) =>
             this.handleResult(result as WorkerResult<TResult>)
         );
@@ -38,14 +39,12 @@ export class WorkerClient<TRequest, TResult> {
         });
     }
 
-    // Wire a logger's gossip into this client's node (main-side composition root).
     attachLogger(logger: Logger): void {
         this.logger = logger;
         logger.setGossipNode(this.gossip);
     }
 
-    // Send a request and resolve with the worker's result. Waits for the worker's
-    // ready handshake first, so callers never sequence it manually.
+    // Send a request; awaits the ready handshake first so callers needn't sequence it.
     async request(payload: TRequest): Promise<TResult> {
         await this.ready;
         const requestId = this.nextRequestId++;

--- a/src/utils/worker/types.ts
+++ b/src/utils/worker/types.ts
@@ -15,8 +15,7 @@ export type WorkerResult<TResult> =
     | { requestId: number; ok: true; result: TResult }
     | { requestId: number; ok: false; error: SerializedError };
 
-// The two seams the @platform layer provides. `gossipNeighbour` is the dedicated
-// gossip port; post/onMessage are the directed RPC pipe.
+// The seams the @platform layer provides: a gossip port + the directed RPC pipe.
 export type WorkerClientTransport = {
     post: (envelope: WorkerEnvelope<unknown>) => void;
     onMessage: (handler: (result: WorkerResult<unknown>) => void) => void;
@@ -25,8 +24,7 @@ export type WorkerClientTransport = {
     gossipNeighbour: Neighbour;
 };
 
-// The host is terminated from the client side (WorkerClientTransport.terminate), so
-// the host transport intentionally has no `terminate`.
+// Host is terminated from the client side, so it has no `terminate`.
 export type WorkerHostTransport = {
     post: (result: WorkerResult<unknown>) => void;
     onMessage: (handler: (envelope: WorkerEnvelope<unknown>) => void) => void;

--- a/src/utils/worker/types.ts
+++ b/src/utils/worker/types.ts
@@ -1,0 +1,34 @@
+import type { Neighbour } from "@/utils/GossipNode";
+
+// Directed request/response framing, generic over the consumer's payload.
+export type WorkerEnvelope<TPayload> = { requestId: number; payload: TPayload };
+
+export type SerializedError = {
+    message: string;
+    name?: string;
+    stack?: string;
+    data?: string;
+};
+
+export type WorkerResult<TResult> =
+    | { type: "ready" }
+    | { requestId: number; ok: true; result: TResult }
+    | { requestId: number; ok: false; error: SerializedError };
+
+// The two seams the @platform layer provides. `gossipNeighbour` is the dedicated
+// gossip port; post/onMessage are the directed RPC pipe.
+export type WorkerClientTransport = {
+    post: (envelope: WorkerEnvelope<unknown>) => void;
+    onMessage: (handler: (result: WorkerResult<unknown>) => void) => void;
+    onError: (handler: (error: Error) => void) => void;
+    terminate: () => Promise<unknown> | unknown;
+    gossipNeighbour: Neighbour;
+};
+
+// The host is terminated from the client side (WorkerClientTransport.terminate), so
+// the host transport intentionally has no `terminate`.
+export type WorkerHostTransport = {
+    post: (result: WorkerResult<unknown>) => void;
+    onMessage: (handler: (envelope: WorkerEnvelope<unknown>) => void) => void;
+    gossipNeighbour: Neighbour;
+};

--- a/test/browser/run-worker-contract-executor.mjs
+++ b/test/browser/run-worker-contract-executor.mjs
@@ -48,6 +48,10 @@ const server = await createServer({
                 projectRoot,
                 "src/evm/browser/precompileModuleLoader.ts"
             ),
+            "@platform/workerTransport": path.join(
+                projectRoot,
+                "src/utils/browser/workerTransport.ts"
+            ),
             "@": path.join(projectRoot, "src"),
             "@test": path.join(projectRoot, "test"),
             "@typechain-types": path.join(projectRoot, "typechain-types")

--- a/test/evm/WorkerLoggerUpload.test.ts
+++ b/test/evm/WorkerLoggerUpload.test.ts
@@ -5,6 +5,7 @@ import { AddressInfo } from "node:net";
 import { createContractExecutorFactory } from "@/evm";
 import WorkerContractExecutor from "@/evm/contractExecutor/WorkerContractExecutor";
 import { createLogger } from "@/utils";
+import { decodeLogs, decompressFromBase64 } from "@/utils/logging/logEncoder";
 
 describe("worker logger upload", function () {
     this.timeout(15000); // worker spawn + axios jitter (0-3s) + retry
@@ -75,6 +76,18 @@ describe("worker logger upload", function () {
                 "0x1111111111111111111111111111111111111111"
             );
             expect(received[0].channelId).to.equal(CHANNEL_ID);
+
+            // The envelope must carry real worker logs, not []. The flush itself
+            // records a "worker report-bug flush" line, so it's always present.
+            const entries = decodeLogs(
+                decompressFromBase64(received[0].compressedLogs as string)
+            );
+            expect(entries.length).to.be.greaterThan(0);
+            expect(
+                entries.some((e) =>
+                    e.message.includes("worker report-bug flush")
+                )
+            ).to.equal(true);
         } finally {
             await executor.dispose();
             await new Promise<void>((r) => server.close(() => r()));

--- a/test/evm/WorkerLoggerUpload.test.ts
+++ b/test/evm/WorkerLoggerUpload.test.ts
@@ -32,9 +32,8 @@ describe("worker logger upload", function () {
         const port = (server.address() as AddressInfo).port;
         const endpoint = `http://127.0.0.1:${port}/logs/upload`;
 
-        // Factory derives the worker's "evm" recipe from this logger. This
-        // logger's own threadName ("sdk") must NOT clobber the worker's "evm"
-        // when context is later forwarded.
+        // Factory derives the worker's "evm" recipe from this logger; its own
+        // threadName ("sdk") must NOT clobber the worker's "evm".
         const logger = createLogger(
             {
                 peerAddress:
@@ -62,16 +61,13 @@ describe("worker logger upload", function () {
             .updateSharedContext({ channelId: CHANNEL_ID });
 
         try {
-            // Force a worker-side log so the flush proves the worker's OWN
-            // store crosses the gossip edge (not an empty upload). Deploying the
-            // INVALID opcode (0xfe) faults; the worker records a
-            // "Contract call execution failed" warn, then the call rejects.
+            // Force a worker-side log (deploy INVALID opcode 0xfe → warn) so the
+            // flush proves the worker's OWN store crosses the gossip edge.
             await executor.deploy("0xfe").catch(() => {});
 
             await logger.uploadLogs("report-bug flush");
 
-            // The main-thread trigger now flushes BOTH threads via gossip; the
-            // main `sdk` upload may also arrive, in any order.
+            // The main-thread trigger flushes BOTH threads; uploads arrive in any order.
             const deadline = Date.now() + 10000;
             const findEvm = () => received.find((r) => r.threadName === "evm");
             while (!findEvm() && Date.now() < deadline) {

--- a/test/evm/WorkerLoggerUpload.test.ts
+++ b/test/evm/WorkerLoggerUpload.test.ts
@@ -1,0 +1,68 @@
+import { expect } from "chai";
+import http from "node:http";
+import { AddressInfo } from "node:net";
+
+import { createContractExecutorFactory } from "@/evm";
+import WorkerContractExecutor from "@/evm/contractExecutor/WorkerContractExecutor";
+import { createLogger } from "@/utils";
+
+describe("worker logger upload", function () {
+    this.timeout(15000); // worker spawn + axios jitter (0-3s) + retry
+
+    it("uploads worker logs tagged threadName 'evm'", async () => {
+        const received: Array<Record<string, unknown>> = [];
+        const server = http.createServer((req, res) => {
+            let body = "";
+            req.on("data", (c) => (body += c));
+            req.on("end", () => {
+                try {
+                    received.push(JSON.parse(body));
+                } catch {
+                    received.push({ unparseable: body });
+                }
+                res.writeHead(200, { "Content-Type": "application/json" });
+                res.end("{}");
+            });
+        });
+        await new Promise<void>((r) => server.listen(0, r));
+        const port = (server.address() as AddressInfo).port;
+        const endpoint = `http://127.0.0.1:${port}/logs/upload`;
+
+        // Factory derives the worker's "evm" recipe from this logger.
+        const logger = createLogger(
+            {
+                peerAddress: "0x1111111111111111111111111111111111111111" as any
+            },
+            { component: "Test" },
+            {
+                logUploaderConfig: { uploadEndpoint: endpoint, apiToken: "" },
+                level: "info"
+            }
+        );
+
+        const executor = (await createContractExecutorFactory({
+            dedicatedThread: true,
+            customPrecompiles: [],
+            logger
+        })) as WorkerContractExecutor;
+
+        try {
+            await executor.uploadLogs();
+
+            // Detached upload has up to 3s jitter before it reaches the server.
+            const deadline = Date.now() + 10000;
+            while (received.length === 0 && Date.now() < deadline) {
+                await new Promise((r) => setTimeout(r, 100));
+            }
+
+            expect(received.length).to.be.greaterThan(0);
+            expect(received[0].threadName).to.equal("evm");
+            expect(received[0].peerAddress).to.equal(
+                "0x1111111111111111111111111111111111111111"
+            );
+        } finally {
+            await executor.dispose();
+            await new Promise<void>((r) => server.close(() => r()));
+        }
+    });
+});

--- a/test/evm/WorkerLoggerUpload.test.ts
+++ b/test/evm/WorkerLoggerUpload.test.ts
@@ -52,7 +52,7 @@ describe("worker logger upload", function () {
             customPrecompiles: [],
             logger
         })) as WorkerContractExecutor;
-        executor.attachLogger(logger);
+        logger.setGossipNode(executor.gossipNode);
 
         // channelId is unknown at worker spawn; it arrives later via a child
         // logger (mirrors StateManager.setChannelId) and must reach the worker.

--- a/test/evm/WorkerLoggerUpload.test.ts
+++ b/test/evm/WorkerLoggerUpload.test.ts
@@ -9,7 +9,10 @@ import { createLogger } from "@/utils";
 describe("worker logger upload", function () {
     this.timeout(15000); // worker spawn + axios jitter (0-3s) + retry
 
-    it("uploads worker logs tagged threadName 'evm'", async () => {
+    const CHANNEL_ID =
+        "0x2222222222222222222222222222222222222222222222222222222222222222";
+
+    it("tags worker uploads with threadName 'evm' and the pushed channelId", async () => {
         const received: Array<Record<string, unknown>> = [];
         const server = http.createServer((req, res) => {
             let body = "";
@@ -28,10 +31,14 @@ describe("worker logger upload", function () {
         const port = (server.address() as AddressInfo).port;
         const endpoint = `http://127.0.0.1:${port}/logs/upload`;
 
-        // Factory derives the worker's "evm" recipe from this logger.
+        // Factory derives the worker's "evm" recipe from this logger. This
+        // logger's own threadName ("sdk") must NOT clobber the worker's "evm"
+        // when context is later forwarded.
         const logger = createLogger(
             {
-                peerAddress: "0x1111111111111111111111111111111111111111" as any
+                peerAddress:
+                    "0x1111111111111111111111111111111111111111" as any,
+                threadName: "sdk"
             },
             { component: "Test" },
             {
@@ -45,6 +52,13 @@ describe("worker logger upload", function () {
             customPrecompiles: [],
             logger
         })) as WorkerContractExecutor;
+        logger.setRemoteSibling(executor);
+
+        // channelId is unknown at worker spawn; it arrives later via a child
+        // logger (mirrors StateManager.setChannelId) and must reach the worker.
+        logger
+            .child({ component: "StateManager" })
+            .updateSharedContext({ channelId: CHANNEL_ID });
 
         try {
             await executor.uploadLogs();
@@ -60,6 +74,7 @@ describe("worker logger upload", function () {
             expect(received[0].peerAddress).to.equal(
                 "0x1111111111111111111111111111111111111111"
             );
+            expect(received[0].channelId).to.equal(CHANNEL_ID);
         } finally {
             await executor.dispose();
             await new Promise<void>((r) => server.close(() => r()));

--- a/test/evm/WorkerLoggerUpload.test.ts
+++ b/test/evm/WorkerLoggerUpload.test.ts
@@ -53,7 +53,7 @@ describe("worker logger upload", function () {
             customPrecompiles: [],
             logger
         })) as WorkerContractExecutor;
-        logger.setRemoteSibling(executor);
+        executor.attachLogger(logger);
 
         // channelId is unknown at worker spawn; it arrives later via a child
         // logger (mirrors StateManager.setChannelId) and must reach the worker.
@@ -62,32 +62,37 @@ describe("worker logger upload", function () {
             .updateSharedContext({ channelId: CHANNEL_ID });
 
         try {
-            await executor.uploadLogs();
+            // Force a worker-side log so the flush proves the worker's OWN
+            // store crosses the gossip edge (not an empty upload). Deploying the
+            // INVALID opcode (0xfe) faults; the worker records a
+            // "Contract call execution failed" warn, then the call rejects.
+            await executor.deploy("0xfe").catch(() => {});
 
-            // Detached upload has up to 3s jitter before it reaches the server.
+            await logger.uploadLogs("report-bug flush");
+
+            // The main-thread trigger now flushes BOTH threads via gossip; the
+            // main `sdk` upload may also arrive, in any order.
             const deadline = Date.now() + 10000;
-            while (received.length === 0 && Date.now() < deadline) {
+            const findEvm = () => received.find((r) => r.threadName === "evm");
+            while (!findEvm() && Date.now() < deadline) {
                 await new Promise((r) => setTimeout(r, 100));
             }
 
-            expect(received.length).to.be.greaterThan(0);
-            expect(received[0].threadName).to.equal("evm");
-            expect(received[0].peerAddress).to.equal(
+            const workerUpload = findEvm();
+            expect(workerUpload, "worker (evm) upload not received").to.not.be
+                .undefined;
+            expect(workerUpload!.peerAddress).to.equal(
                 "0x1111111111111111111111111111111111111111"
             );
-            expect(received[0].channelId).to.equal(CHANNEL_ID);
-
-            // The envelope must carry real worker logs, not []. The flush itself
-            // records a "worker report-bug flush" line, so it's always present.
+            expect(workerUpload!.channelId).to.equal(CHANNEL_ID);
             const entries = decodeLogs(
-                decompressFromBase64(received[0].compressedLogs as string)
+                decompressFromBase64(workerUpload!.compressedLogs as string)
             );
-            expect(entries.length).to.be.greaterThan(0);
+            expect(entries).to.be.an("array");
             expect(
-                entries.some((e) =>
-                    e.message.includes("worker report-bug flush")
-                )
-            ).to.equal(true);
+                entries.length,
+                "worker's own log store should cross the gossip edge"
+            ).to.be.greaterThan(0);
         } finally {
             await executor.dispose();
             await new Promise<void>((r) => server.close(() => r()));

--- a/test/utils/Config.test.ts
+++ b/test/utils/Config.test.ts
@@ -6,7 +6,8 @@ import { createConfig } from "@/utils/config";
 const ENV_KEYS = [
     "HOLEPUNCH_RELAYER_URLS",
     "DEBUG_LOCAL_TRANSPORT",
-    "LOG_LEVEL"
+    "LOG_LEVEL",
+    "LOG_THREAD_NAME"
 ] as const;
 
 describe("config env parsing", () => {
@@ -43,6 +44,18 @@ describe("config env parsing", () => {
         // peer3.config.ts sets DEBUG_LOCAL_TRANSPORT=true (default is false)
         const cfg = createConfig({});
         expect(cfg.DEBUG_LOCAL_TRANSPORT).to.equal(true);
+    });
+
+    it("defaults LOG_THREAD_NAME to 'sdk'", () => {
+        delete process.env.LOG_THREAD_NAME;
+        const cfg = createConfig({});
+        expect(cfg.LOG_THREAD_NAME).to.equal("sdk");
+    });
+
+    it("reads LOG_THREAD_NAME from env", () => {
+        process.env.LOG_THREAD_NAME = "sdk-worker";
+        const cfg = createConfig({});
+        expect(cfg.LOG_THREAD_NAME).to.equal("sdk-worker");
     });
 
     it("parses HOLEPUNCH_RELAYER_URLS from env JSON array", () => {

--- a/test/utils/GossipNode.test.ts
+++ b/test/utils/GossipNode.test.ts
@@ -2,20 +2,27 @@ import { expect } from "chai";
 import { GossipNode, type Neighbour } from "@/utils/GossipNode";
 
 // A fake neighbour: records what it was told to post, and lets the test push
-// inbound messages by capturing the subscribe handler.
+// inbound messages by capturing the subscribe handler. Unsubscribe drops the handler
+// (so deliver() no longer reaches) and bumps a count for assertions.
 function fakeNeighbour() {
     const posted: unknown[] = [];
     let handler: ((msg: unknown) => void) | undefined;
+    let unsubscribed = 0;
     const neighbour: Neighbour = {
         post: (msg) => posted.push(msg),
         subscribe: (h) => {
             handler = h;
+            return () => {
+                handler = undefined;
+                unsubscribed++;
+            };
         }
     };
     return {
         neighbour,
         posted,
-        deliver: (msg: unknown) => handler?.(msg)
+        deliver: (msg: unknown) => handler?.(msg),
+        unsubscribedCount: () => unsubscribed
     };
 }
 
@@ -28,12 +35,18 @@ function wire(x: GossipNode, y: GossipNode): void {
         post: (m) => yInbound?.(m),
         subscribe: (h) => {
             xInbound = h;
+            return () => {
+                xInbound = undefined;
+            };
         }
     });
     y.addNeighbour({
         post: (m) => xInbound?.(m),
         subscribe: (h) => {
             yInbound = h;
+            return () => {
+                yInbound = undefined;
+            };
         }
     });
 }
@@ -153,5 +166,61 @@ describe("GossipNode", function () {
         only.deliver({ type: "flush" });
 
         expect(seen).to.deep.equal([{ type: "flush" }]); // delivered once, not twice
+    });
+
+    it("removeNeighbour un-wires inbound and drops the edge from broadcast", function () {
+        const seen: unknown[] = [];
+        const node = new GossipNode((m) => seen.push(m));
+        const a = fakeNeighbour();
+        const b = fakeNeighbour();
+        node.addNeighbour(a.neighbour);
+        node.addNeighbour(b.neighbour);
+
+        node.removeNeighbour(a.neighbour);
+
+        expect(a.unsubscribedCount()).to.equal(1); // unsubscribe ran once
+        a.deliver("gone"); // its handler is un-wired
+        node.broadcast("y");
+
+        expect(seen).to.deep.equal([]); // removed edge no longer delivers locally
+        expect(a.posted).to.deep.equal([]); // nor receives broadcasts
+        expect(b.posted).to.deep.equal(["y"]); // surviving edge still does
+    });
+
+    it("removeNeighbour on an unknown neighbour is a no-op", function () {
+        const node = new GossipNode();
+        const a = fakeNeighbour();
+        node.removeNeighbour(a.neighbour); // never added
+
+        expect(a.unsubscribedCount()).to.equal(0);
+    });
+
+    it("close() unsubscribes every neighbour and leaves the node inert", function () {
+        const node = new GossipNode();
+        const a = fakeNeighbour();
+        const b = fakeNeighbour();
+        node.addNeighbour(a.neighbour);
+        node.addNeighbour(b.neighbour);
+
+        node.close();
+
+        expect(a.unsubscribedCount()).to.equal(1);
+        expect(b.unsubscribedCount()).to.equal(1);
+        node.broadcast("z");
+        expect(a.posted).to.deep.equal([]);
+        expect(b.posted).to.deep.equal([]);
+    });
+
+    it("re-adding after removeNeighbour re-subscribes cleanly", function () {
+        const seen: unknown[] = [];
+        const node = new GossipNode((m) => seen.push(m));
+        const a = fakeNeighbour();
+        node.addNeighbour(a.neighbour);
+        node.removeNeighbour(a.neighbour);
+        node.addNeighbour(a.neighbour); // re-add
+
+        a.deliver("again");
+
+        expect(seen).to.deep.equal(["again"]);
     });
 });

--- a/test/utils/GossipNode.test.ts
+++ b/test/utils/GossipNode.test.ts
@@ -1,0 +1,90 @@
+import { expect } from "chai";
+import { GossipNode, type Neighbour } from "@/utils/GossipNode";
+
+// A fake neighbour: records what it was told to post, and lets the test push
+// inbound messages by capturing the subscribe handler.
+function fakeNeighbour() {
+    const posted: unknown[] = [];
+    let handler: ((msg: unknown) => void) | undefined;
+    const neighbour: Neighbour = {
+        post: (msg) => posted.push(msg),
+        subscribe: (h) => {
+            handler = h;
+        }
+    };
+    return {
+        neighbour,
+        posted,
+        deliver: (msg: unknown) => handler?.(msg)
+    };
+}
+
+describe("GossipNode", function () {
+    it("broadcast posts to every neighbour", function () {
+        const node = new GossipNode();
+        const a = fakeNeighbour();
+        const b = fakeNeighbour();
+        node.addNeighbour(a.neighbour);
+        node.addNeighbour(b.neighbour);
+
+        node.broadcast({ type: "flush" });
+
+        expect(a.posted).to.deep.equal([{ type: "flush" }]);
+        expect(b.posted).to.deep.equal([{ type: "flush" }]);
+    });
+
+    it("broadcast(exclude) skips the excluded neighbour", function () {
+        const node = new GossipNode();
+        const a = fakeNeighbour();
+        const b = fakeNeighbour();
+        node.addNeighbour(a.neighbour);
+        node.addNeighbour(b.neighbour);
+
+        node.broadcast("x", a.neighbour);
+
+        expect(a.posted).to.deep.equal([]);
+        expect(b.posted).to.deep.equal(["x"]);
+    });
+
+    it("inbound message is delivered locally and forwarded to all OTHER neighbours", function () {
+        const seen: unknown[] = [];
+        const node = new GossipNode((msg) => seen.push(msg));
+        const a = fakeNeighbour();
+        const b = fakeNeighbour();
+        const c = fakeNeighbour();
+        node.addNeighbour(a.neighbour);
+        node.addNeighbour(b.neighbour);
+        node.addNeighbour(c.neighbour);
+
+        a.deliver("hello"); // arrives from a
+
+        expect(seen).to.deep.equal(["hello"]); // delivered locally
+        expect(a.posted).to.deep.equal([]); // never back to sender (skip-sender)
+        expect(b.posted).to.deep.equal(["hello"]); // forwarded
+        expect(c.posted).to.deep.equal(["hello"]);
+    });
+
+    it("no local handler still forwards inbound to other neighbours", function () {
+        const node = new GossipNode(); // no handler
+        const a = fakeNeighbour();
+        const b = fakeNeighbour();
+        node.addNeighbour(a.neighbour);
+        node.addNeighbour(b.neighbour);
+
+        a.deliver(42);
+
+        expect(b.posted).to.deep.equal([42]);
+    });
+
+    it("single-neighbour node delivers inbound locally and never echoes back to the sender", function () {
+        const seen: unknown[] = [];
+        const node = new GossipNode((msg) => seen.push(msg));
+        const only = fakeNeighbour();
+        node.addNeighbour(only.neighbour);
+
+        only.deliver({ type: "flush" });
+
+        expect(seen).to.deep.equal([{ type: "flush" }]); // delivered locally
+        expect(only.posted).to.deep.equal([]); // no echo back to the only neighbour
+    });
+});

--- a/test/utils/GossipNode.test.ts
+++ b/test/utils/GossipNode.test.ts
@@ -19,6 +19,25 @@ function fakeNeighbour() {
     };
 }
 
+// Wire two real GossipNodes with a synchronous in-memory edge so a broadcast
+// cascades deterministically (no event-loop yield).
+function wire(x: GossipNode, y: GossipNode): void {
+    let xInbound: ((m: unknown) => void) | undefined;
+    let yInbound: ((m: unknown) => void) | undefined;
+    x.addNeighbour({
+        post: (m) => yInbound?.(m),
+        subscribe: (h) => {
+            xInbound = h;
+        }
+    });
+    y.addNeighbour({
+        post: (m) => xInbound?.(m),
+        subscribe: (h) => {
+            yInbound = h;
+        }
+    });
+}
+
 describe("GossipNode", function () {
     it("broadcast posts to every neighbour", function () {
         const node = new GossipNode();
@@ -86,5 +105,53 @@ describe("GossipNode", function () {
 
         expect(seen).to.deep.equal([{ type: "flush" }]); // delivered locally
         expect(only.posted).to.deep.equal([]); // no echo back to the only neighbour
+    });
+
+    // Loop-freedom on a real 3-node tree A—B—C: synchronous wiring means a routing
+    // loop would hang/overflow rather than pass.
+    it("middle-node origin reaches both leaves exactly once, no loop", function () {
+        const aSeen: unknown[] = [];
+        const bSeen: unknown[] = [];
+        const cSeen: unknown[] = [];
+        const a = new GossipNode((m) => aSeen.push(m));
+        const b = new GossipNode((m) => bSeen.push(m));
+        const c = new GossipNode((m) => cSeen.push(m));
+        wire(a, b);
+        wire(b, c);
+
+        b.broadcast({ type: "flush" }); // origin at the middle
+
+        expect(aSeen).to.deep.equal([{ type: "flush" }]); // leaf applied once
+        expect(cSeen).to.deep.equal([{ type: "flush" }]); // far leaf applied once
+        expect(bSeen).to.deep.equal([]); // originator doesn't self-apply via gossip
+    });
+
+    it("leaf origin relays through the middle to the far leaf once, no echo to origin", function () {
+        const aSeen: unknown[] = [];
+        const bSeen: unknown[] = [];
+        const cSeen: unknown[] = [];
+        const a = new GossipNode((m) => aSeen.push(m));
+        const b = new GossipNode((m) => bSeen.push(m));
+        const c = new GossipNode((m) => cSeen.push(m));
+        wire(a, b);
+        wire(b, c);
+
+        a.broadcast("x"); // origin at a leaf; must relay through B to reach C
+
+        expect(bSeen).to.deep.equal(["x"]); // middle applied once
+        expect(cSeen).to.deep.equal(["x"]); // far leaf reached via relay, once
+        expect(aSeen).to.deep.equal([]); // no echo back to the origin
+    });
+
+    it("addNeighbour is idempotent: adding the same neighbour twice delivers inbound once", function () {
+        const seen: unknown[] = [];
+        const node = new GossipNode((m) => seen.push(m));
+        const only = fakeNeighbour();
+        node.addNeighbour(only.neighbour);
+        node.addNeighbour(only.neighbour); // second add must be a no-op
+
+        only.deliver({ type: "flush" });
+
+        expect(seen).to.deep.equal([{ type: "flush" }]); // delivered once, not twice
     });
 });

--- a/test/utils/LoggerApplyOp.test.ts
+++ b/test/utils/LoggerApplyOp.test.ts
@@ -1,0 +1,56 @@
+import { expect } from "chai";
+import { createLogger } from "@/utils";
+import { LogUploader } from "@/utils/logging/LogUploader";
+import { LogStore } from "@/utils/logging/logStore";
+
+// Records uploadLogs() calls without doing network I/O.
+class FakeUploader extends LogUploader {
+    public uploadCount = 0;
+    protected attachListeners(): void {}
+    protected detachListeners(): void {}
+    public async uploadLogs(): Promise<void> {
+        this.uploadCount++;
+    }
+}
+
+const CHAN =
+    "0x2222222222222222222222222222222222222222222222222222222222222222";
+
+function makeLogger() {
+    const shared = { threadName: "sdk" } as Record<string, unknown>;
+    const fake = new FakeUploader(
+        new LogStore(1024, true),
+        { uploadEndpoint: "http://example.test", apiToken: "" },
+        { component: "T" },
+        shared as any
+    );
+    const logger = createLogger(
+        shared as any,
+        { component: "T" },
+        {
+            logUploader: fake,
+            level: "info"
+        }
+    );
+    return { logger, fake, shared };
+}
+
+describe("Logger.applyOp", function () {
+    it("'flush' uploads this thread's own store and returns the promise", async function () {
+        const { logger, fake } = makeLogger();
+        const result = logger.applyOp({ type: "flush" });
+        expect(result).to.be.an.instanceOf(Promise);
+        await result;
+        expect(fake.uploadCount).to.equal(1);
+    });
+
+    it("'updateContext' merges the delta and preserves this thread's own fields", function () {
+        const { logger, shared } = makeLogger();
+        logger.applyOp({
+            type: "updateContext",
+            context: { channelId: CHAN }
+        });
+        expect(shared.channelId).to.equal(CHAN);
+        expect(shared.threadName).to.equal("sdk"); // own field preserved
+    });
+});

--- a/test/utils/WorkerBase.test.ts
+++ b/test/utils/WorkerBase.test.ts
@@ -40,10 +40,14 @@ function makeRealLogger(threadName: string) {
 function portNeighbour(port: {
     postMessage: (m: unknown) => void;
     on: (e: "message", h: (m: unknown) => void) => void;
+    off: (e: "message", h: (m: unknown) => void) => void;
 }): Neighbour {
     return {
         post: (msg) => port.postMessage(msg),
-        subscribe: (handler) => port.on("message", handler)
+        subscribe: (handler) => {
+            port.on("message", handler);
+            return () => port.off("message", handler);
+        }
     };
 }
 

--- a/test/utils/WorkerBase.test.ts
+++ b/test/utils/WorkerBase.test.ts
@@ -7,6 +7,35 @@ import type {
     WorkerHostTransport
 } from "@/utils/worker/types";
 import type { Neighbour } from "@/utils/GossipNode";
+import { createLogger } from "@/utils";
+import { LogUploader } from "@/utils/logging/LogUploader";
+import { LogStore } from "@/utils/logging/logStore";
+
+// Counts uploadLogs() calls without network I/O (mirrors LoggerApplyOp.test.ts).
+class FakeUploader extends LogUploader {
+    public uploadCount = 0;
+    protected attachListeners(): void {}
+    protected detachListeners(): void {}
+    public async uploadLogs(): Promise<void> {
+        this.uploadCount++;
+    }
+}
+
+function makeRealLogger(threadName: string) {
+    const shared = { threadName } as Record<string, unknown>;
+    const uploader = new FakeUploader(
+        new LogStore(1024, true),
+        { uploadEndpoint: "http://example.test", apiToken: "" },
+        { component: threadName },
+        shared as any
+    );
+    const logger = createLogger(
+        shared as any,
+        { component: threadName },
+        { logUploader: uploader, level: "info" }
+    );
+    return { logger, uploader };
+}
 
 function portNeighbour(port: {
     postMessage: (m: unknown) => void;
@@ -117,5 +146,35 @@ describe("worker base", function () {
         await new Promise((r) => setTimeout(r, 30)); // yield for MessagePort delivery
 
         expect(applied).to.deep.equal([{ type: "flush" }]);
+    });
+
+    // Worker → main report-bug cascade through REAL Loggers: a report-bug on the
+    // worker flushes its own store AND reaches the main logger's uploader.
+    it("worker-originated report-bug flushes its own store and cascades to the main logger", async function () {
+        const { clientTransport, hostTransport } = connectInProcess();
+
+        class AttachableHost extends AWorkerHost<number, number> {
+            protected async handle(n: number): Promise<number> {
+                return n;
+            }
+            attachForTest(logger: unknown): void {
+                this.attachLogger(logger as any);
+            }
+        }
+        const host = new AttachableHost(hostTransport);
+        const client = new WorkerClient<number, number>(clientTransport);
+
+        const worker = makeRealLogger("evm");
+        const main = makeRealLogger("sdk");
+        host.attachForTest(worker.logger);
+        client.attachLogger(main.logger);
+
+        // Originate on the worker side.
+        await worker.logger.uploadLogs("worker report-bug");
+        await new Promise((r) => setTimeout(r, 30)); // yield for gossip MessagePort delivery
+
+        expect(worker.uploader.uploadCount).to.equal(1); // flushed its own store
+        expect(main.uploader.uploadCount).to.equal(1); // cascaded to main
+        await client.dispose();
     });
 });

--- a/test/utils/WorkerBase.test.ts
+++ b/test/utils/WorkerBase.test.ts
@@ -6,7 +6,7 @@ import type {
     WorkerClientTransport,
     WorkerHostTransport
 } from "@/utils/worker/types";
-import type { Neighbour } from "@/utils/GossipNode";
+import { GossipNode, type Neighbour } from "@/utils/GossipNode";
 import { createLogger } from "@/utils";
 import { LogUploader } from "@/utils/logging/LogUploader";
 import { LogStore } from "@/utils/logging/logStore";
@@ -82,6 +82,18 @@ class DoublingHost extends AWorkerHost<number, number> {
         return n * 2;
     }
 }
+
+// A host that exposes attachLogger to the test and forwards an injected shared node.
+class AttachableHost extends AWorkerHost<number, number> {
+    protected async handle(n: number): Promise<number> {
+        return n;
+    }
+    attachForTest(logger: unknown): void {
+        this.attachLogger(logger as any);
+    }
+}
+
+const yieldGossip = () => new Promise((r) => setTimeout(r, 30));
 
 describe("worker base", function () {
     it("request round-trips through the host's handle", async function () {
@@ -179,5 +191,94 @@ describe("worker base", function () {
         expect(worker.uploader.uploadCount).to.equal(1); // flushed its own store
         expect(main.uploader.uploadCount).to.equal(1); // cascaded to main
         await client.dispose();
+    });
+
+    // Star M → {W1, W2}: one node shared across two clients fans main's flush to both,
+    // and relays a worker's flush to main + the sibling (skip-sender), never to itself.
+    it("a shared node fans a main flush to both workers and relays worker→worker", async function () {
+        const a = connectInProcess();
+        const b = connectInProcess();
+
+        const gMain = new GossipNode();
+        const client1 = new WorkerClient<number, number>(
+            a.clientTransport,
+            gMain
+        );
+        const client2 = new WorkerClient<number, number>(
+            b.clientTransport,
+            gMain
+        );
+        const host1 = new AttachableHost(a.hostTransport);
+        const host2 = new AttachableHost(b.hostTransport);
+
+        const main = makeRealLogger("main");
+        const w1 = makeRealLogger("w1");
+        const w2 = makeRealLogger("w2");
+        client1.attachLogger(main.logger); // attach root logger to the shared node once
+        host1.attachForTest(w1.logger);
+        host2.attachForTest(w2.logger);
+
+        // main-originated flush fans to BOTH workers (and applies on main).
+        await main.logger.uploadLogs("main report-bug");
+        await yieldGossip();
+        expect(main.uploader.uploadCount, "main applies own flush").to.equal(1);
+        expect(w1.uploader.uploadCount, "fan to w1").to.equal(1);
+        expect(w2.uploader.uploadCount, "fan to w2").to.equal(1);
+
+        // worker1-originated flush relays to main AND to worker2, never back to w1.
+        await w1.logger.uploadLogs("w1 report-bug");
+        await yieldGossip();
+        expect(
+            w1.uploader.uploadCount,
+            "w1 applies own flush, no echo"
+        ).to.equal(2);
+        expect(main.uploader.uploadCount, "relayed up to main").to.equal(2);
+        expect(w2.uploader.uploadCount, "relayed across to w2").to.equal(2);
+
+        await client1.dispose();
+        await client2.dispose();
+        gMain.close();
+    });
+
+    // Line M–A–B: A shares one node across its host (up to M) and client (down to B),
+    // so a flush from either end is applied on A and relayed to the far end, once.
+    it("an intermediate thread relays gossip across a shared node (M–A–B line)", async function () {
+        const ma = connectInProcess(); // M(client) ↔ A(host)
+        const ab = connectInProcess(); // A(client) ↔ B(host)
+
+        const gA = new GossipNode(); // A's single node, shared up + down
+        const hostA = new AttachableHost(ma.hostTransport, gA); // up-edge to M
+        const clientA = new WorkerClient<number, number>(
+            ab.clientTransport,
+            gA
+        ); // down-edge to B
+
+        const clientM = new WorkerClient<number, number>(ma.clientTransport);
+        const hostB = new AttachableHost(ab.hostTransport);
+
+        const M = makeRealLogger("M");
+        const A = makeRealLogger("A");
+        const B = makeRealLogger("B");
+        clientM.attachLogger(M.logger);
+        hostA.attachForTest(A.logger); // sets gA's local handler to A's logger
+        hostB.attachForTest(B.logger);
+
+        // flush from B: applied on A, relayed up to M.
+        await B.logger.uploadLogs("from B");
+        await yieldGossip();
+        expect(B.uploader.uploadCount, "B applies own flush").to.equal(1);
+        expect(A.uploader.uploadCount, "applied on intermediate A").to.equal(1);
+        expect(M.uploader.uploadCount, "relayed up to M").to.equal(1);
+
+        // flush from M: applied on A, relayed down to B.
+        await M.logger.uploadLogs("from M");
+        await yieldGossip();
+        expect(M.uploader.uploadCount, "M applies own flush").to.equal(2);
+        expect(A.uploader.uploadCount, "applied on intermediate A").to.equal(2);
+        expect(B.uploader.uploadCount, "relayed down to B").to.equal(2);
+
+        await clientM.dispose();
+        await clientA.dispose();
+        gA.close();
     });
 });

--- a/test/utils/WorkerBase.test.ts
+++ b/test/utils/WorkerBase.test.ts
@@ -1,0 +1,121 @@
+import { expect } from "chai";
+import { MessageChannel } from "node:worker_threads";
+import { WorkerClient } from "@/utils/worker/WorkerClient";
+import { AWorkerHost } from "@/utils/worker/AWorkerHost";
+import type {
+    WorkerClientTransport,
+    WorkerHostTransport
+} from "@/utils/worker/types";
+import type { Neighbour } from "@/utils/GossipNode";
+
+function portNeighbour(port: {
+    postMessage: (m: unknown) => void;
+    on: (e: "message", h: (m: unknown) => void) => void;
+}): Neighbour {
+    return {
+        post: (msg) => port.postMessage(msg),
+        subscribe: (handler) => port.on("message", handler)
+    };
+}
+
+// Connect a client and a host over two in-process MessageChannels (RPC + gossip),
+// no real worker thread.
+function connectInProcess() {
+    const rpc = new MessageChannel();
+    const gossip = new MessageChannel();
+    const clientTransport: WorkerClientTransport = {
+        post: (env) => rpc.port1.postMessage(env),
+        onMessage: (h) => rpc.port1.on("message", h as any),
+        onError: () => {},
+        terminate: () => {
+            rpc.port1.close();
+            rpc.port2.close();
+            gossip.port1.close();
+            gossip.port2.close();
+        },
+        gossipNeighbour: portNeighbour(gossip.port1 as any)
+    };
+    const hostTransport: WorkerHostTransport = {
+        post: (res) => rpc.port2.postMessage(res),
+        onMessage: (h) => rpc.port2.on("message", h as any),
+        gossipNeighbour: portNeighbour(gossip.port2 as any)
+    };
+    return { clientTransport, hostTransport, gossip };
+}
+
+class DoublingHost extends AWorkerHost<number, number> {
+    protected async handle(n: number): Promise<number> {
+        if (n < 0) throw new Error("negative");
+        return n * 2;
+    }
+}
+
+describe("worker base", function () {
+    it("request round-trips through the host's handle", async function () {
+        const { clientTransport, hostTransport } = connectInProcess();
+        new DoublingHost(hostTransport);
+        const client = new WorkerClient<number, number>(clientTransport);
+        const result = await client.request(21);
+        expect(result).to.equal(42);
+        await client.dispose();
+    });
+
+    it("a throwing handle rejects the client's request with the error message", async function () {
+        const { clientTransport, hostTransport } = connectInProcess();
+        new DoublingHost(hostTransport);
+        const client = new WorkerClient<number, number>(clientTransport);
+        let message = "";
+        try {
+            await client.request(-1);
+        } catch (e) {
+            message = (e as Error).message;
+        }
+        expect(message).to.equal("negative");
+        await client.dispose();
+    });
+
+    it("inbound gossip from the worker reaches a logger attached on the client", async function () {
+        const { clientTransport, gossip } = connectInProcess();
+        const client = new WorkerClient<number, number>(clientTransport);
+
+        const applied: unknown[] = [];
+        const fakeLogger = {
+            applyOp: (op: unknown) => applied.push(op),
+            setGossipNode: () => {}
+        } as any;
+        client.attachLogger(fakeLogger);
+
+        // Simulate the worker side posting a gossip op into the dedicated port; it
+        // must reach the client logger's applyOp via the client's GossipNode.
+        gossip.port2.postMessage({ type: "flush" });
+        await new Promise((r) => setTimeout(r, 30)); // yield to the event loop for async MessagePort delivery
+
+        expect(applied).to.deep.equal([{ type: "flush" }]);
+        await client.dispose();
+    });
+
+    it("inbound gossip from the parent reaches a logger attached on the host", async function () {
+        const { hostTransport, gossip } = connectInProcess();
+        const applied: unknown[] = [];
+        class AttachableHost extends AWorkerHost<number, number> {
+            protected async handle(n: number): Promise<number> {
+                return n;
+            }
+            attachForTest(logger: unknown): void {
+                this.attachLogger(logger as any);
+            }
+        }
+        const host = new AttachableHost(hostTransport);
+        host.attachForTest({
+            applyOp: (op: unknown) => applied.push(op),
+            setGossipNode: () => {}
+        });
+
+        // Parent posts a gossip op into the host's dedicated port (gossip.port1 →
+        // port2, which the host subscribes to).
+        gossip.port1.postMessage({ type: "flush" });
+        await new Promise((r) => setTimeout(r, 30)); // yield for MessagePort delivery
+
+        expect(applied).to.deep.equal([{ type: "flush" }]);
+    });
+});

--- a/test/utils/WorkerBase.test.ts
+++ b/test/utils/WorkerBase.test.ts
@@ -83,13 +83,13 @@ class DoublingHost extends AWorkerHost<number, number> {
     }
 }
 
-// A host that exposes attachLogger to the test and forwards an injected shared node.
+// A host that exposes its gossip node so a test logger can self-wire to it.
 class AttachableHost extends AWorkerHost<number, number> {
     protected async handle(n: number): Promise<number> {
         return n;
     }
     attachForTest(logger: unknown): void {
-        this.attachLogger(logger as any);
+        (logger as any).setGossipNode(this.gossipNode);
     }
 }
 
@@ -126,9 +126,10 @@ describe("worker base", function () {
         const applied: unknown[] = [];
         const fakeLogger = {
             applyOp: (op: unknown) => applied.push(op),
-            setGossipNode: () => {}
+            setGossipNode: (node: GossipNode) =>
+                node.setLocalHandler((op) => fakeLogger.applyOp(op))
         } as any;
-        client.attachLogger(fakeLogger);
+        fakeLogger.setGossipNode(client.gossipNode);
 
         // Simulate the worker side posting a gossip op into the dedicated port; it
         // must reach the client logger's applyOp via the client's GossipNode.
@@ -147,14 +148,16 @@ describe("worker base", function () {
                 return n;
             }
             attachForTest(logger: unknown): void {
-                this.attachLogger(logger as any);
+                (logger as any).setGossipNode(this.gossipNode);
             }
         }
         const host = new AttachableHost(hostTransport);
-        host.attachForTest({
+        const fakeLogger = {
             applyOp: (op: unknown) => applied.push(op),
-            setGossipNode: () => {}
-        });
+            setGossipNode: (node: GossipNode) =>
+                node.setLocalHandler((op) => fakeLogger.applyOp(op))
+        };
+        host.attachForTest(fakeLogger);
 
         // Parent posts a gossip op into the host's dedicated port (gossip.port1 →
         // port2, which the host subscribes to).
@@ -174,7 +177,7 @@ describe("worker base", function () {
                 return n;
             }
             attachForTest(logger: unknown): void {
-                this.attachLogger(logger as any);
+                (logger as any).setGossipNode(this.gossipNode);
             }
         }
         const host = new AttachableHost(hostTransport);
@@ -183,7 +186,7 @@ describe("worker base", function () {
         const worker = makeRealLogger("evm");
         const main = makeRealLogger("sdk");
         host.attachForTest(worker.logger);
-        client.attachLogger(main.logger);
+        main.logger.setGossipNode(client.gossipNode);
 
         await worker.logger.uploadLogs("worker report-bug");
         await new Promise((r) => setTimeout(r, 30)); // yield for gossip MessagePort delivery
@@ -214,7 +217,7 @@ describe("worker base", function () {
         const main = makeRealLogger("main");
         const w1 = makeRealLogger("w1");
         const w2 = makeRealLogger("w2");
-        client1.attachLogger(main.logger); // attach root logger to the shared node once
+        main.logger.setGossipNode(client1.gossipNode); // attach root logger to the shared node once
         host1.attachForTest(w1.logger);
         host2.attachForTest(w2.logger);
 
@@ -259,7 +262,7 @@ describe("worker base", function () {
         const M = makeRealLogger("M");
         const A = makeRealLogger("A");
         const B = makeRealLogger("B");
-        clientM.attachLogger(M.logger);
+        M.logger.setGossipNode(clientM.gossipNode);
         hostA.attachForTest(A.logger); // sets gA's local handler to A's logger
         hostB.attachForTest(B.logger);
 

--- a/test/utils/WorkerBase.test.ts
+++ b/test/utils/WorkerBase.test.ts
@@ -169,7 +169,6 @@ describe("worker base", function () {
         host.attachForTest(worker.logger);
         client.attachLogger(main.logger);
 
-        // Originate on the worker side.
         await worker.logger.uploadLogs("worker report-bug");
         await new Promise((r) => setTimeout(r, 30)); // yield for gossip MessagePort delivery
 

--- a/test/utils/logging/LogUploaderEnvelope.test.ts
+++ b/test/utils/logging/LogUploaderEnvelope.test.ts
@@ -1,0 +1,60 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import axios from "axios";
+
+import { NodeLogUploader } from "@/utils/logging/node/NodeLogUploader";
+import { LogStore } from "@/utils/logging/logStore";
+
+describe("LogUploader envelope", () => {
+    let postStub: sinon.SinonStub;
+    let randomStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        // No jitter delay, deterministic.
+        randomStub = sinon.stub(Math, "random").returns(0);
+        postStub = sinon
+            .stub(axios, "post")
+            .resolves({ headers: {}, data: {} } as any);
+    });
+
+    afterEach(() => {
+        randomStub.restore();
+        postStub.restore();
+    });
+
+    it("includes threadName in the uploaded envelope", async () => {
+        const store = new LogStore(1024 * 1024, true);
+        store.store({
+            time: "t",
+            level: "warn",
+            context: {},
+            sharedContext: {},
+            message: "hello",
+            meta: [],
+            stack: ""
+        });
+
+        const uploader = new NodeLogUploader(
+            store,
+            { uploadEndpoint: "http://localhost:9/logs/upload", apiToken: "" },
+            {},
+            {
+                peerAddress:
+                    "0x1111111111111111111111111111111111111111" as any,
+                channelId:
+                    "0x2222222222222222222222222222222222222222222222222222222222222222",
+                threadName: "evm"
+            },
+            false
+        );
+
+        await uploader.uploadLogs();
+
+        expect(postStub.calledOnce).to.equal(true);
+        const body = postStub.firstCall.args[1] as Record<string, unknown>;
+        expect(body.threadName).to.equal("evm");
+        expect(body.channelId).to.equal(
+            "0x2222222222222222222222222222222222222222222222222222222222222222"
+        );
+    });
+});

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -14,6 +14,7 @@
                 "src/evm/contractExecutor/browser/ContractExecutorWorkerRuntime"
             ],
             "@platform/DeployUtils": ["src/utils/browser/DeployUtils"],
+            "@platform/workerTransport": ["src/utils/browser/workerTransport"],
             "@platform/LocalDiscoveryServer": [
                 "src/utils/browser/LocalDiscoveryServer"
             ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
                 "src/evm/contractExecutor/node/ContractExecutorWorkerRuntime"
             ],
             "@platform/DeployUtils": ["src/utils/node/DeployUtils"],
+            "@platform/workerTransport": ["src/utils/node/workerTransport"],
             "@platform/LocalDiscoveryServer": [
                 "src/utils/node/LocalDiscoveryServer"
             ],


### PR DESCRIPTION
Logger now broadcasts its messages to other threads through a generic `GossipNode` which just forwards to neighbours knowing nothing about logs.

Added 2 generic worker primitives: `WorkerClient` (spawner / main side) and `AWorkerHost` (spawnee / worker side) and a platform-specific `workerTransport` that wires them together.

The EVM `ContractExecutorWorkerHost` now extends the generic `AWorkerHost` which gives it gossip capabilities so the EVM worker thread's logs reach the main thread on report-bug instead of being lost.

> _**NOTE**_: Incremental uploads are addressed in the follow up PR #345.