### PR TITLE
fix(harness): resolve harness-control RPC manifest by runtime extension

### DIFF
--- a/test/fixtures/PeerTestHarness.ts
+++ b/test/fixtures/PeerTestHarness.ts
@@ -593,11 +593,15 @@ export class PeerTestHarness<
      * {@link HarnessControlRpc}) takes precedence.
      */
     private resolveHarnessRpcManifest(): CustomRpcManifest {
+        // Resolve the sibling RPC with the same extension this module runs as:
+        // ".js" when consumed from the built dist, ".ts" under ts-node. A
+        // hardcoded ".ts" breaks dist consumers, where only ".js" ships.
+        const ext = __filename.endsWith(".ts") ? "ts" : "js";
         return (
             this.options.customRpcManifest ?? {
                 module: path.resolve(
                     __dirname,
-                    "customRpc/harnessControl/HarnessControlRpc.ts"
+                    `customRpc/harnessControl/HarnessControlRpc.${ext}`
                 )
             }
         );


### PR DESCRIPTION
## Summary

`PeerTestHarness.resolveHarnessRpcManifest()` builds the default custom-RPC manifest that **every** peer is constructed with, pointing at the harness-control RPC module. The path was hardcoded with a `.ts` extension:

```ts
module: path.resolve(__dirname, "customRpc/harnessControl/HarnessControlRpc.ts")
```

This resolves only when the harness runs from source under ts-node, where `__dirname` is `test/fixtures/` and the `.ts` file exists. It breaks when the SDK is consumed as the **built package**: downstream consumers import the harness via the `./test-harness` export, which resolves to `dist/test-harness.js`, so `__dirname` is inside `dist/test/fixtures/` — where only the compiled `.js` ships, not `.ts`. The runtime module loader then throws:

```
Cannot find module '.../dist/test/fixtures/customRpc/harnessControl/HarnessControlRpc.ts'
imported from '.../dist/src/utils/moduleLoader/node/importModuleFromManifest.js'
```

Because this is the default manifest, it fails harness **setup** — so it takes down every downstream integration spec that consumes the SDK from `dist`, not a single test.

## Fix

Derive the extension from the running module so the manifest resolves the sibling that actually exists next to it — `.js` when consumed from `dist`, `.ts` under ts-node:

```ts
const ext = __filename.endsWith(".ts") ? "ts" : "js";
module: path.resolve(__dirname, `customRpc/harnessControl/HarnessControlRpc.${ext}`)
```

The node module loader already special-cases `.ts` specifiers (registering ts-node) and plain `require`/`import` for `.js`, so both branches load correctly.

## Test Plan

- Built the SDK (`yarn build`) and ran a downstream integration suite that consumes the harness via the built `./test-harness` export.
  - **Before:** 0 passing — every spec failed at harness setup with the `MODULE_NOT_FOUND` error above.
  - **After:** the full heads-up-hand integration specs load and pass (3 passing).
- In-source (ts-node) harness runs are unaffected — the `.ts` branch is preserved.
