### PR TITLE
fix(spectate): bind sync response to the requested channel

### DIFF
--- a/src/rpc/services/spectate/SpectateRpcMethods.ts
+++ b/src/rpc/services/spectate/SpectateRpcMethods.ts
@@ -3,6 +3,7 @@ import { ATransport } from "@/transport";
 import SpectateService, { SyncRequest } from "./SpectateService";
 import { Bytes, ChannelId } from "@/types";
 import Clock from "@/Clock";
+import { ethers } from "ethers";
 import { Codec, hash, Type } from "@/utils";
 import { Block, StateSnapshot } from "@/models";
 import type { DisputeWindowVerification } from "@/types";
@@ -76,6 +77,25 @@ class SpectateServiceRpcMethods extends ARpcMethods {
                 this.service.logger.debug(
                     "onSpectateResponse - no pending request for peer; aborting",
                     { peerAddress }
+                );
+                return this.service.abort(peerAddress);
+            }
+
+            // Bind the response to the channel we actually requested. Every
+            // fetch/verify/persist below trusts `channelId`; without this a peer
+            // could answer a request for one channel with a (valid) payload for
+            // another and corrupt our local state.
+            if (
+                ethers.hexlify(channelId) !==
+                ethers.hexlify(syncRequest.channelId)
+            ) {
+                this.service.logger.warn(
+                    "onSpectateResponse - response channelId does not match the pending request; aborting",
+                    {
+                        peerAddress,
+                        requestedChannelId: syncRequest.channelId,
+                        responseChannelId: channelId
+                    }
                 );
                 return this.service.abort(peerAddress);
             }

--- a/test/e2e/E2E-Spectate.test.ts
+++ b/test/e2e/E2E-Spectate.test.ts
@@ -97,6 +97,127 @@ describe("E2E: Spectate Service", function () {
         });
     });
 
+    describe("Channel Binding", function () {
+        it("aborts before any chain read when a peer answers with a mismatched channelId", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(2, 0);
+            await h.transition.advanceState({ count: 1 });
+            await h.assert.sync.peersInSyncWait({ peerIndices: [0, 1] });
+
+            const realChannelId = h.channelId!;
+            const forkId = h.activeForkId!;
+            const wrongChannelId = ethers.keccak256(
+                ethers.toUtf8Bytes("spectate-wrong-channel")
+            );
+            expect(wrongChannelId).to.not.equal(String(realChannelId));
+
+            const peer1Address = h.getPeer(1).address;
+
+            // A valid, decodable payload for the REAL channel, so the decode at
+            // the top of onSpectateResponse succeeds and the channel-binding
+            // guard — not a decode error — is what aborts.
+            const blockInfo = await h
+                .control(h.getPeer(1))
+                .query.getLatestBlockInfo(forkId)
+                .request();
+            expect(blockInfo).to.not.be.null;
+            const blockHeight = Number(
+                Codec.decode(blockInfo!.encodedBlock, Type.Block).transaction
+                    .header.transactionCnt
+            );
+            const encodedSyncPayload = await h
+                .control(h.getPeer(1))
+                .spectate.generateSyncPayload(
+                    realChannelId,
+                    forkId,
+                    blockHeight
+                )
+                .request();
+            expect(encodedSyncPayload).to.not.be.null;
+
+            // Drive onSpectateResponse host-side: a pending request for the REAL
+            // channel, but the response claims a DIFFERENT channel.
+            const result = await h.execOnHost(
+                h.getPeer(0),
+                async (sm, args) => {
+                    const spectateService =
+                        sm.p2pManager.localRpc.spectateService;
+                    const profile =
+                        sm.p2pManager.profileManager.getProfileByEvmAddress(
+                            args.peer1Address
+                        );
+                    const transport = profile?.transport;
+                    if (!transport?.peerAddress) {
+                        throw new Error("no handshaked transport to peer 1");
+                    }
+                    const internal = spectateService as unknown as {
+                        requestMapByPeerAddress: Map<
+                            string,
+                            { channelId: unknown; initTime: number }
+                        >;
+                        fetchAndPersistOnChainSnapshot: (
+                            channelId: unknown
+                        ) => Promise<unknown>;
+                    };
+
+                    internal.requestMapByPeerAddress.set(
+                        transport.peerAddress,
+                        {
+                            channelId: args.realChannelId,
+                            initTime: Math.floor(Date.now() / 1000)
+                        }
+                    );
+
+                    // Trip a flag if execution ever reaches the first on-chain read.
+                    let fetchCalled = false;
+                    const originalFetch =
+                        internal.fetchAndPersistOnChainSnapshot.bind(
+                            spectateService
+                        );
+                    internal.fetchAndPersistOnChainSnapshot = async (
+                        cid: unknown
+                    ) => {
+                        fetchCalled = true;
+                        return originalFetch(cid);
+                    };
+
+                    try {
+                        await spectateService
+                            .createRPCMethods(transport)
+                            .onSpectateResponse(
+                                args.wrongChannelId,
+                                args.encodedSyncPayload
+                            );
+                    } finally {
+                        internal.fetchAndPersistOnChainSnapshot = originalFetch;
+                    }
+
+                    return {
+                        fetchCalled,
+                        stillPending: internal.requestMapByPeerAddress.has(
+                            transport.peerAddress
+                        )
+                    };
+                },
+                {
+                    peer1Address,
+                    realChannelId,
+                    wrongChannelId,
+                    encodedSyncPayload: encodedSyncPayload!
+                }
+            );
+
+            expect(
+                result.fetchCalled,
+                "mismatched channelId must abort before any on-chain read"
+            ).to.equal(false);
+            expect(
+                result.stillPending,
+                "pending request should be consumed by the rejected response"
+            ).to.equal(false);
+        });
+    });
+
     describe("Same Fork Spectating", function () {
         it("should spectate successfully when on-chain snapshot is already on the same fork", async function () {
             const h = TestSession.getHarness();


### PR DESCRIPTION
## Summary

`onSpectateResponse` correlated the pending sync request **by peer address only** and then trusted the response-supplied `channelId` for every on-chain fetch/verify/persist (`fetchAndPersistOnChainSnapshot`, dispute-window fetches, `verifyMilestones`, `verifyBalanceInvariantCheckSnapshot`, and ultimately `unsafeSetLatestState`). It never compared that `channelId` to the channel we actually requested.

A handshaked peer with an in-flight sync request could therefore answer a request for **channel A** with a payload that is cryptographically valid for **channel B**. The on-chain checks are channel-agnostic, so the channel-B payload verifies and gets persisted into the channel-A state manager — corrupting local state/forkId to the wrong channel (a binding/confusion bug, not a forgery).

### Fix
Reject the response when `channelId` does not match the pending request's, immediately after the request is taken and **before** any chain read or persistence. The comparison uses `ethers.hexlify` for canonical byte equality; a malformed wire value throws and is caught by the existing handler `try/catch`, which aborts.

## Test Plan
- New E2E regression test (`E2E: Spectate Service › Channel Binding`): registers a pending request for the real channel, delivers an `onSpectateResponse` carrying a **different** channelId (with an otherwise valid, decodable payload), and asserts the handler aborts **before** the first on-chain read and consumes the pending request.
- `yarn tsc --noEmit` — clean.
- Happy-path spectate sync tests still pass (genesis, block-0, same-fork, skip-when-ahead) — the guard never fires when the honest responder echoes the requested channelId.