### PR TITLE
feat(logging): incremental (delta) crash-log uploads

### DIFF
--- a/scripts/logging/crash-log-server.js
+++ b/scripts/logging/crash-log-server.js
@@ -9,6 +9,7 @@ const express = require("express");
 const cors = require("cors");
 const fs = require("fs").promises;
 const path = require("path");
+const { decodeLogs, buildAppendLines, parseLastSeq } = require("./logStitch");
 
 const PORT = process.env.CRASH_LOG_SERVER_PORT || 3001;
 const LOG_DIR =
@@ -16,6 +17,8 @@ const LOG_DIR =
 
 const app = express();
 const channelDirCache = new Map();
+// lastWrittenSeq per "<channel>/<peer>/<thread>" file path.
+const fileSeqCache = new Map();
 let uploadInFlight = 0;
 let uploadRequestSeq = 0;
 
@@ -225,43 +228,65 @@ app.use("/logs/upload", (req, res, next) => {
 app.post("/logs/upload", express.json({ limit: "50mb" }), async (req, res) => {
     try {
         const meta = getRequestMeta(req);
-        const parseDoneMs = meta ? Date.now() - meta.startedAt : -1;
-        const { channelId, peerAddress, compressedLogs } = req.body || {};
+        const { channelId, peerAddress, threadName, compressedLogs, fromSeq } =
+            req.body || {};
 
         if (meta && meta.uploadId) {
             res.setHeader("x-upload-id", meta.uploadId);
         }
 
-        if (!channelId || !peerAddress || !compressedLogs) {
+        if (
+            !channelId ||
+            !peerAddress ||
+            !compressedLogs ||
+            typeof fromSeq !== "number"
+        ) {
             console.warn(
-                `[CrashLogServer][${meta ? meta.requestId : "unknown"}] Upload rejected: uploadId=${meta && meta.uploadId ? meta.uploadId : "N/A"} missing required fields channelId=${Boolean(channelId)} peerAddress=${Boolean(peerAddress)} compressedLogs=${Boolean(compressedLogs)}`
+                `[CrashLogServer][${meta ? meta.requestId : "unknown"}] Upload rejected: missing fields channelId=${Boolean(channelId)} peerAddress=${Boolean(peerAddress)} compressedLogs=${Boolean(compressedLogs)} fromSeq=${typeof fromSeq}`
             );
-            res.status(400).json({
-                error: "Incorrect request data"
-            });
+            res.status(400).json({ error: "Incorrect request data" });
             return;
         }
 
         const payloadBytes = Buffer.byteLength(String(compressedLogs), "utf8");
-        const resolveStartedAt = Date.now();
 
-        const { dir: channelDir, timestamp } = await resolveChannelDir(
-            channelId,
-            { rotateIfOld: true }
-        );
-        const resolveMs = Date.now() - resolveStartedAt;
+        const safeChannel = sanitizeSegment(channelId);
         const safePeer = sanitizeSegment(peerAddress);
-        const filename = `${safePeer}`;
-        const filepath = path.join(channelDir, filename);
+        const safeThread = sanitizeSegment(threadName || "sdk");
+        const peerDir = path.join(LOG_DIR, safeChannel, safePeer);
+        await fs.mkdir(peerDir, { recursive: true });
+        const filename = `${safeThread}.ndjson`;
+        const filepath = path.join(peerDir, filename);
+
+        // Recover lastWrittenSeq (in-memory, or by reading the file once).
+        let lastWrittenSeq = fileSeqCache.get(filepath);
+        if (lastWrittenSeq === undefined) {
+            let existing = "";
+            try {
+                existing = await fs.readFile(filepath, "utf8");
+            } catch {
+                existing = "";
+            }
+            lastWrittenSeq = parseLastSeq(existing);
+        }
+
+        const entries = decodeLogs(compressedLogs);
+        const { lines, newLastSeq, gap } = buildAppendLines(
+            entries,
+            fromSeq,
+            lastWrittenSeq
+        );
 
         const writeStartedAt = Date.now();
-
-        await fs.writeFile(filepath, compressedLogs, "utf8");
-
+        if (lines.length > 0) {
+            await fs.appendFile(filepath, lines.join("\n") + "\n", "utf8");
+            fileSeqCache.set(filepath, newLastSeq);
+        }
         const writeMs = Date.now() - writeStartedAt;
+        const timestamp = formatTimestamp();
 
         console.log(
-            `[CrashLogServer][${meta ? meta.requestId : "unknown"}] Upload stored uploadId=${meta && meta.uploadId ? meta.uploadId : "N/A"} channelId=${channelId} peer=${safePeer} payloadBytes=${payloadBytes} parseMs=${parseDoneMs} resolveDirMs=${resolveMs} writeMs=${writeMs} timestamp=${timestamp}`
+            `[CrashLogServer][${meta ? meta.requestId : "unknown"}] Upload stored uploadId=${meta && meta.uploadId ? meta.uploadId : "N/A"} channelId=${channelId} peer=${safePeer} thread=${safeThread} appended=${lines.length} gap=${gap ? `[${gap[0]},${gap[1]}]` : "none"} lastSeq=${newLastSeq} payloadBytes=${payloadBytes} writeMs=${writeMs} timestamp=${timestamp}`
         );
 
         res.status(200).json({
@@ -269,7 +294,8 @@ app.post("/logs/upload", express.json({ limit: "50mb" }), async (req, res) => {
             uploadId: meta && meta.uploadId ? meta.uploadId : null,
             channelId,
             peerAddress,
-            filename
+            filename,
+            lastSeq: newLastSeq
         });
     } catch (err) {
         console.error("[CrashLogServer] Upload failed:", err);
@@ -370,7 +396,11 @@ async function start() {
     });
 }
 
-start().catch((err) => {
-    console.error("[CrashLogServer] Failed to start:", err);
-    process.exit(1);
-});
+if (require.main === module) {
+    start().catch((err) => {
+        console.error("[CrashLogServer] Failed to start:", err);
+        process.exit(1);
+    });
+}
+
+module.exports = { app, start };

--- a/scripts/logging/crash-log-server.js
+++ b/scripts/logging/crash-log-server.js
@@ -228,8 +228,14 @@ app.use("/logs/upload", (req, res, next) => {
 app.post("/logs/upload", express.json({ limit: "50mb" }), async (req, res) => {
     try {
         const meta = getRequestMeta(req);
-        const { channelId, peerAddress, threadName, compressedLogs, fromSeq } =
-            req.body || {};
+        const {
+            channelId,
+            peerAddress,
+            threadName,
+            compressedLogs,
+            fromSeq,
+            toSeq
+        } = req.body || {};
 
         if (meta && meta.uploadId) {
             res.setHeader("x-upload-id", meta.uploadId);
@@ -239,10 +245,11 @@ app.post("/logs/upload", express.json({ limit: "50mb" }), async (req, res) => {
             !channelId ||
             !peerAddress ||
             !compressedLogs ||
-            typeof fromSeq !== "number"
+            typeof fromSeq !== "number" ||
+            typeof toSeq !== "number"
         ) {
             console.warn(
-                `[CrashLogServer][${meta ? meta.requestId : "unknown"}] Upload rejected: missing fields channelId=${Boolean(channelId)} peerAddress=${Boolean(peerAddress)} compressedLogs=${Boolean(compressedLogs)} fromSeq=${typeof fromSeq}`
+                `[CrashLogServer][${meta ? meta.requestId : "unknown"}] Upload rejected: missing fields channelId=${Boolean(channelId)} peerAddress=${Boolean(peerAddress)} compressedLogs=${Boolean(compressedLogs)} fromSeq=${typeof fromSeq} toSeq=${typeof toSeq}`
             );
             res.status(400).json({ error: "Incorrect request data" });
             return;

--- a/scripts/logging/crash-log-server.js
+++ b/scripts/logging/crash-log-server.js
@@ -265,7 +265,7 @@ app.post("/logs/upload", express.json({ limit: "50mb" }), async (req, res) => {
         const filename = `${safeThread}.ndjson`;
         const filepath = path.join(peerDir, filename);
 
-        // Recover lastWrittenSeq (in-memory, or by reading the file once).
+        // lastWrittenSeq: cached, else read once from the file
         let lastWrittenSeq = fileSeqCache.get(filepath);
         if (lastWrittenSeq === undefined) {
             let existing = "";

--- a/scripts/logging/crash-log-server.js
+++ b/scripts/logging/crash-log-server.js
@@ -278,7 +278,7 @@ app.post("/logs/upload", express.json({ limit: "50mb" }), async (req, res) => {
         }
 
         const entries = decodeLogs(compressedLogs);
-        const { lines, newLastSeq, gap } = buildAppendLines(
+        const { lines, newLastSeq } = buildAppendLines(
             entries,
             fromSeq,
             lastWrittenSeq
@@ -293,7 +293,7 @@ app.post("/logs/upload", express.json({ limit: "50mb" }), async (req, res) => {
         const timestamp = formatTimestamp();
 
         console.log(
-            `[CrashLogServer][${meta ? meta.requestId : "unknown"}] Upload stored uploadId=${meta && meta.uploadId ? meta.uploadId : "N/A"} channelId=${channelId} peer=${safePeer} thread=${safeThread} appended=${lines.length} gap=${gap ? `[${gap[0]},${gap[1]}]` : "none"} lastSeq=${newLastSeq} payloadBytes=${payloadBytes} writeMs=${writeMs} timestamp=${timestamp}`
+            `[CrashLogServer][${meta ? meta.requestId : "unknown"}] Upload stored uploadId=${meta && meta.uploadId ? meta.uploadId : "N/A"} channelId=${channelId} peer=${safePeer} thread=${safeThread} appended=${lines.length} lastSeq=${newLastSeq} payloadBytes=${payloadBytes} writeMs=${writeMs} timestamp=${timestamp}`
         );
 
         res.status(200).json({

--- a/scripts/logging/logStitch.js
+++ b/scripts/logging/logStitch.js
@@ -3,8 +3,7 @@
 // Dependency-free stitch logic shared by the crash-log server and its tests.
 const { decompressSync, strFromU8 } = require("fflate");
 
-// Mirror the SDK's logEncoder: base64 -> gunzip -> JSON array of per-entry JSON
-// strings -> entry objects.
+// base64 -> gunzip -> JSON array of per-entry JSON strings (mirrors logEncoder)
 function decodeLogs(compressedLogs) {
     const bytes = Uint8Array.from(Buffer.from(compressedLogs, "base64"));
     const serialized = strFromU8(decompressSync(bytes));
@@ -12,11 +11,7 @@ function decodeLogs(compressedLogs) {
     return Array.isArray(arr) ? arr.map((s) => JSON.parse(s)) : arr;
 }
 
-// Build the NDJSON lines to append for a delta batch.
-// - entries: decoded log entries, contiguous starting at fromSeq
-// - fromSeq: seq of entries[0]
-// - lastWrittenSeq: highest seq already on disk for this file (-1 if none)
-// Returns { lines: string[], newLastSeq: number, gap: [number, number] | null }.
+// NDJSON lines for a delta batch starting at fromSeq; skips seq <= lastWrittenSeq, marks gaps.
 function buildAppendLines(entries, fromSeq, lastWrittenSeq) {
     const lines = [];
     let gap = null;
@@ -29,14 +24,14 @@ function buildAppendLines(entries, fromSeq, lastWrittenSeq) {
     let newLastSeq = lastWrittenSeq;
     for (let i = 0; i < entries.length; i++) {
         const seq = fromSeq + i;
-        if (seq <= lastWrittenSeq) continue; // dedup overlap on retry
+        if (seq <= lastWrittenSeq) continue; // dedup retry overlap
         lines.push(JSON.stringify({ seq, ...entries[i] }));
         newLastSeq = seq;
     }
     return { lines, newLastSeq, gap };
 }
 
-// Recover lastWrittenSeq from existing file contents (last seq-bearing line).
+// lastWrittenSeq from the last seq-bearing line.
 function parseLastSeq(ndjson) {
     if (!ndjson) return -1;
     const lines = ndjson.split("\n");

--- a/scripts/logging/logStitch.js
+++ b/scripts/logging/logStitch.js
@@ -8,27 +8,23 @@ function decodeLogs(compressedLogs) {
     const bytes = Uint8Array.from(Buffer.from(compressedLogs, "base64"));
     const serialized = strFromU8(decompressSync(bytes));
     const arr = JSON.parse(serialized);
-    return Array.isArray(arr) ? arr.map((s) => JSON.parse(s)) : arr;
+    if (!Array.isArray(arr))
+        throw new Error("Failed to deserialize log entries");
+    return arr.map((s) => JSON.parse(s));
 }
 
-// NDJSON lines for a delta batch starting at fromSeq; skips seq <= lastWrittenSeq, marks gaps.
+// NDJSON lines for a delta batch from fromSeq; skips seq <= lastWrittenSeq (retry overlap).
+// No gap marker needed: a jump in seq between adjacent lines is itself the gap, read-time.
 function buildAppendLines(entries, fromSeq, lastWrittenSeq) {
     const lines = [];
-    let gap = null;
-
-    if (fromSeq > lastWrittenSeq + 1) {
-        gap = [lastWrittenSeq + 1, fromSeq - 1];
-        lines.push(JSON.stringify({ gap }));
-    }
-
     let newLastSeq = lastWrittenSeq;
     for (let i = 0; i < entries.length; i++) {
         const seq = fromSeq + i;
-        if (seq <= lastWrittenSeq) continue; // dedup retry overlap
+        if (seq <= lastWrittenSeq) continue;
         lines.push(JSON.stringify({ seq, ...entries[i] }));
         newLastSeq = seq;
     }
-    return { lines, newLastSeq, gap };
+    return { lines, newLastSeq };
 }
 
 // lastWrittenSeq from the last seq-bearing line.

--- a/scripts/logging/logStitch.js
+++ b/scripts/logging/logStitch.js
@@ -1,0 +1,56 @@
+"use strict";
+
+// Dependency-free stitch logic shared by the crash-log server and its tests.
+const { decompressSync, strFromU8 } = require("fflate");
+
+// Mirror the SDK's logEncoder: base64 -> gunzip -> JSON array of per-entry JSON
+// strings -> entry objects.
+function decodeLogs(compressedLogs) {
+    const bytes = Uint8Array.from(Buffer.from(compressedLogs, "base64"));
+    const serialized = strFromU8(decompressSync(bytes));
+    const arr = JSON.parse(serialized);
+    return Array.isArray(arr) ? arr.map((s) => JSON.parse(s)) : arr;
+}
+
+// Build the NDJSON lines to append for a delta batch.
+// - entries: decoded log entries, contiguous starting at fromSeq
+// - fromSeq: seq of entries[0]
+// - lastWrittenSeq: highest seq already on disk for this file (-1 if none)
+// Returns { lines: string[], newLastSeq: number, gap: [number, number] | null }.
+function buildAppendLines(entries, fromSeq, lastWrittenSeq) {
+    const lines = [];
+    let gap = null;
+
+    if (fromSeq > lastWrittenSeq + 1) {
+        gap = [lastWrittenSeq + 1, fromSeq - 1];
+        lines.push(JSON.stringify({ gap }));
+    }
+
+    let newLastSeq = lastWrittenSeq;
+    for (let i = 0; i < entries.length; i++) {
+        const seq = fromSeq + i;
+        if (seq <= lastWrittenSeq) continue; // dedup overlap on retry
+        lines.push(JSON.stringify({ seq, ...entries[i] }));
+        newLastSeq = seq;
+    }
+    return { lines, newLastSeq, gap };
+}
+
+// Recover lastWrittenSeq from existing file contents (last seq-bearing line).
+function parseLastSeq(ndjson) {
+    if (!ndjson) return -1;
+    const lines = ndjson.split("\n");
+    for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i].trim();
+        if (!line) continue;
+        try {
+            const obj = JSON.parse(line);
+            if (typeof obj.seq === "number") return obj.seq;
+        } catch {
+            // ignore unparseable lines
+        }
+    }
+    return -1;
+}
+
+module.exports = { decodeLogs, buildAppendLines, parseLastSeq };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -20,6 +20,7 @@ export type Config = {
     CRASH_LOG_UPLOAD_ENDPOINT: string;
     CRASH_LOG_API_TOKEN: string;
     CRASH_LOG_MAX_SIZE_MB: number;
+    CRASH_LOG_FLUSH_MIN_INTERVAL_MS: number;
 };
 
 const DEFAULT_CONFIG: Config = {
@@ -41,7 +42,8 @@ const DEFAULT_CONFIG: Config = {
     // Crash log collection is enabled when upload endpoint is configured.
     CRASH_LOG_UPLOAD_ENDPOINT: "",
     CRASH_LOG_API_TOKEN: "",
-    CRASH_LOG_MAX_SIZE_MB: 10
+    CRASH_LOG_MAX_SIZE_MB: 10,
+    CRASH_LOG_FLUSH_MIN_INTERVAL_MS: 2000
 };
 
 export function isNodeRuntime() {

--- a/src/utils/logging/LogUploader.ts
+++ b/src/utils/logging/LogUploader.ts
@@ -22,12 +22,15 @@ export type LogUploaderOptions = {
 export type LogUploaderConfig = {
     uploadEndpoint: string;
     apiToken?: string;
+    flushMinIntervalMs?: number;
 };
 
 export abstract class LogUploader {
     protected logger?: Logger;
     private destroyed = false;
     private lastUploadedSeq = -1;
+    private lastUploadAt = -Infinity;
+    private trailingTimer?: ReturnType<typeof setTimeout>;
 
     constructor(
         protected readonly logStore: LogStore,
@@ -72,8 +75,29 @@ export abstract class LogUploader {
 
     public async uploadLogs(
         _unhandledError?: Error,
-        _isUserInitiated = false
+        isUserInitiated = false
     ): Promise<void> {
+        if (!this.isEnabled()) return;
+        if (isUserInitiated) {
+            await this.doUpload();
+            return;
+        }
+        const interval = this.config.flushMinIntervalMs ?? 2000;
+        const elapsed = Date.now() - this.lastUploadAt;
+        if (elapsed >= interval) {
+            await this.doUpload();
+            return;
+        }
+        // Within the window: ensure exactly one trailing upload at the boundary.
+        if (!this.trailingTimer) {
+            this.trailingTimer = setTimeout(() => {
+                this.trailingTimer = undefined;
+                void this.doUpload();
+            }, interval - elapsed);
+        }
+    }
+
+    private async doUpload(): Promise<void> {
         if (!this.isEnabled()) return;
 
         const { entries, fromSeq, toSeq } = this.logStore.getLogsSince(
@@ -138,6 +162,7 @@ export abstract class LogUploader {
             // Advance the watermark ONLY on success; failures merge into the
             // next delta.
             this.lastUploadedSeq = toSeq;
+            this.lastUploadAt = Date.now();
             console.trace(
                 `Logs uploaded. uploadId=${uploadId} responseUploadId=${response.headers?.["x-upload-id"] || "N/A"} seq=[${fromSeq}..${toSeq}]`
             );
@@ -162,6 +187,10 @@ export abstract class LogUploader {
         // console.trace("Destroying LogUploader");
 
         this.destroyed = true;
+        if (this.trailingTimer) {
+            clearTimeout(this.trailingTimer);
+            this.trailingTimer = undefined;
+        }
         this.detachListeners();
     }
 }

--- a/src/utils/logging/LogUploader.ts
+++ b/src/utils/logging/LogUploader.ts
@@ -31,6 +31,8 @@ export abstract class LogUploader {
     private lastUploadedSeq = -1;
     private lastUploadAt = -Infinity;
     private trailingTimer?: ReturnType<typeof setTimeout>;
+    private uploading = false;
+    private pendingUpload = false;
 
     constructor(
         protected readonly logStore: LogStore,
@@ -100,16 +102,44 @@ export abstract class LogUploader {
     private async doUpload(): Promise<void> {
         if (!this.isEnabled()) return;
 
+        // Single-flight: never POST two deltas concurrently (they'd send the
+        // same range twice). A trigger arriving mid-flight sets a pending flag,
+        // and the in-flight loop re-sends the newly accumulated delta before
+        // releasing — so nothing is lost and nothing overlaps.
+        if (this.uploading) {
+            this.pendingUpload = true;
+            return;
+        }
+        this.uploading = true;
+        try {
+            do {
+                this.pendingUpload = false;
+                const sent = await this.postDelta();
+                if (!sent) break; // nothing new, or POST failed — a later trigger retries
+            } while (this.pendingUpload);
+        } catch (err) {
+            // postDelta swallows POST errors; this guards encode/compress so a
+            // fire-and-forget doUpload() (the trailing timer) never rejects.
+            console.error(`Log upload aborted: ${String(err)}`);
+        } finally {
+            this.uploading = false;
+        }
+    }
+
+    // Upload the current delta once. Returns true if a batch was POSTed
+    // successfully (watermark advanced), false if nothing was new or the POST
+    // failed (the watermark holds so the entries merge into the next delta).
+    private async postDelta(): Promise<boolean> {
         const { entries, fromSeq, toSeq } = this.logStore.getLogsSince(
             this.lastUploadedSeq
         );
-        if (entries.length === 0) return; // nothing new
+        if (entries.length === 0) return false; // nothing new
 
         const channelId = this.sharedContext.channelId || ethers.ZeroHash;
         const peerAddress =
             this.sharedContext.peerAddress || ethers.ZeroAddress;
         const threadName = this.sharedContext.threadName;
-        if (!channelId || !peerAddress) return;
+        if (!channelId || !peerAddress) return false;
 
         const uploadStartedAt = Date.now();
         const serializedLogs = encodeLogs(entries);
@@ -166,6 +196,7 @@ export abstract class LogUploader {
             console.trace(
                 `Logs uploaded. uploadId=${uploadId} responseUploadId=${response.headers?.["x-upload-id"] || "N/A"} seq=[${fromSeq}..${toSeq}]`
             );
+            return true;
         } catch (uploadError) {
             sanitizeAxiosErrorForLogging(uploadError);
             const { code, status, statusText, timeout } =
@@ -176,6 +207,7 @@ export abstract class LogUploader {
                 { code, status, statusText, timeout, elapsedMs }
             );
             // Swallow — uploads are best-effort and must not block teardown.
+            return false;
         }
     }
 

--- a/src/utils/logging/LogUploader.ts
+++ b/src/utils/logging/LogUploader.ts
@@ -90,7 +90,7 @@ export abstract class LogUploader {
             await this.doUpload();
             return;
         }
-        // Within the window: ensure exactly one trailing upload at the boundary.
+        // within window: schedule one trailing upload at the boundary
         if (!this.trailingTimer) {
             this.trailingTimer = setTimeout(() => {
                 this.trailingTimer = undefined;
@@ -102,10 +102,7 @@ export abstract class LogUploader {
     private async doUpload(): Promise<void> {
         if (!this.isEnabled()) return;
 
-        // Single-flight: never POST two deltas concurrently (they'd send the
-        // same range twice). A trigger arriving mid-flight sets a pending flag,
-        // and the in-flight loop re-sends the newly accumulated delta before
-        // releasing — so nothing is lost and nothing overlaps.
+        // single-flight: a mid-flight trigger sets pendingUpload; the loop re-sends after
         if (this.uploading) {
             this.pendingUpload = true;
             return;
@@ -115,20 +112,17 @@ export abstract class LogUploader {
             do {
                 this.pendingUpload = false;
                 const sent = await this.postDelta();
-                if (!sent) break; // nothing new, or POST failed — a later trigger retries
+                if (!sent) break; // nothing new or POST failed
             } while (this.pendingUpload);
         } catch (err) {
-            // postDelta swallows POST errors; this guards encode/compress so a
-            // fire-and-forget doUpload() (the trailing timer) never rejects.
+            // guard encode/compress throws so the fire-and-forget timer never rejects
             console.error(`Log upload aborted: ${String(err)}`);
         } finally {
             this.uploading = false;
         }
     }
 
-    // Upload the current delta once. Returns true if a batch was POSTed
-    // successfully (watermark advanced), false if nothing was new or the POST
-    // failed (the watermark holds so the entries merge into the next delta).
+    // Upload the delta once; true if POSTed (watermark advanced), false if empty/failed.
     private async postDelta(): Promise<boolean> {
         const { entries, fromSeq, toSeq } = this.logStore.getLogsSince(
             this.lastUploadedSeq
@@ -189,8 +183,7 @@ export abstract class LogUploader {
                     }
                 }
             );
-            // Advance the watermark ONLY on success; failures merge into the
-            // next delta.
+            // advance watermark only on success; failures merge into the next delta
             this.lastUploadedSeq = toSeq;
             this.lastUploadAt = Date.now();
             console.trace(
@@ -206,7 +199,7 @@ export abstract class LogUploader {
                 `Log upload failed: uploadId=${uploadId} channelId=${channelId} peerAddress=${peerAddress} seq=[${fromSeq}..${toSeq}] endpoint=${this.config.uploadEndpoint}\n Error: ${String(uploadError)}\n`,
                 { code, status, statusText, timeout, elapsedMs }
             );
-            // Swallow — uploads are best-effort and must not block teardown.
+            // best-effort; swallow so it can't block teardown
             return false;
         }
     }
@@ -215,9 +208,6 @@ export abstract class LogUploader {
         if (this.destroyed) {
             return;
         }
-
-        // console.trace("Destroying LogUploader");
-
         this.destroyed = true;
         if (this.trailingTimer) {
             clearTimeout(this.trailingTimer);

--- a/src/utils/logging/LogUploader.ts
+++ b/src/utils/logging/LogUploader.ts
@@ -75,6 +75,8 @@ export abstract class LogUploader {
         return Promise.resolve(undefined);
     }
 
+    // POST-side throttle, separate from Logger.error()'s gossip throttle: that bounds
+    // fan-out per originating thread; this bounds POSTs on the shared receiving uploader.
     public async uploadLogs(
         _unhandledError?: Error,
         isUserInitiated = false

--- a/src/utils/logging/LogUploader.ts
+++ b/src/utils/logging/LogUploader.ts
@@ -8,7 +8,6 @@ import {
 } from "./Logger";
 import { ethers } from "ethers";
 import { retry } from "../retry";
-import { sleep } from "..";
 import {
     getAxiosFailureSummary,
     getAxiosRetrySummary,
@@ -28,7 +27,7 @@ export type LogUploaderConfig = {
 export abstract class LogUploader {
     protected logger?: Logger;
     private destroyed = false;
-    private uploadInitiated = false;
+    private lastUploadedSeq = -1;
 
     constructor(
         protected readonly logStore: LogStore,
@@ -72,50 +71,41 @@ export abstract class LogUploader {
     }
 
     public async uploadLogs(
-        unhandledError?: Error,
-        isUserInitiated = false
+        _unhandledError?: Error,
+        _isUserInitiated = false
     ): Promise<void> {
-        // TODO - use the above arguments
-        let rawLogsSize;
-        let compressedLogsSize;
+        if (!this.isEnabled()) return;
+
+        const { entries, fromSeq, toSeq } = this.logStore.getLogsSince(
+            this.lastUploadedSeq
+        );
+        if (entries.length === 0) return; // nothing new
+
+        const channelId = this.sharedContext.channelId || ethers.ZeroHash;
+        const peerAddress =
+            this.sharedContext.peerAddress || ethers.ZeroAddress;
+        const threadName = this.sharedContext.threadName;
+        if (!channelId || !peerAddress) return;
+
         const uploadStartedAt = Date.now();
+        const serializedLogs = encodeLogs(entries);
+        const rawLogsSize = serializedLogs.length * 2;
+        const compressedLogs = compressToBase64(serializedLogs);
+        const compressedLogsSize = compressedLogs.length * 2;
+
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json"
+        };
+        if (this.config.apiToken) {
+            headers["Authorization"] = `Bearer ${this.config.apiToken}`;
+        }
+        const uploadId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        headers["x-upload-id"] = uploadId;
+        console.trace(
+            `Log uploading started. uploadId=${uploadId} channelId=${channelId} peerAddress=${peerAddress} seq=[${fromSeq}..${toSeq}] Raw: ${rawLogsSize / 1e6}MB, Compressed: ${compressedLogsSize / 1e6}MB.`
+        );
+
         try {
-            if (!this.isEnabled()) return;
-
-            // Random jitter (0-3s) to spread upload bursts
-            const jitterMs = Math.floor(Math.random() * 3000);
-            if (this.uploadInitiated) return;
-            this.uploadInitiated = true;
-            await sleep(jitterMs);
-            this.uploadInitiated = false;
-
-            const storedLogs = this.logStore.getAllLogs();
-            const channelId = this.sharedContext.channelId || ethers.ZeroHash;
-            const peerAddress =
-                this.sharedContext.peerAddress || ethers.ZeroAddress;
-            const threadName = this.sharedContext.threadName;
-
-            if (!channelId || !peerAddress) {
-                return; // ignore
-            }
-
-            // Generate plain log and compress before upload
-            const serializedLogs = encodeLogs(storedLogs);
-            rawLogsSize = serializedLogs.length * 2;
-            const compressedLogs = compressToBase64(serializedLogs);
-            compressedLogsSize = compressedLogs.length * 2;
-
-            const headers: Record<string, string> = {
-                "Content-Type": "application/json"
-            };
-            if (this.config.apiToken) {
-                headers["Authorization"] = `Bearer ${this.config.apiToken}`;
-            }
-            const uploadId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-            headers["x-upload-id"] = uploadId;
-            console.trace(
-                `Log uploading started. uploadId=${uploadId} channelId=${channelId} peerAddress=${peerAddress} Raw size: ${rawLogsSize / 1e6}MB, Compressed size: ${compressedLogsSize / 1e6}MB.`
-            );
             const response = await retry(
                 async () =>
                     axios.post(
@@ -124,7 +114,9 @@ export abstract class LogUploader {
                             channelId,
                             peerAddress,
                             threadName,
-                            compressedLogs
+                            compressedLogs,
+                            fromSeq,
+                            toSeq
                         },
                         {
                             headers,
@@ -137,57 +129,28 @@ export abstract class LogUploader {
                     delayMs: 1000,
                     onRetry: (attempt, error) => {
                         const { code, status } = getAxiosRetrySummary(error);
-                        const networkSnapshot = this.getSyncNetworkSnapshot(
-                            this.config.uploadEndpoint,
-                            error
-                        );
                         console.warn(
                             `Log upload retrying. uploadId=${uploadId} attempt=${attempt + 1} code=${code || "N/A"} status=${status || "N/A"}`
-                        );
-                        console.warn(
-                            `Log upload retry diagnostics. uploadId=${uploadId}`,
-                            networkSnapshot
                         );
                     }
                 }
             );
+            // Advance the watermark ONLY on success; failures merge into the
+            // next delta.
+            this.lastUploadedSeq = toSeq;
             console.trace(
-                `Logs uploaded successfully. uploadId=${uploadId} responseUploadId=${response.headers?.["x-upload-id"] || "N/A"} channelId=${channelId} peerAddress=${peerAddress} Raw size: ${rawLogsSize / 1e6}MB, Compressed size: ${compressedLogsSize / 1e6}MB.`
+                `Logs uploaded. uploadId=${uploadId} responseUploadId=${response.headers?.["x-upload-id"] || "N/A"} seq=[${fromSeq}..${toSeq}]`
             );
-            // don't clear logs, since if multiple uploads are started, only the first will have the logs
         } catch (uploadError) {
             sanitizeAxiosErrorForLogging(uploadError);
-
-            const {
-                code,
-                status,
-                statusText,
-                timeout,
-                requestUploadId,
-                responseUploadId
-            } = getAxiosFailureSummary(uploadError);
+            const { code, status, statusText, timeout } =
+                getAxiosFailureSummary(uploadError);
             const elapsedMs = Date.now() - uploadStartedAt;
-            const networkSnapshot = this.getSyncNetworkSnapshot(
-                this.config.uploadEndpoint,
-                uploadError
-            );
-            const dnsSnapshot = await this.getDnsLookupSnapshot(
-                this.config.uploadEndpoint
-            );
-
             console.error(
-                `Log upload failed: requestUploadId=${requestUploadId || "N/A"} responseUploadId=${responseUploadId || "N/A"} channelId=${this.sharedContext.channelId || ethers.ZeroHash} peerAddress=${this.sharedContext.peerAddress || ethers.ZeroAddress} Raw size: ${rawLogsSize ? rawLogsSize / 1e6 : "N/A"}MB, Compressed size: ${compressedLogsSize ? compressedLogsSize / 1e6 : "N/A"}MB - endpoint: ${this.config.uploadEndpoint}\n Error: ${String(uploadError)}\n`,
-                {
-                    code,
-                    status,
-                    statusText,
-                    timeout,
-                    elapsedMs,
-                    networkSnapshot,
-                    dnsSnapshot
-                }
+                `Log upload failed: uploadId=${uploadId} channelId=${channelId} peerAddress=${peerAddress} seq=[${fromSeq}..${toSeq}] endpoint=${this.config.uploadEndpoint}\n Error: ${String(uploadError)}\n`,
+                { code, status, statusText, timeout, elapsedMs }
             );
-            // Swallow the error — uploads are best-effort and must not block test teardown
+            // Swallow — uploads are best-effort and must not block teardown.
         }
     }
 

--- a/src/utils/logging/Logger.ts
+++ b/src/utils/logging/Logger.ts
@@ -211,9 +211,7 @@ export abstract class Logger {
     }
     public error(message: any, ...meta: any[]): void {
         this.log("error", message, meta);
-        // Restored cross-thread fan-out: an error() now flushes ALL threads so
-        // report-bug captures a stuck-but-not-crashed worker. Throttled per
-        // logger so an error storm can't flood the gossip tree or the uploader.
+        // flush all threads (stuck-worker capture), throttled so a storm can't flood gossip/HTTP
         const interval = config.CRASH_LOG_FLUSH_MIN_INTERVAL_MS;
         const now = Date.now();
         if (now - this.lastErrorFlushAt < interval) return;

--- a/src/utils/logging/Logger.ts
+++ b/src/utils/logging/Logger.ts
@@ -5,6 +5,7 @@ import type { LogStore } from "./logStore";
 import { LoggerUtils } from "../LoggerUtils";
 import { DetachedPromises } from "../DetachedPromises";
 import type { GossipNode } from "@/utils/GossipNode";
+import { config } from "@/utils/config";
 
 // The context exclusive to each logger
 export type ExclusiveLoggerContext = {
@@ -22,7 +23,7 @@ export type SharedLoggerContext = {
 
 // Cross-thread ops every logger applies to its own state; carried opaquely by GossipNode.
 export type LoggerOp =
-    | { type: "flush" }
+    | { type: "flush"; userInitiated?: boolean }
     | { type: "updateContext"; context: SharedLoggerContext };
 
 export type LogLevel = "debug" | "info" | "warn" | "error" | "verbose";
@@ -70,6 +71,7 @@ export abstract class Logger {
     protected readonly children: Set<Logger> = new Set();
     private node?: GossipNode;
     private destroyed = false;
+    private lastErrorFlushAt = -Infinity;
     private performanceMonitorStop?: () => void;
 
     constructor(
@@ -132,7 +134,10 @@ export abstract class Logger {
     public applyOp(op: LoggerOp): Promise<void> | undefined {
         switch (op.type) {
             case "flush":
-                return this.logUploader?.uploadLogs();
+                return this.logUploader?.uploadLogs(
+                    undefined,
+                    op.userInitiated ?? false
+                );
             case "updateContext":
                 Object.assign(this.sharedContext, op.context);
                 return;
@@ -206,10 +211,14 @@ export abstract class Logger {
     }
     public error(message: any, ...meta: any[]): void {
         this.log("error", message, meta);
-        // Flush only this thread's own store — NO cross-thread gossip (error() has
-        // 60+ call sites; fanning out would re-upload every thread on every error).
-        // The report-bug path (uploadLogs) is what pulls all threads.
-        const promise = this.applyOp({ type: "flush" });
+        // Restored cross-thread fan-out: an error() now flushes ALL threads so
+        // report-bug captures a stuck-but-not-crashed worker. Throttled per
+        // logger so an error storm can't flood the gossip tree or the uploader.
+        const interval = config.CRASH_LOG_FLUSH_MIN_INTERVAL_MS;
+        const now = Date.now();
+        if (now - this.lastErrorFlushAt < interval) return;
+        this.lastErrorFlushAt = now;
+        const promise = this.originate({ type: "flush" });
         if (promise) DetachedPromises.collect(promise);
     }
     public verbose(message: any, ...meta: any[]): void {
@@ -229,7 +238,7 @@ export abstract class Logger {
         }
         const localTime = new Date().getTime() / 1000;
         this.warn(message, ...meta, localTime);
-        await this.originate({ type: "flush" });
+        await this.originate({ type: "flush", userInitiated: true });
     }
 
     // Apply an op locally AND gossip it to the rest of the tree; returns the flush promise.

--- a/src/utils/logging/browser/createLogger.ts
+++ b/src/utils/logging/browser/createLogger.ts
@@ -22,7 +22,8 @@ export const createLogger = (
         options.logUploaderConfig ||
         ({
             uploadEndpoint: config.CRASH_LOG_UPLOAD_ENDPOINT,
-            apiToken: config.CRASH_LOG_API_TOKEN || ""
+            apiToken: config.CRASH_LOG_API_TOKEN || "",
+            flushMinIntervalMs: config.CRASH_LOG_FLUSH_MIN_INTERVAL_MS
         } as LogUploaderConfig);
 
     // Store-enable follows the EFFECTIVE endpoint (injected recipe or global),

--- a/src/utils/logging/logStore.ts
+++ b/src/utils/logging/logStore.ts
@@ -26,7 +26,7 @@ export class LogStore {
         });
         this.currentSize += entrySize;
 
-        // Maintain circular buffer (evicts oldest seqs from the front)
+        // circular buffer: evict oldest from the front
         while (this.currentSize > this.maxSize && this.logs.length > 0) {
             const removed = this.logs.shift();
             if (removed) {
@@ -35,9 +35,7 @@ export class LogStore {
         }
     }
 
-    // Entries with seq > sinceSeq. Buffer is always a contiguous seq run, so
-    // fromSeq is the oldest retained seq past the cursor (a fromSeq jump past
-    // sinceSeq+1 means eviction outran the cursor — acceptable loss).
+    // Delta after sinceSeq; fromSeq jumping past sinceSeq+1 = eviction outran the cursor (lossy).
     getLogsSince(sinceSeq: number): {
         entries: LogEntry[];
         fromSeq: number;

--- a/src/utils/logging/logStore.ts
+++ b/src/utils/logging/logStore.ts
@@ -3,8 +3,10 @@ import { encodeLogEntry } from "./logEncoder";
 
 // Shared log storage helper (instance-based)
 export class LogStore {
-    private logs: Array<{ entry: LogEntry; sizeInBytes: number }> = [];
+    private logs: Array<{ entry: LogEntry; sizeInBytes: number; seq: number }> =
+        [];
     private currentSize = 0;
+    private nextSeq = 0; // monotonic; never reset by eviction
 
     constructor(
         private readonly maxSize: number,
@@ -17,16 +19,39 @@ export class LogStore {
         const serializedLog = encodeLogEntry(logEntry);
 
         const entrySize = serializedLog.length * 2; // 2* since the serialized string is UTF-16
-        this.logs.push({ entry: logEntry, sizeInBytes: entrySize });
+        this.logs.push({
+            entry: logEntry,
+            sizeInBytes: entrySize,
+            seq: this.nextSeq++
+        });
         this.currentSize += entrySize;
 
-        // Maintain circular buffer
+        // Maintain circular buffer (evicts oldest seqs from the front)
         while (this.currentSize > this.maxSize && this.logs.length > 0) {
             const removed = this.logs.shift();
             if (removed) {
                 this.currentSize -= removed.sizeInBytes;
             }
         }
+    }
+
+    // Entries with seq > sinceSeq. Buffer is always a contiguous seq run, so
+    // fromSeq is the oldest retained seq past the cursor (a fromSeq jump past
+    // sinceSeq+1 means eviction outran the cursor — acceptable loss).
+    getLogsSince(sinceSeq: number): {
+        entries: LogEntry[];
+        fromSeq: number;
+        toSeq: number;
+    } {
+        const fresh = this.logs.filter((item) => item.seq > sinceSeq);
+        if (fresh.length === 0) {
+            return { entries: [], fromSeq: sinceSeq + 1, toSeq: sinceSeq };
+        }
+        return {
+            entries: fresh.map((item) => item.entry),
+            fromSeq: fresh[0].seq,
+            toSeq: fresh[fresh.length - 1].seq
+        };
     }
 
     getAllLogs(): LogEntry[] {

--- a/src/utils/logging/node/createLogger.ts
+++ b/src/utils/logging/node/createLogger.ts
@@ -22,7 +22,8 @@ export const createLogger = (
         options.logUploaderConfig ||
         ({
             uploadEndpoint: config.CRASH_LOG_UPLOAD_ENDPOINT,
-            apiToken: config.CRASH_LOG_API_TOKEN || ""
+            apiToken: config.CRASH_LOG_API_TOKEN || "",
+            flushMinIntervalMs: config.CRASH_LOG_FLUSH_MIN_INTERVAL_MS
         } as LogUploaderConfig);
 
     // Store-enable follows the EFFECTIVE endpoint (injected recipe or global),

--- a/test/utils/logging/logStitch.test.ts
+++ b/test/utils/logging/logStitch.test.ts
@@ -18,12 +18,11 @@ const e = (m: string) => ({
 
 describe("logStitch.buildAppendLines", () => {
     it("appends new entries with seq prefixes from a fresh file", () => {
-        const { lines, newLastSeq, gap } = buildAppendLines(
+        const { lines, newLastSeq } = buildAppendLines(
             [e("a"), e("b")],
             0, // fromSeq
             -1 // lastWrittenSeq (empty file)
         );
-        expect(gap).to.equal(null);
         expect(newLastSeq).to.equal(1);
         expect(lines.map((l: string) => JSON.parse(l).seq)).to.deep.equal([
             0, 1
@@ -41,21 +40,20 @@ describe("logStitch.buildAppendLines", () => {
         expect(lines.map((l: string) => JSON.parse(l).seq)).to.deep.equal([2]);
     });
 
-    it("writes a gap marker when fromSeq jumps past lastWrittenSeq+1", () => {
-        const { lines, newLastSeq, gap } = buildAppendLines(
+    it("does not materialize a gap marker when fromSeq jumps past lastWrittenSeq+1", () => {
+        const { lines, newLastSeq } = buildAppendLines(
             [e("x")],
             16, // fromSeq
             7 // lastWrittenSeq → 8..15 missing
         );
-        expect(gap).to.deep.equal([8, 15]);
-        expect(JSON.parse(lines[0]).gap).to.deep.equal([8, 15]);
-        expect(JSON.parse(lines[1]).seq).to.equal(16);
+        expect(lines.length).to.equal(1);
+        expect(JSON.parse(lines[0]).seq).to.equal(16);
+        expect(JSON.parse(lines[0]).gap).to.equal(undefined);
         expect(newLastSeq).to.equal(16);
     });
 
     it("parseLastSeq reads the seq of the last seq-bearing NDJSON line", () => {
-        const ndjson =
-            '{"seq":0,"message":"a"}\n{"gap":[1,2]}\n{"seq":3,"message":"b"}\n';
+        const ndjson = '{"seq":0,"message":"a"}\n\n{"seq":3,"message":"b"}\n';
         expect(parseLastSeq(ndjson)).to.equal(3);
         expect(parseLastSeq("")).to.equal(-1);
     });

--- a/test/utils/logging/logStitch.test.ts
+++ b/test/utils/logging/logStitch.test.ts
@@ -1,0 +1,62 @@
+import { expect } from "chai";
+// CommonJS module under scripts/ — require it directly (no express dependency).
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {
+    buildAppendLines,
+    parseLastSeq
+} = require("../../../scripts/logging/logStitch.js");
+
+const e = (m: string) => ({
+    time: "t",
+    level: "warn",
+    context: {},
+    sharedContext: {},
+    message: m,
+    meta: [],
+    stack: ""
+});
+
+describe("logStitch.buildAppendLines", () => {
+    it("appends new entries with seq prefixes from a fresh file", () => {
+        const { lines, newLastSeq, gap } = buildAppendLines(
+            [e("a"), e("b")],
+            0, // fromSeq
+            -1 // lastWrittenSeq (empty file)
+        );
+        expect(gap).to.equal(null);
+        expect(newLastSeq).to.equal(1);
+        expect(lines.map((l: string) => JSON.parse(l).seq)).to.deep.equal([
+            0, 1
+        ]);
+        expect(JSON.parse(lines[0]).message).to.equal("a");
+    });
+
+    it("dedups entries already written on a retry", () => {
+        const { lines, newLastSeq } = buildAppendLines(
+            [e("a"), e("b"), e("c")],
+            0,
+            1 // already wrote seq 0,1
+        );
+        expect(newLastSeq).to.equal(2);
+        expect(lines.map((l: string) => JSON.parse(l).seq)).to.deep.equal([2]);
+    });
+
+    it("writes a gap marker when fromSeq jumps past lastWrittenSeq+1", () => {
+        const { lines, newLastSeq, gap } = buildAppendLines(
+            [e("x")],
+            16, // fromSeq
+            7 // lastWrittenSeq → 8..15 missing
+        );
+        expect(gap).to.deep.equal([8, 15]);
+        expect(JSON.parse(lines[0]).gap).to.deep.equal([8, 15]);
+        expect(JSON.parse(lines[1]).seq).to.equal(16);
+        expect(newLastSeq).to.equal(16);
+    });
+
+    it("parseLastSeq reads the seq of the last seq-bearing NDJSON line", () => {
+        const ndjson =
+            '{"seq":0,"message":"a"}\n{"gap":[1,2]}\n{"seq":3,"message":"b"}\n';
+        expect(parseLastSeq(ndjson)).to.equal(3);
+        expect(parseLastSeq("")).to.equal(-1);
+    });
+});

--- a/test/utils/logging/logStore.seq.test.ts
+++ b/test/utils/logging/logStore.seq.test.ts
@@ -1,0 +1,58 @@
+import { expect } from "chai";
+import { LogStore } from "@/utils/logging/logStore";
+import { LogEntry } from "@/utils/logging/Logger";
+
+function entry(message: string): LogEntry {
+    return {
+        time: "t",
+        level: "warn",
+        context: {},
+        sharedContext: {},
+        message,
+        meta: [],
+        stack: ""
+    };
+}
+
+describe("LogStore seq + getLogsSince", () => {
+    it("assigns contiguous seqs and returns only entries after the cursor", () => {
+        const store = new LogStore(10 * 1024 * 1024, true); // big: no eviction
+        for (let i = 0; i < 5; i++) store.store(entry(`m${i}`));
+
+        const all = store.getLogsSince(-1);
+        expect(all.fromSeq).to.equal(0);
+        expect(all.toSeq).to.equal(4);
+        expect(all.entries.map((e) => e.message)).to.deep.equal([
+            "m0",
+            "m1",
+            "m2",
+            "m3",
+            "m4"
+        ]);
+
+        const delta = store.getLogsSince(2);
+        expect(delta.fromSeq).to.equal(3);
+        expect(delta.toSeq).to.equal(4);
+        expect(delta.entries.map((e) => e.message)).to.deep.equal(["m3", "m4"]);
+    });
+
+    it("returns an empty range when nothing is newer than the cursor", () => {
+        const store = new LogStore(10 * 1024 * 1024, true);
+        store.store(entry("only"));
+        const r = store.getLogsSince(0);
+        expect(r.entries).to.deep.equal([]);
+        expect(r.fromSeq).to.equal(1);
+        expect(r.toSeq).to.equal(0); // empty: from > to
+    });
+
+    it("reports a gap (fromSeq jumps) when eviction outran the cursor", () => {
+        // Small cap forces eviction of the oldest entries.
+        const store = new LogStore(2000, true);
+        for (let i = 0; i < 100; i++) store.store(entry(`big-message-${i}`));
+
+        const r = store.getLogsSince(-1);
+        expect(r.toSeq).to.equal(99); // newest is always retained
+        expect(r.fromSeq).to.be.greaterThan(0); // oldest entries evicted
+        expect(r.entries.length).to.equal(r.toSeq - r.fromSeq + 1); // contiguous
+    });
+});

--- a/test/utils/logging/logUploaderDelta.test.ts
+++ b/test/utils/logging/logUploaderDelta.test.ts
@@ -21,7 +21,11 @@ function entry(message: string): LogEntry {
 function makeUploader(store: LogStore) {
     return new NodeLogUploader(
         store,
-        { uploadEndpoint: "http://localhost:9/logs/upload", apiToken: "" },
+        {
+            uploadEndpoint: "http://localhost:9/logs/upload",
+            apiToken: "",
+            flushMinIntervalMs: 0
+        },
         {},
         {
             peerAddress: "0x1111111111111111111111111111111111111111" as any,

--- a/test/utils/logging/logUploaderDelta.test.ts
+++ b/test/utils/logging/logUploaderDelta.test.ts
@@ -1,0 +1,94 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import axios from "axios";
+
+import { NodeLogUploader } from "@/utils/logging/node/NodeLogUploader";
+import { LogStore } from "@/utils/logging/logStore";
+import { LogEntry } from "@/utils/logging/Logger";
+
+function entry(message: string): LogEntry {
+    return {
+        time: "t",
+        level: "warn",
+        context: {},
+        sharedContext: {},
+        message,
+        meta: [],
+        stack: ""
+    };
+}
+
+function makeUploader(store: LogStore) {
+    return new NodeLogUploader(
+        store,
+        { uploadEndpoint: "http://localhost:9/logs/upload", apiToken: "" },
+        {},
+        {
+            peerAddress: "0x1111111111111111111111111111111111111111" as any,
+            channelId:
+                "0x2222222222222222222222222222222222222222222222222222222222222222",
+            threadName: "evm"
+        },
+        false
+    );
+}
+
+describe("LogUploader delta + watermark", () => {
+    let postStub: sinon.SinonStub;
+    let randomStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        randomStub = sinon.stub(Math, "random").returns(0);
+        postStub = sinon
+            .stub(axios, "post")
+            .resolves({ headers: {}, data: {} } as any);
+    });
+    afterEach(() => {
+        randomStub.restore();
+        postStub.restore();
+    });
+
+    it("uploads only entries newer than the last successful upload", async () => {
+        const store = new LogStore(10 * 1024 * 1024, true);
+        store.store(entry("a"));
+        store.store(entry("b"));
+        const uploader = makeUploader(store);
+
+        await uploader.uploadLogs();
+        let body = postStub.lastCall.args[1] as Record<string, unknown>;
+        expect(body.fromSeq).to.equal(0);
+        expect(body.toSeq).to.equal(1);
+
+        store.store(entry("c"));
+        await uploader.uploadLogs();
+        body = postStub.lastCall.args[1] as Record<string, unknown>;
+        expect(body.fromSeq).to.equal(2);
+        expect(body.toSeq).to.equal(2);
+        expect(postStub.calledTwice).to.equal(true);
+    });
+
+    it("skips the POST when there is nothing new", async () => {
+        const store = new LogStore(10 * 1024 * 1024, true);
+        store.store(entry("a"));
+        const uploader = makeUploader(store);
+
+        await uploader.uploadLogs();
+        await uploader.uploadLogs(); // no new entries
+        expect(postStub.calledOnce).to.equal(true);
+    });
+
+    it("does not advance the watermark when the upload fails", async () => {
+        const store = new LogStore(10 * 1024 * 1024, true);
+        store.store(entry("a"));
+        const uploader = makeUploader(store);
+
+        postStub.rejects(new Error("network down"));
+        await uploader.uploadLogs(); // swallowed
+        postStub.resolves({ headers: {}, data: {} } as any);
+
+        await uploader.uploadLogs(); // retries the same entry
+        const body = postStub.lastCall.args[1] as Record<string, unknown>;
+        expect(body.fromSeq).to.equal(0);
+        expect(body.toSeq).to.equal(0);
+    });
+});

--- a/test/utils/logging/logUploaderThrottle.test.ts
+++ b/test/utils/logging/logUploaderThrottle.test.ts
@@ -1,0 +1,86 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import axios from "axios";
+
+import { NodeLogUploader } from "@/utils/logging/node/NodeLogUploader";
+import { LogStore } from "@/utils/logging/logStore";
+import { LogEntry } from "@/utils/logging/Logger";
+
+function entry(message: string): LogEntry {
+    return {
+        time: "t",
+        level: "warn",
+        context: {},
+        sharedContext: {},
+        message,
+        meta: [],
+        stack: ""
+    };
+}
+
+function makeUploader(store: LogStore, flushMinIntervalMs: number) {
+    return new NodeLogUploader(
+        store,
+        {
+            uploadEndpoint: "http://localhost:9/logs/upload",
+            apiToken: "",
+            flushMinIntervalMs
+        },
+        {},
+        {
+            peerAddress: "0x1111111111111111111111111111111111111111" as any,
+            channelId:
+                "0x2222222222222222222222222222222222222222222222222222222222222222",
+            threadName: "evm"
+        },
+        false
+    );
+}
+
+describe("LogUploader throttle", () => {
+    let clock: sinon.SinonFakeTimers;
+    let postStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers();
+        postStub = sinon
+            .stub(axios, "post")
+            .resolves({ headers: {}, data: {} } as any);
+    });
+    afterEach(() => {
+        postStub.restore();
+        clock.restore();
+    });
+
+    it("coalesces rapid triggers into one leading + one trailing upload", async () => {
+        const store = new LogStore(10 * 1024 * 1024, true);
+        const uploader = makeUploader(store, 1000);
+
+        store.store(entry("a"));
+        await uploader.uploadLogs(); // leading: uploads immediately
+        expect(postStub.callCount).to.equal(1);
+
+        store.store(entry("b"));
+        await uploader.uploadLogs(); // within window: schedules trailing
+        store.store(entry("c"));
+        await uploader.uploadLogs(); // within window: collapses into the trailing
+        expect(postStub.callCount).to.equal(1);
+
+        await clock.tickAsync(1000); // fire the trailing timer
+        expect(postStub.callCount).to.equal(2);
+        const body = postStub.lastCall.args[1] as Record<string, unknown>;
+        expect(body.fromSeq).to.equal(1);
+        expect(body.toSeq).to.equal(2); // b and c, batched
+    });
+
+    it("user-initiated uploads bypass the throttle", async () => {
+        const store = new LogStore(10 * 1024 * 1024, true);
+        const uploader = makeUploader(store, 1000);
+
+        store.store(entry("a"));
+        await uploader.uploadLogs(); // leading
+        store.store(entry("b"));
+        await uploader.uploadLogs(undefined, true); // bypass → immediate
+        expect(postStub.callCount).to.equal(2);
+    });
+});

--- a/test/utils/logging/logUploaderThrottle.test.ts
+++ b/test/utils/logging/logUploaderThrottle.test.ts
@@ -83,4 +83,43 @@ describe("LogUploader throttle", () => {
         await uploader.uploadLogs(undefined, true); // bypass → immediate
         expect(postStub.callCount).to.equal(2);
     });
+
+    it("never POSTs two deltas concurrently (single-flight)", async () => {
+        const store = new LogStore(10 * 1024 * 1024, true);
+        const uploader = makeUploader(store, 0); // no throttle window
+
+        // First POST hangs until released; later POSTs resolve at once.
+        let calls = 0;
+        let releaseFirst: (v: any) => void = () => {};
+        postStub.callsFake(() => {
+            calls++;
+            if (calls === 1) {
+                return new Promise((res) => {
+                    releaseFirst = res;
+                });
+            }
+            return Promise.resolve({ headers: {}, data: {} } as any);
+        });
+
+        store.store(entry("a"));
+        const first = uploader.uploadLogs(); // starts doUpload, awaits the hanging POST
+        store.store(entry("b"));
+        // A second trigger (e.g. user-initiated report-bug) while the first is
+        // in flight must NOT launch a concurrent POST.
+        await uploader.uploadLogs(undefined, true);
+        expect(postStub.callCount).to.equal(1);
+
+        releaseFirst({ headers: {}, data: {} });
+        await first;
+
+        // The pending trigger flushed the newer delta only after the first
+        // completed — two sequential POSTs, never overlapping.
+        expect(postStub.callCount).to.equal(2);
+        expect(
+            (postStub.firstCall.args[1] as Record<string, unknown>).toSeq
+        ).to.equal(0);
+        expect(
+            (postStub.secondCall.args[1] as Record<string, unknown>).toSeq
+        ).to.equal(1);
+    });
 });

--- a/test/utils/logging/loggerErrorFanout.test.ts
+++ b/test/utils/logging/loggerErrorFanout.test.ts
@@ -1,0 +1,59 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import { createLogger } from "@/utils";
+import { createConfig } from "@/utils/config";
+import { LogUploader } from "@/utils/logging/LogUploader";
+import { LogStore } from "@/utils/logging/logStore";
+
+class FakeUploader extends LogUploader {
+    public uploadCount = 0;
+    protected attachListeners(): void {}
+    protected detachListeners(): void {}
+    public async uploadLogs(): Promise<void> {
+        this.uploadCount++;
+    }
+}
+
+function makeLogger() {
+    const shared = { threadName: "sdk" } as Record<string, unknown>;
+    const fake = new FakeUploader(
+        new LogStore(1024 * 1024, true),
+        { uploadEndpoint: "http://example.test", apiToken: "" },
+        { component: "T" },
+        shared as any
+    );
+    const logger = createLogger(
+        shared as any,
+        { component: "T" },
+        { logUploader: fake, level: "info" }
+    );
+    return { logger, fake };
+}
+
+describe("Logger.error fan-out throttle", () => {
+    let clock: sinon.SinonFakeTimers;
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers();
+        createConfig({ CRASH_LOG_FLUSH_MIN_INTERVAL_MS: 1000 });
+    });
+    afterEach(() => {
+        clock.restore();
+        createConfig({}); // reset to defaults
+    });
+
+    it("flushes at most once per interval despite rapid error() calls", async () => {
+        const { logger, fake } = makeLogger();
+
+        logger.error("boom 1");
+        logger.error("boom 2");
+        logger.error("boom 3");
+        await clock.tickAsync(0); // let detached flush promises settle
+        expect(fake.uploadCount).to.equal(1);
+
+        await clock.tickAsync(1000);
+        logger.error("boom 4");
+        await clock.tickAsync(0);
+        expect(fake.uploadCount).to.equal(2);
+    });
+});


### PR DESCRIPTION
Follow-up to #344. Makes crash-log uploads **incremental** using sequenced `ndjson` appends.

`logStore` tracks a `seq` number now, so each thread uploads only the log entries it hasn't sent yet and the server **appends** them per `(channel, peer, thread)` instead of re-POSTing and overwriting the whole 10 MB buffer on every flush.

This makes the cross-thread flush cheap enough to **restore `error()`'s all-threads flush**.

`LogUploader` also throttles so it doesn't storm.

Follow up TBD (perhaps in a separate PR would be better):

- [ ] Update `scripts/logging/crash-log-server.js` to account for the latest changes end to end
- [ ] Update log-explorer ui to account for the changes