### PR TITLE
fix(webrtc): harden worker-thread WebRTC bridge resilience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,7 @@
 - For post-edit validation, run the narrowest relevant test first when available.
 - Run `yarn tsc --noEmit -p tsconfig.json` for TypeScript typechecking.
 - Run `yarn compile` for compile-level validation when changes affect the build or exported package surface.
+
+## Conventions
+
+- Never log with `console.*`. Use the internal logger (the one returned during `p2pSetup`); its output is collected and shipped for analysis, so `console.*` calls are invisible to that pipeline. This applies to main-thread code too. If a module has no logger in scope, thread one through its options/params rather than reaching for `console.*`.

--- a/src/rpc/services/WebRTCSetup/connection/LocalWebRTCConnectionFactory.ts
+++ b/src/rpc/services/WebRTCSetup/connection/LocalWebRTCConnectionFactory.ts
@@ -51,7 +51,14 @@ class LocalWebRTCConnectionFactory implements WebRTCConnectionFactory {
         this.connectionMap.set(peerAddress, connection);
 
         connection.onicecandidate = (event: { candidate?: any }) => {
-            if (event.candidate) callbacks.onIceCandidate(event.candidate);
+            if (!event.candidate) return;
+            // Normalize to a plain init dict so JSON.stringify downstream
+            // produces a candidate the remote can reconstruct across engines.
+            const candidate =
+                typeof event.candidate.toJSON === "function"
+                    ? event.candidate.toJSON()
+                    : event.candidate;
+            callbacks.onIceCandidate(candidate);
         };
 
         const notifyState = () => {

--- a/src/rpc/services/WebRTCSetup/connection/WebRTCBridgeProtocol.ts
+++ b/src/rpc/services/WebRTCSetup/connection/WebRTCBridgeProtocol.ts
@@ -19,24 +19,20 @@ export type WebRTCBridgeRequest =
     | {
           method: "acceptOffer";
           peerAddress: WebRTCPeerAddress;
-          offer: any;
+          offer: RTCSessionDescriptionInit;
       }
     | {
           method: "applyAnswer";
           peerAddress: WebRTCPeerAddress;
-          answer: any;
+          answer: RTCSessionDescriptionInit;
       }
     | {
           method: "addIceCandidate";
           peerAddress: WebRTCPeerAddress;
-          candidate: any;
+          candidate: RTCIceCandidateInit;
       }
     | {
           method: "close";
-          peerAddress: WebRTCPeerAddress;
-      }
-    | {
-          method: "getState";
           peerAddress: WebRTCPeerAddress;
       };
 
@@ -90,7 +86,7 @@ export type WebRTCBridgePortMessage =
           namespace: typeof WEBRTC_BRIDGE_NAMESPACE;
           type: "iceCandidate";
           peerAddress: WebRTCPeerAddress;
-          candidate: any;
+          candidate: RTCIceCandidateInit;
       }
     | {
           namespace: typeof WEBRTC_BRIDGE_NAMESPACE;

--- a/src/rpc/services/WebRTCSetup/connection/WebRTCMainThreadBridge.ts
+++ b/src/rpc/services/WebRTCSetup/connection/WebRTCMainThreadBridge.ts
@@ -13,7 +13,24 @@ import type {
 } from "./WebRTCConnectionTypes";
 import { loadWebRTCProvider, type WebRTCProvider } from "./WebRTCProvider";
 
+export type WebRTCChannelMode = "auto" | "transfer" | "proxy";
+
 export type WebRTCMainThreadBridgeOptions = {
+    /**
+     * How a freshly-created RTCDataChannel is handed to the worker:
+     *  - "auto" (default): attempt to transfer the channel to the worker and,
+     *    if the runtime can't transfer it, fall back to proxying its messages
+     *    over the bridge.
+     *  - "transfer": only transfer; throw if the runtime can't (strict).
+     *  - "proxy": always proxy — use when transfer is known-unsupported
+     *    (e.g. Firefox/Safari) or in tests.
+     */
+    channelMode?: WebRTCChannelMode;
+    /**
+     * Whether "auto" mode may fall back to proxying when a transfer attempt
+     * fails. Defaults to true so the bridge works on runtimes that do not
+     * support transferable RTCDataChannels.
+     */
     allowProxyFallback?: boolean;
 };
 
@@ -32,6 +49,9 @@ type ConnectionRecord = {
 
 class WebRTCMainThreadBridgeBroker {
     private provider?: WebRTCProvider;
+    // Cached the first time "auto" mode attempts a transfer: once we learn the
+    // runtime can't transfer channels we go straight to proxy for the rest.
+    private channelTransferSupported?: boolean;
     private readonly connectionsByPeerAddress = new Map<
         WebRTCPeerAddress,
         ConnectionRecord
@@ -134,9 +154,11 @@ class WebRTCMainThreadBridgeBroker {
         if (request.method === "close") {
             return this.close(request.peerAddress);
         }
-        if (request.method === "getState") {
-            return this.getState(request.peerAddress);
-        }
+        throw new Error(
+            `Unknown WebRTC bridge request method: ${
+                (request as { method?: string }).method
+            }`
+        );
     }
 
     private async createConnectionRecord(
@@ -255,22 +277,16 @@ class WebRTCMainThreadBridgeBroker {
         record.connection.close();
     }
 
-    private getState(
-        peerAddress: WebRTCPeerAddress
-    ): WebRTCConnectionStateSnapshot {
-        const connection =
-            this.connectionsByPeerAddress.get(peerAddress)?.connection;
-        if (!connection) {
-            return { connectionState: "unknown", iceState: "unknown" };
-        }
-        return this.getSnapshot(connection);
-    }
-
     private postChannel(
         peerAddress: WebRTCPeerAddress,
         record: ConnectionRecord,
         channel: WebRTCDataChannelLike
     ): void {
+        if (this.shouldProxyChannel()) {
+            this.postProxyChannel(peerAddress, record, channel);
+            return;
+        }
+
         const transferredMessage: WebRTCBridgePortMessage = {
             namespace: WEBRTC_BRIDGE_NAMESPACE,
             type: "channel",
@@ -281,13 +297,41 @@ class WebRTCMainThreadBridgeBroker {
 
         try {
             this.post(transferredMessage, [channel as unknown as Transferable]);
+            this.channelTransferSupported = true;
             return;
         } catch (error) {
-            if (!this.options.allowProxyFallback) {
+            this.channelTransferSupported = false;
+            const channelMode = this.options.channelMode ?? "auto";
+            const allowProxyFallback = this.options.allowProxyFallback ?? true;
+            if (channelMode === "transfer" || !allowProxyFallback) {
                 throw error;
             }
+            // Surface the reason once (subsequent channels skip the attempt via
+            // shouldProxyChannel) so a transfer-unsupported runtime is visible
+            // rather than silently degrading.
+            console.warn(
+                "[peer3:webrtc-bridge] RTCDataChannel transfer is unsupported in this runtime; " +
+                    "falling back to proxying channel messages over the bridge.",
+                error
+            );
         }
 
+        this.postProxyChannel(peerAddress, record, channel);
+    }
+
+    private shouldProxyChannel(): boolean {
+        const channelMode = this.options.channelMode ?? "auto";
+        if (channelMode === "proxy") return true;
+        if (channelMode === "transfer") return false;
+        // "auto": once a transfer attempt has failed, never attempt again.
+        return this.channelTransferSupported === false;
+    }
+
+    private postProxyChannel(
+        peerAddress: WebRTCPeerAddress,
+        record: ConnectionRecord,
+        channel: WebRTCDataChannelLike
+    ): void {
         record.proxiedChannel = channel;
         this.wireProxyChannel(peerAddress, record, channel);
         this.post({

--- a/src/rpc/services/WebRTCSetup/connection/WebRTCMainThreadBridge.ts
+++ b/src/rpc/services/WebRTCSetup/connection/WebRTCMainThreadBridge.ts
@@ -12,6 +12,7 @@ import type {
     WebRTCPeerConnectionLike
 } from "./WebRTCConnectionTypes";
 import { loadWebRTCProvider, type WebRTCProvider } from "./WebRTCProvider";
+import type { Logger } from "@/utils/logging/Logger";
 
 export type WebRTCChannelMode = "auto" | "transfer" | "proxy";
 
@@ -27,11 +28,11 @@ export type WebRTCMainThreadBridgeOptions = {
      */
     channelMode?: WebRTCChannelMode;
     /**
-     * Whether "auto" mode may fall back to proxying when a transfer attempt
-     * fails. Defaults to true so the bridge works on runtimes that do not
-     * support transferable RTCDataChannels.
+     * Logger for bridge diagnostics on the main thread. Pass the logger
+     * returned by `p2pSetup` so notices reach the SDK log pipeline instead of
+     * the console.
      */
-    allowProxyFallback?: boolean;
+    logger?: Logger;
 };
 
 export type WebRTCMainThreadBridgeHandle = {
@@ -301,15 +302,13 @@ class WebRTCMainThreadBridgeBroker {
             return;
         } catch (error) {
             this.channelTransferSupported = false;
-            const channelMode = this.options.channelMode ?? "auto";
-            const allowProxyFallback = this.options.allowProxyFallback ?? true;
-            if (channelMode === "transfer" || !allowProxyFallback) {
+            if ((this.options.channelMode ?? "auto") === "transfer") {
                 throw error;
             }
             // Surface the reason once (subsequent channels skip the attempt via
             // shouldProxyChannel) so a transfer-unsupported runtime is visible
             // rather than silently degrading.
-            console.warn(
+            this.options.logger?.warn(
                 "[peer3:webrtc-bridge] RTCDataChannel transfer is unsupported in this runtime; " +
                     "falling back to proxying channel messages over the bridge.",
                 error

--- a/src/rpc/services/WebRTCSetup/connection/WorkerBridgeWebRTCConnectionFactory.ts
+++ b/src/rpc/services/WebRTCSetup/connection/WorkerBridgeWebRTCConnectionFactory.ts
@@ -18,6 +18,11 @@ const UNKNOWN_STATE: WebRTCConnectionStateSnapshot = {
     iceState: "unknown"
 };
 
+// Worker→main bridge requests are local postMessage round-trips that normally
+// settle in milliseconds. This bound only exists so a dropped/closed bridge can
+// never leave an awaiting WebRTC setup call hanging forever.
+const BRIDGE_REQUEST_TIMEOUT_MS = 30_000;
+
 function isWorkerRuntime(): boolean {
     const runtime = globalThis as any;
     return (
@@ -87,6 +92,7 @@ class WebRTCWorkerBridgeClient {
         {
             resolve: (value: any) => void;
             reject: (error: Error) => void;
+            timeoutId: ReturnType<typeof setTimeout>;
         }
     >();
     private readonly callbacksByPeerAddress = new Map<
@@ -122,7 +128,10 @@ class WebRTCWorkerBridgeClient {
         return this.stateByPeerAddress.get(peerAddress) || UNKNOWN_STATE;
     }
 
-    request(request: WebRTCBridgeRequest): Promise<any> {
+    request(
+        request: WebRTCBridgeRequest,
+        timeoutMs = BRIDGE_REQUEST_TIMEOUT_MS
+    ): Promise<any> {
         const requestId = this.nextRequestId++;
         const message: WebRTCBridgePortMessage = {
             namespace: WEBRTC_BRIDGE_NAMESPACE,
@@ -132,9 +141,38 @@ class WebRTCWorkerBridgeClient {
         };
 
         return new Promise((resolve, reject) => {
-            this.pendingRequests.set(requestId, { resolve, reject });
+            const timeoutId = setTimeout(() => {
+                if (!this.pendingRequests.delete(requestId)) return;
+                reject(
+                    new Error(
+                        `WebRTC bridge request "${request.method}" timed out after ${timeoutMs}ms`
+                    )
+                );
+            }, timeoutMs);
+            this.pendingRequests.set(requestId, {
+                resolve,
+                reject,
+                timeoutId
+            });
             this.port.postMessage(message);
         });
+    }
+
+    /**
+     * Rejects every in-flight request and detaches the port. Called when the
+     * bridge port is replaced or torn down so awaiting WebRTC setup calls fail
+     * fast instead of hanging on a port that will never respond.
+     */
+    dispose(
+        reason = "WebRTC bridge port closed before the request completed"
+    ): void {
+        for (const pending of this.pendingRequests.values()) {
+            clearTimeout(pending.timeoutId);
+            pending.reject(new Error(reason));
+        }
+        this.pendingRequests.clear();
+        this.port.onmessage = null;
+        this.port.close?.();
     }
 
     private handleMessage(message: WebRTCBridgePortMessage): void {
@@ -144,6 +182,7 @@ class WebRTCWorkerBridgeClient {
             const pending = this.pendingRequests.get(message.requestId);
             if (!pending) return;
             this.pendingRequests.delete(message.requestId);
+            clearTimeout(pending.timeoutId);
             if (message.ok) {
                 pending.resolve(message.result);
             } else {
@@ -243,7 +282,9 @@ class WorkerBridgeWebRTCConnectionFactory implements WebRTCConnectionFactory {
     }
 
     registerPort(port: MessagePort): void {
-        this.bridgePort?.close?.();
+        this.client?.dispose(
+            "WebRTC bridge port was replaced before the request completed"
+        );
         this.bridgePort = port;
         this.client = new WebRTCWorkerBridgeClient(port);
 
@@ -278,13 +319,16 @@ class WorkerBridgeWebRTCConnectionFactory implements WebRTCConnectionFactory {
 
     ensureReceiverRegistered(): void {
         if (this.receiverRegistered) return;
-        this.receiverRegistered = true;
 
         if (!isWorkerRuntime()) return;
 
         const runtime = globalThis as any;
         if (typeof runtime.addEventListener !== "function") return;
         if (typeof runtime.removeEventListener !== "function") return;
+
+        // Only latch the flag once we are actually attaching the listener, so a
+        // premature main-thread call can't permanently suppress registration.
+        this.receiverRegistered = true;
 
         const listener = ((event: MessageEvent) => {
             if (!this.isBridgeInitMessage(event.data)) return;

--- a/src/rpc/services/initHandshake/InitHandshakeRpcMethods.ts
+++ b/src/rpc/services/initHandshake/InitHandshakeRpcMethods.ts
@@ -228,6 +228,11 @@ class InitHandshakeRpcMethods extends ARpcMethods {
     /**
      * Sent after a peer verifies our handshake response. We only treat the handshake
      * as complete once we have both: (1) verified the remote, and (2) received this ack.
+     *
+     * `challengeHash` is a diagnostic correlation id only — it lets a single log
+     * stream be followed across the two threads/peers. It is NOT an authenticity
+     * check and MUST NOT be trusted for any decision: peer authenticity is
+     * established solely by signature verification in `onInitHandshakeResponse`.
      */
     public async onInitHandshakeAck(challengeHash?: Hash) {
         LoggerUtils.logInitHandshakeMessage(

--- a/test/browser/run-worker-contract-executor.mjs
+++ b/test/browser/run-worker-contract-executor.mjs
@@ -97,7 +97,8 @@ try {
             () =>
                 Boolean(globalThis.runContractExecutorWorkerBrowserSmoke) &&
                 Boolean(globalThis.runWebRTCMainThreadBrowserSmoke) &&
-                Boolean(globalThis.runWebRTCDedicatedWorkerBrowserSmoke)
+                Boolean(globalThis.runWebRTCDedicatedWorkerBrowserSmoke) &&
+                Boolean(globalThis.runWebRTCProxyWorkerBrowserSmoke)
         );
     } catch (error) {
         if (browserErrors.length) {
@@ -118,6 +119,11 @@ try {
         if (!globalThis.runWebRTCDedicatedWorkerBrowserSmoke) {
             throw new Error(
                 "WebRTC dedicated-worker smoke function was not registered"
+            );
+        }
+        if (!globalThis.runWebRTCProxyWorkerBrowserSmoke) {
+            throw new Error(
+                "WebRTC proxy-worker smoke function was not registered"
             );
         }
         const withTimeout = (label, promise) =>
@@ -143,10 +149,15 @@ try {
             "WebRTC dedicated-worker browser smoke",
             globalThis.runWebRTCDedicatedWorkerBrowserSmoke()
         );
+        const webRTCProxyWorker = await withTimeout(
+            "WebRTC proxy-worker browser smoke",
+            globalThis.runWebRTCProxyWorkerBrowserSmoke()
+        );
         return {
             contractExecutor,
             webRTCMainThread,
-            webRTCDedicatedWorker
+            webRTCDedicatedWorker,
+            webRTCProxyWorker
         };
     });
 
@@ -156,6 +167,8 @@ try {
     assert.equal(result.webRTCMainThread.receivedByResponder, 1);
     assert.equal(result.webRTCDedicatedWorker.receivedByMain, 1);
     assert.equal(result.webRTCDedicatedWorker.receivedByWorker, 1);
+    assert.equal(result.webRTCProxyWorker.receivedByMain, 1);
+    assert.equal(result.webRTCProxyWorker.receivedByWorker, 1);
     assert.equal(browserErrors.length, 0, browserErrors[0]?.stack);
 
     console.log("Browser worker and WebRTC smoke passed");

--- a/test/browser/webrtc-service-smoke.js
+++ b/test/browser/webrtc-service-smoke.js
@@ -279,7 +279,7 @@ globalThis.runWebRTCMainThreadBrowserSmoke = async () => {
     };
 };
 
-globalThis.runWebRTCDedicatedWorkerBrowserSmoke = async () => {
+async function runWebRTCWorkerBridgeSmoke(bridgeOptions = {}) {
     const errors = [];
     const progress = [];
     const mainHarness = createServiceHarness(
@@ -299,7 +299,7 @@ globalThis.runWebRTCDedicatedWorkerBrowserSmoke = async () => {
         new URL("./webrtc-service-worker.js", import.meta.url),
         { type: "module" }
     );
-    const bridge = installWebRTCMainThreadBridge(worker);
+    const bridge = installWebRTCMainThreadBridge(worker, bridgeOptions);
 
     const postToWorker = (message) => worker.postMessage(message);
 
@@ -453,4 +453,14 @@ globalThis.runWebRTCDedicatedWorkerBrowserSmoke = async () => {
         bridge.dispose();
         worker.terminate();
     }
-};
+}
+
+globalThis.runWebRTCDedicatedWorkerBrowserSmoke = () =>
+    runWebRTCWorkerBridgeSmoke();
+
+// Force the proxy path: channel traffic is relayed over the bridge rather than
+// handed to the worker as a transferred RTCDataChannel. Chromium supports
+// channel transfer, so without forcing this the proxy path (the one
+// Firefox/Safari always take) is never exercised end-to-end.
+globalThis.runWebRTCProxyWorkerBrowserSmoke = () =>
+    runWebRTCWorkerBridgeSmoke({ channelMode: "proxy" });

--- a/test/utils/WebRTCTransport.test.ts
+++ b/test/utils/WebRTCTransport.test.ts
@@ -69,13 +69,33 @@ function createP2PManager(
 }
 
 describe("WebRTCTransport", function () {
-    it("rejects a data channel that is not open", function () {
+    it("queues sends on a connecting channel and flushes them once it opens", function () {
         const channel = new FakeRTCDataChannel();
         channel.readyState = "connecting";
 
-        expect(() => new WebRTCTransport(channel, createP2PManager())).to.throw(
-            "WebRTCTransport requires an open RTCDataChannel"
+        let handshakes = 0;
+        const transport = new WebRTCTransport(
+            channel,
+            createP2PManager({
+                onInitHandshake: () => {
+                    handshakes++;
+                }
+            })
         );
+
+        // A non-open channel must not send, handshake, or throw on construction.
+        expect(handshakes).to.equal(0);
+
+        transport._send("queued-1");
+        transport._send("queued-2");
+        expect(channel.sent).to.deep.equal([]);
+
+        // Once the channel opens, queued RPCs flush in order and the handshake starts.
+        channel.readyState = "open";
+        channel.onopen?.();
+
+        expect(channel.sent).to.deep.equal(["queued-1", "queued-2"]);
+        expect(handshakes).to.equal(1);
     });
 
     it("starts the WebRTC handshake when constructed with an open channel", function () {
@@ -94,6 +114,24 @@ describe("WebRTCTransport", function () {
         expect(transport.webRTCChannel.readyState).to.equal("open");
     });
 
+    it("starts the handshake only once even if the open event fires again", function () {
+        const channel = new FakeRTCDataChannel();
+        let handshakes = 0;
+        new WebRTCTransport(
+            channel,
+            createP2PManager({
+                onInitHandshake: () => {
+                    handshakes++;
+                }
+            })
+        );
+
+        // Constructed open (handshake #1); a redundant open event must not re-handshake.
+        channel.onopen?.();
+
+        expect(handshakes).to.equal(1);
+    });
+
     it("sends over the open data channel", function () {
         const channel = new FakeRTCDataChannel();
         const transport = new WebRTCTransport(channel, createP2PManager());
@@ -101,5 +139,15 @@ describe("WebRTCTransport", function () {
         transport._send("outbound");
 
         expect(channel.sent).to.deep.equal(["outbound"]);
+    });
+
+    it("drops sends when the channel is already closed", function () {
+        const channel = new FakeRTCDataChannel();
+        channel.readyState = "closed";
+        const transport = new WebRTCTransport(channel, createP2PManager());
+
+        transport._send("dropped");
+
+        expect(channel.sent).to.deep.equal([]);
     });
 });

--- a/test/utils/WebRTCWorkerBridgeConnectionFactory.test.ts
+++ b/test/utils/WebRTCWorkerBridgeConnectionFactory.test.ts
@@ -139,4 +139,32 @@ describe("WorkerBridgeWebRTCConnectionFactory", function () {
         });
         expect(iceCandidate).to.deep.equal({ candidate: "candidate:1" });
     });
+
+    it("rejects in-flight requests when the bridge port is replaced", async function () {
+        const first = new MessageChannel();
+        const factory = WorkerBridgeWebRTCConnectionFactory.getInstance();
+        factory.registerPort(first.port1);
+
+        const offerPromise = factory.createOffer("0xpeer", {
+            onIceCandidate: () => undefined,
+            onDataChannel: () => undefined,
+            onConnectionStateChange: () => undefined,
+            onError: () => undefined
+        });
+
+        // Replacing the port must reject the abandoned request rather than
+        // leaving its awaiting WebRTC setup call pending forever.
+        const second = new MessageChannel();
+        factory.registerPort(second.port1);
+
+        let rejection: Error | undefined;
+        try {
+            await offerPromise;
+        } catch (error) {
+            rejection = error as Error;
+        }
+
+        expect(rejection).to.be.instanceOf(Error);
+        expect(rejection?.message).to.contain("replaced");
+    });
 });


### PR DESCRIPTION
Builds on #342 (`webrtc-worker`). This PR targets that branch so the changes show up as a reviewable delta on top of the worker-thread WebRTC work, rather than as inline comments.

## Summary

Hardening for the worker→main WebRTC bridge introduced in #342:

- **Bound the bridge request lifecycle.** Worker→main requests (`createOffer`/`acceptOffer`/`applyAnswer`/`addIceCandidate`/`close`) had no timeout and nothing rejected in-flight requests when the `MessagePort` was replaced or the bridge was torn down. A dropped/closed bridge could leave the awaiting WebRTC setup call pending forever. Each request now has a timeout, and replacing the port rejects its in-flight requests via a `dispose()` on the bridge client.
- **Made channel delivery safe by default and deterministic.** Transferable `RTCDataChannel` is Chromium-only; on Firefox/Safari the transfer attempt throws. The bridge defaulted to *not* falling back, so channel setup failed there (and on `acceptOffer` it failed asymmetrically, after the answer was already returned). Proxy fallback now defaults on, the transfer-vs-proxy choice is explicit via a `channelMode` option (`auto` | `transfer` | `proxy`) plus a one-time capability cache, and a transfer-unsupported runtime is logged once instead of silently degrading.
- **Normalized local-path ICE candidates** via `toJSON()` so they serialize to a reconstructable init dict across engines (matching the bridge path).
- **Removed the unreachable `getState` bridge request path** and made the broker throw on an unknown method instead of resolving `undefined`.
- **Registered the worker bridge listener before latching its guard flag**, so a premature main-thread call can't suppress registration.
- **Documented** that the handshake-ack `challengeHash` is a diagnostic correlation id, not an authenticity check (authenticity is the signature check in `onInitHandshakeResponse`).

### Note for review
`challengeHash` is documented as diagnostic rather than turned into a validated check: real validation needs the responder to persist the request-side challenge and adds a new handshake failure path that isn't end-to-end verifiable from the current browser smoke. Happy to add it if you'd prefer — it's your handshake design call.

## Test Plan

- `tsc --noEmit` on both `tsconfig.json` and `tsconfig.browser.json` — clean.
- **Full `yarn test` (non-e2e hardhat suite) — 257 passing.** Includes the WebRTC unit tests:
  - Rewrote the transport test that asserted a constructor throw the rewrite no longer performs; it now asserts queue-then-flush-on-open, plus closed-drop and handshake-dedup.
  - Added a worker-bridge port-replacement rejection test.
- `yarn test:browser:worker` (real headless Chromium via Playwright) — pass, including a **new forced-proxy worker-bridge smoke** so the proxy path (the one Firefox/Safari always take) is exercised end-to-end; Chromium otherwise always transfers and never hits it.