### PR TITLE
fix(handshake): domain-separate init-handshake signatures to close signing oracle

### DIFF
--- a/src/rpc/services/initHandshake/InitHandshakeRpcMethods.ts
+++ b/src/rpc/services/initHandshake/InitHandshakeRpcMethods.ts
@@ -27,6 +27,24 @@ class InitHandshakeRpcMethods extends ARpcMethods {
                 messageTime: time
             }
         );
+        // Reject malformed inputs before signing. A non-32-byte challenge or a
+        // non-numeric time (NaN slips past the skew check below) would let a
+        // peer steer what gets signed.
+        if (!ethers.isHexString(challengeHash, 32) || !Number.isFinite(time)) {
+            LoggerUtils.logInitHandshakeMessage(
+                this.service.logger,
+                this.senderTransport,
+                {
+                    direction: "local",
+                    message: "rejected",
+                    challengeHash,
+                    messageTime: time,
+                    reason: "malformed handshake request (challenge/time)"
+                }
+            );
+            this.p2pManager.disconnectConnection(this.senderTransport);
+            return;
+        }
         const timeDifference = time - localTime;
         if (Math.abs(timeDifference) > agreementTime) {
             LoggerUtils.logInitHandshakeMessage(
@@ -46,9 +64,10 @@ class InitHandshakeRpcMethods extends ARpcMethods {
             this.p2pManager.disconnectConnection(this.senderTransport);
             return;
         }
-        const challengeHashBytes = ethers.getBytes(challengeHash);
+        const challengeMessage =
+            InitHandshakeService.buildHandshakeChallengeMessage(challengeHash);
         const signature =
-            await this.p2pManager.p2pSigner.signMessage(challengeHashBytes);
+            await this.p2pManager.p2pSigner.signMessage(challengeMessage);
         LoggerUtils.logInitHandshakeMessage(
             this.service.logger,
             this.senderTransport,
@@ -142,13 +161,11 @@ class InitHandshakeRpcMethods extends ARpcMethods {
             return;
         }
         //verify signature
-        const challengeHashBytes = ethers.getBytes(
-            challenge.randomChallengeHash
-        );
-        const signerAddress = ethers.verifyMessage(
-            challengeHashBytes,
-            signature
-        );
+        const challengeMessage =
+            InitHandshakeService.buildHandshakeChallengeMessage(
+                challenge.randomChallengeHash
+            );
+        const signerAddress = ethers.verifyMessage(challengeMessage, signature);
         LoggerUtils.logInitHandshakeMessage(
             this.service.logger,
             this.senderTransport,

--- a/src/rpc/services/initHandshake/InitHandshakeService.ts
+++ b/src/rpc/services/initHandshake/InitHandshakeService.ts
@@ -10,6 +10,7 @@ import type P2PManager from "@/P2PManager";
 import { TimeoutManager } from "@/utils/TimeoutManager";
 import EventBarrier from "@/utils/EventBarrier";
 import { Status } from "@/types";
+import { Hash } from "@/types/types";
 import { DetachedPromises, getChecksumAddress } from "@/utils";
 import { LoggerUtils } from "@/utils/LoggerUtils";
 import { EventBarrierCapturedError } from "@/utils/EventBarrier";
@@ -20,6 +21,25 @@ type ConnectionChallenge = {
 };
 
 class InitHandshakeService extends ARpcService<InitHandshakeRpcMethods> {
+    /**
+     * Domain tag scoping a handshake signature to the handshake protocol.
+     * The responder signs this string, never the bare 32-byte challenge hash.
+     * Blocks/protocol messages are EIP-191 signatures over a raw 32-byte keccak
+     * hash, so signing a domain-tagged string makes a handshake signature
+     * structurally incapable of colliding with a block signature — closing the
+     * pre-auth signing-oracle (challengeHash = keccak256(encodedBlock)).
+     */
+    public static readonly HANDSHAKE_DOMAIN = "peer3:init-handshake:v1";
+
+    /**
+     * Canonical message both peers sign/verify for a given challenge. Uses
+     * `hexlify` so requester (locally generated) and responder (wire) derive an
+     * identical string regardless of input casing/representation.
+     */
+    public static buildHandshakeChallengeMessage(challengeHash: Hash): string {
+        return `${InitHandshakeService.HANDSHAKE_DOMAIN}:${ethers.hexlify(challengeHash)}`;
+    }
+
     mapTransportToChallenge: WeakMap<ATransport, ConnectionChallenge> =
         new WeakMap<ATransport, ConnectionChallenge>();
     timeoutManager: TimeoutManager;

--- a/test/harness/actions/RPCActions.ts
+++ b/test/harness/actions/RPCActions.ts
@@ -3,6 +3,7 @@ import type { HarnessControlRpc } from "@test/fixtures/customRpc/harnessControl/
 import type { TestPeer } from "@test/harness/core/types";
 import { Logger } from "@/utils";
 import { ForkId, Address } from "@/types/types";
+import InitHandshakeService from "@/rpc/services/initHandshake/InitHandshakeService";
 import { hash as fakeHash } from "@test/factory";
 import Clock from "@/Clock";
 
@@ -392,9 +393,13 @@ export class RPCActions<
         challengeHash: string,
         responseTime: number
     ): Promise<void> {
+        // Mirror production: the responder signs the domain-separated challenge
+        // message, not the bare hash, so the response verifies.
+        const challengeMessage =
+            InitHandshakeService.buildHandshakeChallengeMessage(challengeHash);
         const signature = await this.harness
             .control(responder)
-            .handshake.signMessage(challengeHash)
+            .handshake.signMessage(challengeMessage)
             .request();
         const preferredTransport = await this.harness
             .control(responder)

--- a/test/rpc/initHandshake/InitHandshakeChallenge.test.ts
+++ b/test/rpc/initHandshake/InitHandshakeChallenge.test.ts
@@ -1,0 +1,55 @@
+import { expect } from "chai";
+import { ethers } from "ethers";
+
+import InitHandshakeService from "@/rpc/services/initHandshake/InitHandshakeService";
+
+/**
+ * Regression: the init-handshake response endpoint must not be usable as a
+ * signing oracle. Blocks/protocol messages are EIP-191 signatures over a raw
+ * 32-byte keccak hash (see SignatureUtils / Block.hash). Before the fix the
+ * responder signed the bare challenge hash, so a peer could set
+ * challengeHash = keccak256(encodedBlock) and get back a valid block signature.
+ * Domain-separating the signed message closes that collision.
+ */
+describe("InitHandshake challenge domain separation", function () {
+    const wallet = ethers.Wallet.createRandom();
+
+    it("round-trips: a domain-separated handshake signature recovers the signer", async function () {
+        const challengeHash = ethers.keccak256(ethers.randomBytes(32));
+        const message =
+            InitHandshakeService.buildHandshakeChallengeMessage(challengeHash);
+
+        const signature = await wallet.signMessage(message);
+
+        expect(ethers.verifyMessage(message, signature)).to.equal(
+            wallet.address
+        );
+    });
+
+    it("does not collide with block signing: the handshake signature is not valid over the raw challenge hash", async function () {
+        // Attack: the peer sets the challenge to a real block hash, hoping the
+        // returned handshake signature doubles as a valid block signature.
+        const encodedBlock = ethers.hexlify(ethers.randomBytes(128));
+        const blockHash = ethers.keccak256(encodedBlock);
+
+        const message =
+            InitHandshakeService.buildHandshakeChallengeMessage(blockHash);
+        const handshakeSignature = await wallet.signMessage(message);
+
+        // Block verification recovers from the raw 32-byte hash. The
+        // domain-separated handshake signature must NOT recover the signer here.
+        const recoveredAsBlock = ethers.verifyMessage(
+            ethers.getBytes(blockHash),
+            handshakeSignature
+        );
+        expect(recoveredAsBlock).to.not.equal(wallet.address);
+    });
+
+    it("derives an identical message regardless of challenge-hash casing", function () {
+        const lower = "0x" + "ab".repeat(32);
+        const upper = "0x" + "AB".repeat(32);
+        expect(
+            InitHandshakeService.buildHandshakeChallengeMessage(lower)
+        ).to.equal(InitHandshakeService.buildHandshakeChallengeMessage(upper));
+    });
+});


### PR DESCRIPTION
## Summary

The init-handshake responder signed the peer-supplied 32-byte `challengeHash` verbatim with the participant signer (`p2pSigner.signMessage(getBytes(challengeHash))`). Blocks and protocol messages are EIP-191 signatures over a **raw 32-byte keccak hash** (`SignatureUtils`, `Block.hash`; verified on-chain by `UtilityFacet`). So a pre-authentication peer could send `challengeHash = keccak256(encodedBlock)` and receive a signature that is a **valid block signature** attributable to the victim — i.e. the handshake was a signing oracle.

### Fix
- Sign/verify a **domain-separated string** `peer3:init-handshake:v1:<hexlify(challengeHash)>` instead of the raw hash. The EIP-191 preimage length and content then differ from any 32-byte hash the protocol signs, so a handshake signature can never be replayed as a block/dispute signature. The helper lives on the (non-routable) `InitHandshakeService` as a static so both sign and verify sides derive an identical canonical message.
- **Reject malformed requests before signing**: a non-32-byte challenge or a non-finite `time` (a `NaN` time otherwise slips past the `Math.abs(...) > agreementTime` skew check, since any comparison with `NaN` is `false`).
- Updated the test harness responder (`RPCActions.deliverResponse`) to sign the domain-separated message so it mirrors production.

No new oracle is introduced: the only other `p2pSigner.signMessage` path signs a locally-built raw 32-byte block hash, and no protocol message consumes a `peer3:init-handshake:v1:…` string.

## Test Plan
- New unit test `test/rpc/initHandshake/InitHandshakeChallenge.test.ts`:
  - round-trips a domain-separated signature back to the signer;
  - asserts a handshake signature does **not** verify over the raw challenge hash (the anti-collision / anti-oracle property);
  - asserts message derivation is canonical regardless of hash casing.
- `yarn tsc --noEmit` — clean.
- `test/e2e/E2E-InitHandshake.test.ts` — all 7 E2E handshake tests pass (completion, WebRTC upgrade, time/RTT validation, unsolicited-response rejection).