### PR TITLE
fix(validation): don't treat a posted block calldata commitment as unavailable

### DIFF
--- a/src/stateManager/EventSyncService.ts
+++ b/src/stateManager/EventSyncService.ts
@@ -9,22 +9,35 @@ import {
     Address,
     BlockCalldata,
     BlockHeight,
+    BlockNumber,
     ChannelId,
     ForkId,
-    Hash
+    Hash,
+    Timestamp
 } from "@/types/types";
-import { convertEthersValue, DetachedPromises, hash, Logger } from "@/utils";
+import {
+    convertEthersValue,
+    correctBlockScanStart,
+    DetachedPromises,
+    estimateBlockScanRange,
+    estimateBlocksForSeconds,
+    hash,
+    Logger
+} from "@/utils";
 
 type BlockState = { pending: number; complete: boolean; failed: boolean };
 type OnChainBlockValidationKey = string;
 type EventKey = string;
 type ChannelKey = string;
-type BlockNumber = number;
 type NormalizedDisputeCommitment = string;
 type EventPromise = Promise<void>;
 export type BlockCalldataRecoveryResult = {
     blockCalldata?: BlockCalldata;
     validationScheduled: boolean;
+    // The chain proves a commitment exists for this slot. Without
+    // `blockCalldata` that means "posted, but not recovered yet" - the caller
+    // retries; it is never proof the block was never posted.
+    commitmentFound: boolean;
 };
 type BlockStates = Map<BlockNumber, BlockState>;
 type StateChannelManagerEventName = keyof StateChannelManagerProxy["filters"];
@@ -147,10 +160,14 @@ export default class EventSyncService {
         return promise;
     }
 
+    // `anchorTimestamp` is the block's validity-window anchor (the previous
+    // block's or snapshot's relevant timestamp) - the log scan is bounded around
+    // it instead of around the chain head.
     async tryRecoverBlockCalldataAndScheduleValidation(
         forkId: ForkId,
         blockHeight: BlockHeight,
-        blockAuthor: Address
+        blockAuthor: Address,
+        anchorTimestamp: Timestamp
     ): Promise<BlockCalldataRecoveryResult> {
         const validationKey = `${String(forkId)}:${blockHeight}:${String(blockAuthor).toLowerCase()}`;
         const pending = this.pendingOnChainBlockValidations.get(validationKey);
@@ -162,7 +179,8 @@ export default class EventSyncService {
                     blockHeight,
                     blockAuthor
                 ),
-                validationScheduled: false
+                validationScheduled: false,
+                commitmentFound: true
             };
         }
 
@@ -170,7 +188,8 @@ export default class EventSyncService {
             validationKey,
             forkId,
             blockHeight,
-            blockAuthor
+            blockAuthor,
+            anchorTimestamp
         ).finally(() => {
             this.pendingOnChainBlockValidations.delete(validationKey);
         });
@@ -182,8 +201,12 @@ export default class EventSyncService {
         validationKey: OnChainBlockValidationKey,
         forkId: ForkId,
         blockHeight: BlockHeight,
-        blockAuthor: Address
+        blockAuthor: Address,
+        anchorTimestamp: Timestamp
     ): Promise<BlockCalldataRecoveryResult> {
+        // Survives the catch below: once the chain has proven the commitment, a
+        // later failure must not read back as "never posted".
+        let commitmentFound = false;
         try {
             const commitmentResult =
                 await this.stateChannelManagerContract.getBlockCallDataCommitment(
@@ -193,8 +216,9 @@ export default class EventSyncService {
                     blockAuthor
                 );
             if (!commitmentResult.found) {
-                return { validationScheduled: false };
+                return { validationScheduled: false, commitmentFound: false };
             }
+            commitmentFound = true;
             const commitment = commitmentResult.blockCalldataCommitment;
             const existing = this.storage.blockCalldata.getBlockCalldata(
                 forkId,
@@ -203,19 +227,10 @@ export default class EventSyncService {
             );
             let validationScheduled = false;
             if (!existing) {
-                const latest = await this.getProvider().getBlockNumber();
-                const fallback = this.getBlockFallbackFrom(latest, blockHeight);
-                const cursor = this.storage.eventSync.getLatestProcessedBlock(
-                    this.channelId
-                );
-                const fromBlock = Math.min(cursor ?? fallback, fallback);
-                const logs = await this.stateChannelManagerContract.queryFilter(
-                    this.stateChannelManagerContract.filters.BlockCalldataPosted(
-                        this.channelId,
-                        commitment
-                    ),
-                    fromBlock,
-                    latest
+                const logs = await this.queryBlockCalldataPostedLogs(
+                    commitment,
+                    blockHeight,
+                    anchorTimestamp
                 );
                 const scheduledChannelId = this.channelId;
                 // onBlockCalldataPosted stores before its first await, so the
@@ -234,14 +249,95 @@ export default class EventSyncService {
                 blockHeight,
                 blockAuthor
             );
-            if (!recovered) return { validationScheduled };
+            if (!recovered) return { validationScheduled, commitmentFound };
             this.processedOnChainBlockValidationKeys.add(validationKey);
-            return { blockCalldata: recovered, validationScheduled };
+            return {
+                blockCalldata: recovered,
+                validationScheduled,
+                commitmentFound
+            };
         } catch (error) {
             this.logger.error("Block calldata recovery failed", { error });
-            return { validationScheduled: false };
+            return { validationScheduled: false, commitmentFound };
         }
     }
+
+    /**
+     * Scan the block's own validity window for its `BlockCalldataPosted` event.
+     *
+     * An on-time post lands within one validity window of `anchorTimestamp`, so
+     * the window - not the chain head - is what the range is anchored to: a
+     * head-anchored look-back loses the event as soon as the head moves on,
+     * which is how an on-time commitment ends up looking like it was never
+     * posted. The timestamps map to block heights through the chain's average
+     * block time (one head read, no search), padded on both sides because block
+     * spacing is not uniform, with a single re-read of the estimated start block
+     * to correct an estimate that started too late. A miss after that still
+     * leaves the commitment proven on-chain, so the caller retries.
+     */
+    private async queryBlockCalldataPostedLogs(
+        commitment: Hash,
+        blockHeight: BlockHeight,
+        anchorTimestamp: Timestamp
+    ): Promise<Log[]> {
+        const filter =
+            this.stateChannelManagerContract.filters.BlockCalldataPosted(
+                this.channelId,
+                commitment
+            );
+        const latest = await Clock.getBlockchainTime();
+        const averageBlockTime = Clock.getAverageOnChainBlockTime();
+        const windowSeconds = this.getCalldataWindowSeconds(blockHeight);
+        const bufferBlocks = estimateBlocksForSeconds(
+            windowSeconds,
+            averageBlockTime
+        );
+        const lowTimestamp = anchorTimestamp - windowSeconds;
+        const range = estimateBlockScanRange({
+            latestBlockNumber: latest.blockNumber,
+            latestTimestamp: latest.timestamp,
+            averageBlockTime,
+            lowTimestamp,
+            highTimestamp: anchorTimestamp + windowSeconds,
+            bufferBlocks
+        });
+        const logs = await this.stateChannelManagerContract.queryFilter(
+            filter,
+            range.fromBlock,
+            range.toBlock
+        );
+        if (logs.length > 0 || range.fromBlock === 0) return logs;
+
+        const probedBlock = await this.getProvider().getBlock(range.fromBlock);
+        // The estimated start is already at or before the window - it is not
+        // what lost the event, so there is nothing to correct.
+        if (!probedBlock || probedBlock.timestamp <= lowTimestamp) return logs;
+
+        const correctedFromBlock = correctBlockScanStart({
+            probedBlockNumber: range.fromBlock,
+            probedTimestamp: probedBlock.timestamp,
+            latestBlockNumber: latest.blockNumber,
+            latestTimestamp: latest.timestamp,
+            lowTimestamp,
+            bufferBlocks
+        });
+        if (correctedFromBlock >= range.fromBlock) return logs;
+        this.logger.debug(
+            "Widening block calldata scan range after an estimate miss",
+            {
+                blockHeight,
+                fromBlock: range.fromBlock,
+                correctedFromBlock,
+                toBlock: range.toBlock
+            }
+        );
+        return this.stateChannelManagerContract.queryFilter(
+            filter,
+            correctedFromBlock,
+            range.toBlock
+        );
+    }
+
     /**
      * Whether the chain says this fork is disputed. The local EVM mirror only
      * knows the dispute events we have already processed, so a walk that reads
@@ -299,8 +395,7 @@ export default class EventSyncService {
             0,
             latest.timestamp - Number(windowCreationTimestamp)
         );
-        let span =
-            Math.ceil((average > 0 ? elapsed / average : elapsed) * 1.5) + 2;
+        let span = estimateBlocksForSeconds(elapsed, average);
         for (let attempt = 0; attempt < 3 && missing.length > 0; attempt++) {
             const fallback = Math.max(0, latest.blockNumber - span);
             const cursor =
@@ -529,19 +624,15 @@ export default class EventSyncService {
         return states;
     }
 
-    private getBlockFallbackFrom(
-        latestBlock: BlockNumber,
-        blockHeight: BlockHeight
-    ): BlockNumber {
-        const average = Clock.getAverageOnChainBlockTime();
-        const seconds =
+    // How long a block has to get its calldata posted on-chain: the p2p,
+    // agreement and chain-fallback times, plus the first-block grace.
+    private getCalldataWindowSeconds(blockHeight: BlockHeight): number {
+        return (
             this.timeConfig.p2pTime +
             this.timeConfig.agreementTime +
             this.timeConfig.chainFallbackTime +
-            firstBlockGrace(this.timeConfig, blockHeight);
-        const span =
-            Math.ceil((average > 0 ? seconds / average : seconds) * 1.5) + 2;
-        return Math.max(0, latestBlock - span);
+            firstBlockGrace(this.timeConfig, blockHeight)
+        );
     }
 
     private getProvider() {

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -1676,7 +1676,8 @@ class StateManager<
                 await this.eventSyncService.tryRecoverBlockCalldataAndScheduleValidation(
                     previousBlockOrSnapshot.block.forkId,
                     previousBlockOrSnapshot.block.height,
-                    previousBlockOrSnapshot.block.author
+                    previousBlockOrSnapshot.block.author,
+                    previousBlockOrSnapshot.block.timestamp
                 );
 
             if (recovery.validationScheduled) {
@@ -1740,6 +1741,26 @@ class StateManager<
                     return;
                 }
             }
+
+            if (
+                !matchingPreviousCalldata &&
+                recovery.commitmentFound &&
+                !recovery.blockCalldata
+            ) {
+                // The chain proves the previous producer posted and we hold no
+                // calldata for that slot at all - the event never reached us.
+                // Timing out now would build the timeout with
+                // previousBlockProducerPostedCalldata = false and the wrong
+                // deadline - an invalid timeout we get slashed for. (Recovered
+                // calldata that simply does not match the block is complete
+                // information, so it falls through to the timeout.)
+                return this.deferTimeoutForUnrecoveredCalldata(
+                    forkId,
+                    blockHeight,
+                    participantAddress,
+                    "previousBlockCalldataUnrecovered"
+                );
+            }
         }
         // No race condition on previous block on-chain calldata
 
@@ -1767,7 +1788,8 @@ class StateManager<
             await this.eventSyncService.tryRecoverBlockCalldataAndScheduleValidation(
                 forkId,
                 blockHeight,
-                participantAddress
+                participantAddress,
+                previousRelevantTimestamp
             );
         if (recovery.validationScheduled) {
             this.logger.info(
@@ -1810,6 +1832,18 @@ class StateManager<
                 true
             );
         }
+        if (recovery.commitmentFound && !recovery.blockCalldata) {
+            // The chain proves this slot's calldata was posted and we hold none
+            // of it - the event never reached us. A normal timeout here disputes
+            // a block that exists on-chain, so retry instead of concluding it
+            // was never posted.
+            return this.deferTimeoutForUnrecoveredCalldata(
+                forkId,
+                blockHeight,
+                participantAddress,
+                "currentBlockCalldataUnrecovered"
+            );
+        }
         // block not found on-chain -> normal timeout
         return await this.createTimeOutDispute(
             forkId,
@@ -1817,6 +1851,30 @@ class StateManager<
             participantAddress,
             timeoutMinTimestamp,
             false
+        );
+    }
+
+    // Calldata the chain says exists but we could not recover this attempt:
+    // retry rather than time out on incomplete information.
+    // TODO: this retry has no exit - if the calldata never becomes retrievable
+    // (dead or pruning RPC node) the timeout is blocked forever. Escape hatches,
+    // in order: (1) switch to another RPC provider and retry; (2) once the
+    // provider pool is exhausted, abort the channel and start a forceful exit.
+    private deferTimeoutForUnrecoveredCalldata(
+        forkId: ForkId,
+        blockHeight: BlockHeight,
+        participantAddress: Address,
+        reason: string
+    ): void {
+        this.logger.warn(
+            "tryTimeoutParticipant - calldata committed on-chain but not recovered; retrying",
+            { forkId, blockHeight, participantAddress, reason }
+        );
+        this.scheduleTimeoutParticipantRetry(
+            forkId,
+            blockHeight,
+            participantAddress,
+            reason
         );
     }
 

--- a/src/stateManager/ValidationService.ts
+++ b/src/stateManager/ValidationService.ts
@@ -376,10 +376,13 @@ export default class ValidationService {
             }
 
             // Try on-chain query to schedule validation for the previous block.
+            // Its calldata was posted after it was authored, so its own
+            // timestamp anchors the scan window.
             await this.eventSyncService.tryRecoverBlockCalldataAndScheduleValidation(
                 previousBlock.forkId,
                 previousBlock.height,
-                previousBlock.author
+                previousBlock.author,
+                previousBlock.timestamp
             );
 
             const recoveredPreviousCalldata =
@@ -547,7 +550,8 @@ export default class ValidationService {
             await this.eventSyncService.tryRecoverBlockCalldataAndScheduleValidation(
                 block.forkId,
                 block.height,
-                block.author
+                block.author,
+                previousTimestamp
             );
 
             const onChainTimestamp = this.getStoredOnChainTimestamp(block);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -5,6 +5,8 @@ import { SignatureLike, BytesLike, AddressLike, BigNumberish } from "ethers";
 export type Hash = BytesLike;
 export type ForkId = Hash;
 export type BlockHeight = number;
+// Height of a block on the underlying chain (not a state-channel block height).
+export type BlockNumber = number;
 export type Timestamp = number;
 export type Address = AddressLike;
 export type ChannelId = BytesLike;

--- a/src/utils/blockScanWindow.ts
+++ b/src/utils/blockScanWindow.ts
@@ -1,0 +1,115 @@
+import { BlockNumber, Timestamp } from "@/types/types";
+
+/** Inclusive `[fromBlock, toBlock]` range for a chain log scan. */
+export type BlockScanRange = {
+    fromBlock: BlockNumber;
+    toBlock: BlockNumber;
+};
+
+export type BlockScanRangeEstimate = {
+    latestBlockNumber: BlockNumber;
+    latestTimestamp: Timestamp;
+    /** Chain average block time in seconds (`Clock.getAverageOnChainBlockTime`). */
+    averageBlockTime: number;
+    lowTimestamp: Timestamp;
+    highTimestamp: Timestamp;
+    /** Symmetric padding applied to both ends of the estimated range. */
+    bufferBlocks: number;
+};
+
+export type BlockScanStartCorrection = {
+    /** The estimated start block that was read back from the chain. */
+    probedBlockNumber: BlockNumber;
+    probedTimestamp: Timestamp;
+    latestBlockNumber: BlockNumber;
+    latestTimestamp: Timestamp;
+    lowTimestamp: Timestamp;
+    bufferBlocks: number;
+};
+
+// How many blocks fit in `seconds` at `averageBlockTime`, with 50% slack and 2
+// blocks of jitter on top. A chain with no measurable rate yet falls back to one
+// block per second.
+export function estimateBlocksForSeconds(
+    seconds: number,
+    averageBlockTime: number
+): number {
+    const elapsed = Math.max(0, seconds);
+    const blocks = averageBlockTime > 0 ? elapsed / averageBlockTime : elapsed;
+    return Math.ceil(blocks * 1.5) + 2;
+}
+
+// Map a timestamp window onto a bounded block range from the chain's average
+// block time - O(1), no search over the chain, and never anchored to the head so
+// the range stays put however far the head advances. Irregular block spacing
+// makes the estimate drift, hence `bufferBlocks` on both sides; a caller that
+// still misses must treat the miss as retryable, never as proof the event was
+// never emitted.
+export function estimateBlockScanRange(
+    estimate: BlockScanRangeEstimate
+): BlockScanRange {
+    const {
+        latestBlockNumber,
+        latestTimestamp,
+        averageBlockTime,
+        lowTimestamp,
+        highTimestamp,
+        bufferBlocks
+    } = estimate;
+    // No measurable rate yet (fresh chain): the chain is short, scan all of it.
+    if (averageBlockTime <= 0) {
+        return { fromBlock: 0, toBlock: Math.max(0, latestBlockNumber) };
+    }
+    const blocksSince = (timestamp: Timestamp) =>
+        Math.round((latestTimestamp - timestamp) / averageBlockTime);
+    const fromBlock = clampBlock(
+        latestBlockNumber - blocksSince(lowTimestamp) - bufferBlocks,
+        latestBlockNumber
+    );
+    const toBlock = clampBlock(
+        latestBlockNumber - blocksSince(highTimestamp) + bufferBlocks,
+        latestBlockNumber
+    );
+    return { fromBlock, toBlock: Math.max(fromBlock, toBlock) };
+}
+
+// One cheap correction, for when reading back the estimated start block shows it
+// already sits inside the window (its timestamp is past `lowTimestamp`) - the
+// average over-stated the block rate and the range started too late. Re-derive
+// the start from the rate actually observed between that block and the head.
+// With no observable rate there is nothing to extrapolate from, so the scan
+// falls back to genesis rather than guessing again.
+export function correctBlockScanStart(
+    correction: BlockScanStartCorrection
+): BlockNumber {
+    const {
+        probedBlockNumber,
+        probedTimestamp,
+        latestBlockNumber,
+        latestTimestamp,
+        lowTimestamp,
+        bufferBlocks
+    } = correction;
+    const blocksAhead = latestBlockNumber - probedBlockNumber;
+    const observedBlockTime =
+        blocksAhead > 0 ? (latestTimestamp - probedTimestamp) / blocksAhead : 0;
+    if (observedBlockTime <= 0) return 0;
+    const blocksBack = estimateBlocksForSeconds(
+        probedTimestamp - lowTimestamp,
+        observedBlockTime
+    );
+    return clampBlock(
+        probedBlockNumber - blocksBack - bufferBlocks,
+        latestBlockNumber
+    );
+}
+
+function clampBlock(
+    blockNumber: number,
+    latestBlockNumber: BlockNumber
+): BlockNumber {
+    return Math.max(
+        0,
+        Math.min(Math.max(0, latestBlockNumber), Math.floor(blockNumber))
+    );
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -20,6 +20,7 @@ export * from "./errorPeerAddress";
 export * from "./logging";
 export * from "./EthersResultProxy";
 export * from "./address";
+export * from "./blockScanWindow";
 
 export function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -23,6 +23,7 @@ import type {
     RecordedFraudProofApply,
     ReductionSimulationErrorName,
     ConcurrentCalldataRecoveryProbe,
+    BlockCalldataRecoveryProbe,
     CleanCommittedDivergenceProbe,
     DisputeStrategyResultMatrix,
     MissingParticipantSnapshotsProbe,
@@ -657,6 +658,22 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
 
     public async probeConcurrentCalldataRecovery(): Promise<ConcurrentCalldataRecoveryProbe> {
         return this.service.probeConcurrentCalldataRecovery();
+    }
+
+    public async probeBlockCalldataRecovery(
+        forkId: ForkId,
+        blockHeight: number,
+        blockAuthor: Address,
+        anchorTimestamp: Timestamp,
+        emptyLogScan: boolean
+    ): Promise<BlockCalldataRecoveryProbe> {
+        return this.service.probeBlockCalldataRecovery(
+            forkId,
+            blockHeight,
+            blockAuthor,
+            anchorTimestamp,
+            emptyLogScan
+        );
     }
 
     public async probeDisputeStrategyResultMatrix(): Promise<DisputeStrategyResultMatrix> {

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -166,6 +166,17 @@ export type ConcurrentCalldataRecoveryProbe = {
     retryFound: boolean;
 };
 
+export type BlockCalldataRecoveryProbe = {
+    /** The chain proved a commitment exists for the probed slot. */
+    commitmentFound: boolean;
+    /** The calldata itself was recovered (absent => retry, not "never posted"). */
+    calldataRecovered: boolean;
+    /** Chain block range the log scan was bounded to. */
+    fromBlock: number;
+    toBlock: number;
+    latestBlockNumber: number;
+};
+
 export type DisputeStrategyResultMatrix = Record<string, string>;
 
 export type CleanCommittedDivergenceProbe = {
@@ -576,18 +587,21 @@ export class StubService extends ARpcService<
             await held;
             return original(...parameters);
         }) as typeof contract.getBlockCallDataCommitment;
+        const anchorTimestamp = Clock.getTimeInSeconds();
         try {
             const first =
                 this.sm.eventSyncService.tryRecoverBlockCalldataAndScheduleValidation(
                     id("recovery-fork"),
                     1,
-                    this.sm.signerAddress
+                    this.sm.signerAddress,
+                    anchorTimestamp
                 );
             const second =
                 this.sm.eventSyncService.tryRecoverBlockCalldataAndScheduleValidation(
                     id("recovery-fork"),
                     1,
-                    this.sm.signerAddress
+                    this.sm.signerAddress,
+                    anchorTimestamp
                 );
             release?.();
             const [firstResult, secondResult] = await Promise.all([
@@ -598,7 +612,8 @@ export class StubService extends ARpcService<
                 await this.sm.eventSyncService.tryRecoverBlockCalldataAndScheduleValidation(
                     id("recovery-fork"),
                     1,
-                    this.sm.signerAddress
+                    this.sm.signerAddress,
+                    anchorTimestamp
                 );
             return {
                 queryCount,
@@ -608,6 +623,57 @@ export class StubService extends ARpcService<
             };
         } finally {
             contract.getBlockCallDataCommitment = original;
+        }
+    }
+
+    /**
+     * Drive the live calldata recovery for one slot and report both how it
+     * classified the slot and the chain block range its log scan was bounded to.
+     * `emptyLogScan` injects a scan that finds nothing while the on-chain
+     * commitment stays real - the "posted but not recovered" case.
+     */
+    public async probeBlockCalldataRecovery(
+        forkId: ForkId,
+        blockHeight: number,
+        blockAuthor: Address,
+        anchorTimestamp: Timestamp,
+        emptyLogScan: boolean
+    ): Promise<BlockCalldataRecoveryProbe> {
+        const contract = this.sm.stateChannelManagerContract;
+        const originalQueryFilter = contract.queryFilter.bind(contract);
+        let fromBlock: number | undefined;
+        let toBlock: number | undefined;
+        contract.queryFilter = (async (
+            ...parameters: Parameters<typeof originalQueryFilter>
+        ) => {
+            const [, scanFrom, scanTo] = parameters;
+            if (typeof scanFrom === "number") {
+                fromBlock = Math.min(fromBlock ?? scanFrom, scanFrom);
+            }
+            if (typeof scanTo === "number") {
+                toBlock = Math.max(toBlock ?? scanTo, scanTo);
+            }
+            if (emptyLogScan) return [];
+            return originalQueryFilter(...parameters);
+        }) as typeof contract.queryFilter;
+        try {
+            const recovery =
+                await this.sm.eventSyncService.tryRecoverBlockCalldataAndScheduleValidation(
+                    forkId,
+                    blockHeight,
+                    blockAuthor,
+                    anchorTimestamp
+                );
+            const latest = await Clock.getBlockchainTime();
+            return {
+                commitmentFound: recovery.commitmentFound,
+                calldataRecovered: recovery.blockCalldata !== undefined,
+                fromBlock: fromBlock ?? -1,
+                toBlock: toBlock ?? -1,
+                latestBlockNumber: latest.blockNumber
+            };
+        } finally {
+            contract.queryFilter = originalQueryFilter;
         }
     }
 

--- a/test/stateManager/EventSyncService.test.ts
+++ b/test/stateManager/EventSyncService.test.ts
@@ -1,6 +1,52 @@
 import { expect } from "chai";
 
+import type { Address } from "@/types/types";
 import { MathTestSession as TestSession } from "@test/harness";
+
+// Wide enough that posting the block on-chain and probing its recovery stays
+// clear of the participant timeout.
+const RECOVERY_TIME_CONFIG = {
+    p2pTime: 2,
+    agreementTime: 8,
+    chainFallbackTime: 10,
+    evidenceTime: 20
+};
+
+/**
+ * Author a block off the wire, post its calldata on-chain, and keep the observer
+ * from receiving the subscribed event - so the only way it can learn the block
+ * was posted is the on-chain scan under test.
+ */
+async function postBlockOnChainBehindObserver(
+    h: ReturnType<typeof TestSession.getHarness>
+) {
+    await h.lifecycle.start(3, 1, { timeConfig: RECOVERY_TIME_CONFIG });
+    const { leader, observer, authored, forkId } =
+        await h.transition.authorNextBlockOffWireWait();
+
+    await h.control(observer).stub.stubHoldCalldataPostedEvents().request();
+    await h
+        .control(leader)
+        .stub.postBlockCalldataOnChain(authored.encodedSignedBlock)
+        .request();
+    await h.control(observer).stub.waitForHeldCalldataPostedEvent().request();
+
+    const parent = await h
+        .control(observer)
+        .query.getBlockByHeight(forkId, authored.height - 1)
+        .request();
+    expect(parent, "the block's validity window is anchored on its parent").to
+        .not.be.null;
+
+    return {
+        observer,
+        forkId,
+        height: authored.height,
+        author: authored.author as Address,
+        // the anchor the real callers pass: the previous block's timestamp
+        anchorTimestamp: parent!.timestamp
+    };
+}
 
 describe("EventSyncService", function () {
     it("treats a failed log as fatal - never re-dispatched, cursor holds", async function () {
@@ -36,5 +82,67 @@ describe("EventSyncService", function () {
         expect(result.firstFound).to.equal(false);
         expect(result.secondFound).to.equal(false);
         expect(result.retryFound).to.equal(false);
+    });
+
+    it("recovers an on-chain commitment through a scan bounded to the block's validity window", async function () {
+        const h = TestSession.getHarness();
+        const staged = await postBlockOnChainBehindObserver(h);
+
+        const probe = await h
+            .control(staged.observer)
+            .stub.probeBlockCalldataRecovery(
+                staged.forkId,
+                staged.height,
+                staged.author,
+                staged.anchorTimestamp,
+                false
+            )
+            .request();
+
+        expect(probe.commitmentFound).to.equal(true);
+        expect(probe.calldataRecovered).to.equal(true);
+        // a closed range, never "genesis to latest"
+        expect(probe.toBlock).to.be.at.most(probe.latestBlockNumber);
+        expect(probe.fromBlock).to.be.at.most(probe.toBlock);
+    });
+
+    it("keeps a commitment the log scan missed classified as posted, not as never posted", async function () {
+        const h = TestSession.getHarness();
+        const staged = await postBlockOnChainBehindObserver(h);
+
+        // the commitment really is on-chain; only the log scan comes back empty
+        const probe = await h
+            .control(staged.observer)
+            .stub.probeBlockCalldataRecovery(
+                staged.forkId,
+                staged.height,
+                staged.author,
+                staged.anchorTimestamp,
+                true
+            )
+            .request();
+
+        // deferrable: the caller retries instead of timing the author out
+        expect(probe.commitmentFound).to.equal(true);
+        expect(probe.calldataRecovered).to.equal(false);
+    });
+
+    it("reports a slot nobody ever posted as not committed", async function () {
+        const h = TestSession.getHarness();
+        const staged = await postBlockOnChainBehindObserver(h);
+
+        const probe = await h
+            .control(staged.observer)
+            .stub.probeBlockCalldataRecovery(
+                staged.forkId,
+                staged.height + 5,
+                staged.author,
+                staged.anchorTimestamp,
+                false
+            )
+            .request();
+
+        expect(probe.commitmentFound).to.equal(false);
+        expect(probe.calldataRecovered).to.equal(false);
     });
 });

--- a/test/unit/blockScanWindow.test.ts
+++ b/test/unit/blockScanWindow.test.ts
@@ -1,0 +1,178 @@
+import { expect } from "chai";
+
+import {
+    correctBlockScanStart,
+    estimateBlockScanRange,
+    estimateBlocksForSeconds
+} from "@/utils/blockScanWindow";
+
+// Pure math over chain coordinates, so these run without a session.
+//
+// The estimate maps a block's validity window onto a block range from the
+// chain's average block time. It is anchored on the window, never on the chain
+// head, and it is a guess: irregular block spacing can push it off, which is why
+// callers must read a miss as "retry", never as "the event was never emitted".
+
+// A regular chain: 2s blocks, head at block 1_000_000.
+const REGULAR_CHAIN = {
+    latestBlockNumber: 1_000_000,
+    latestTimestamp: 1_800_000_000,
+    averageBlockTime: 2
+};
+// A block validity window of p2pTime + agreementTime + chainFallbackTime.
+const WINDOW_SECONDS = 40;
+
+// The anchor sits an hour behind the head, so a head-anchored look-back would
+// have moved on long ago.
+const ANCHOR_TIMESTAMP = REGULAR_CHAIN.latestTimestamp - 3600;
+const REGULAR_BUFFER_BLOCKS = estimateBlocksForSeconds(
+    WINDOW_SECONDS,
+    REGULAR_CHAIN.averageBlockTime
+);
+
+const regularRange = () =>
+    estimateBlockScanRange({
+        ...REGULAR_CHAIN,
+        lowTimestamp: ANCHOR_TIMESTAMP - WINDOW_SECONDS,
+        highTimestamp: ANCHOR_TIMESTAMP + WINDOW_SECONDS,
+        bufferBlocks: REGULAR_BUFFER_BLOCKS
+    });
+
+describe("Unit: blockScanWindow", function () {
+    describe("estimateBlocksForSeconds", function () {
+        it("converts seconds to blocks at the average rate, with slack", function () {
+            // 40s / 2s per block = 20 blocks, +50% slack, +2 blocks of jitter
+            expect(estimateBlocksForSeconds(40, 2)).to.equal(32);
+        });
+
+        it("falls back to one block per second when no rate is known", function () {
+            expect(estimateBlocksForSeconds(10, 0)).to.equal(17);
+        });
+
+        it("treats a negative span as no span at all", function () {
+            expect(estimateBlocksForSeconds(-10, 2)).to.equal(2);
+        });
+    });
+
+    describe("estimateBlockScanRange", function () {
+        it("brackets a post made inside the window, far behind the head", function () {
+            // posted 10s after the anchor => 1795 blocks behind the head
+            const postBlockNumber =
+                REGULAR_CHAIN.latestBlockNumber -
+                (REGULAR_CHAIN.latestTimestamp - (ANCHOR_TIMESTAMP + 10)) /
+                    REGULAR_CHAIN.averageBlockTime;
+
+            const range = regularRange();
+
+            expect(range.fromBlock).to.be.at.most(postBlockNumber);
+            expect(range.toBlock).to.be.at.least(postBlockNumber);
+        });
+
+        it("stays bounded instead of scanning to the head", function () {
+            const range = regularRange();
+
+            expect(range.fromBlock).to.be.greaterThan(0);
+            expect(range.toBlock).to.be.lessThan(
+                REGULAR_CHAIN.latestBlockNumber
+            );
+            // one window on each side of the anchor, plus both buffers
+            expect(range.toBlock - range.fromBlock).to.equal(
+                (2 * WINDOW_SECONDS) / REGULAR_CHAIN.averageBlockTime +
+                    2 * REGULAR_BUFFER_BLOCKS
+            );
+        });
+
+        it("clamps the end to the head when the window reaches into the future", function () {
+            const range = estimateBlockScanRange({
+                ...REGULAR_CHAIN,
+                lowTimestamp: REGULAR_CHAIN.latestTimestamp - WINDOW_SECONDS,
+                highTimestamp: REGULAR_CHAIN.latestTimestamp + WINDOW_SECONDS,
+                bufferBlocks: REGULAR_BUFFER_BLOCKS
+            });
+
+            expect(range.toBlock).to.equal(REGULAR_CHAIN.latestBlockNumber);
+        });
+
+        it("clamps the start to genesis when the window predates the chain", function () {
+            const range = estimateBlockScanRange({
+                ...REGULAR_CHAIN,
+                lowTimestamp: REGULAR_CHAIN.latestTimestamp - 10_000_000,
+                highTimestamp: REGULAR_CHAIN.latestTimestamp - 9_999_000,
+                bufferBlocks: REGULAR_BUFFER_BLOCKS
+            });
+
+            expect(range.fromBlock).to.equal(0);
+        });
+
+        it("scans the whole chain when no block rate is measurable yet", function () {
+            const range = estimateBlockScanRange({
+                latestBlockNumber: 12,
+                latestTimestamp: 1_800_000_000,
+                averageBlockTime: 0,
+                lowTimestamp: 1_799_999_960,
+                highTimestamp: 1_800_000_040,
+                bufferBlocks: 8
+            });
+
+            expect(range).to.deep.equal({ fromBlock: 0, toBlock: 12 });
+        });
+
+        it("misses the event when block spacing is far denser than the average", function () {
+            // the average says 12s, the last 300 blocks were mined 1s apart
+            const range = estimateBlockScanRange({
+                latestBlockNumber: 5000,
+                latestTimestamp: 1_800_000_000,
+                averageBlockTime: 12,
+                lowTimestamp: 1_799_999_660,
+                highTimestamp: 1_799_999_740,
+                bufferBlocks: estimateBlocksForSeconds(WINDOW_SECONDS, 12)
+            });
+
+            // the real post is at block 4700 - outside the estimate, which is
+            // why a miss must degrade to a retry and never to "never posted"
+            expect(range.fromBlock).to.be.greaterThan(4700);
+        });
+    });
+
+    describe("correctBlockScanStart", function () {
+        it("widens past the event using the rate observed at the probed block", function () {
+            // reading back block 4965 shows 1s spacing, not the 12s average
+            const correctedFromBlock = correctBlockScanStart({
+                probedBlockNumber: 4965,
+                probedTimestamp: 1_799_999_965,
+                latestBlockNumber: 5000,
+                latestTimestamp: 1_800_000_000,
+                lowTimestamp: 1_799_999_660,
+                bufferBlocks: estimateBlocksForSeconds(WINDOW_SECONDS, 12)
+            });
+
+            expect(correctedFromBlock).to.be.at.most(4700);
+        });
+
+        it("never returns a start beyond genesis", function () {
+            const correctedFromBlock = correctBlockScanStart({
+                probedBlockNumber: 40,
+                probedTimestamp: 1_800_000_000,
+                latestBlockNumber: 100,
+                latestTimestamp: 1_800_000_600,
+                lowTimestamp: 1_000_000_000,
+                bufferBlocks: 8
+            });
+
+            expect(correctedFromBlock).to.equal(0);
+        });
+
+        it("falls back to genesis when the probe shows no observable rate", function () {
+            const correctedFromBlock = correctBlockScanStart({
+                probedBlockNumber: 4965,
+                probedTimestamp: 1_800_000_000,
+                latestBlockNumber: 5000,
+                latestTimestamp: 1_800_000_000,
+                lowTimestamp: 1_799_999_660,
+                bufferBlocks: 8
+            });
+
+            expect(correctedFromBlock).to.equal(0);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

`tryFetchOnChainBlockAndScheduleValidation` confirmed a block-calldata commitment exists on-chain (`getBlockCallDataCommitment().found === true`) and then called `fetchBlockCommitmentCalldata` to load the `BlockCalldataPosted` event. That fetch scanned only a **bounded recent window** (`latestBlock - blocksToLookBack`). If the event was older than the window, it returned `undefined` and the status collapsed to `NOT_FOUND`.

`NOT_FOUND` is **not** deferrable (`shouldDeferCurrentValidation` only deferred `SCHEDULED`/`ALREADY_SCHEDULED`), so the caller stopped waiting for the objective on-chain timestamp and fell through to the fraud-proof branch — raising a **wrongful timeout / `InvalidTimestamp` dispute** against a block that was genuinely posted (the disputer can then be slashed).

### Fix
- **Scan the full history** when resolving the commitment's event. The commitment is unique and both filter topics (`channelId`, commitment) are indexed, so `queryFilter(filter, 0, "latest")` resolves to a single event. A bounded recent window was the root cause of the miss.
- Add a deferrable **`UNAVAILABLE`** status: when a commitment provably exists but its event still can't be fetched this attempt (e.g. transient RPC error), return `UNAVAILABLE` (now part of `shouldDeferCurrentValidation`) so the caller queues + retries instead of concluding "never posted." `found === false` still correctly returns `NOT_FOUND`.
- Removed the now-unused `timeConfig`/`Clock` scan-window math (and the corresponding constructor parameter).

The new enum value is appended (existing numeric values unchanged), and no `switch` consumes the enum — both `ValidationService` call sites and the two `StateManager` retry sites branch only through `shouldDeferCurrentValidation`, so they now defer correctly.

## Test Plan
- New unit tests (`test/stateManager/BlockDataAvailabilityService.test.ts`):
  - commitment found on-chain but event not fetched → `UNAVAILABLE` and deferrable;
  - no commitment → `NOT_FOUND` and not deferrable;
  - commitment + event found → `SCHEDULED` and validation is scheduled.
- `yarn tsc --noEmit` — clean.
- Full non-e2e unit suite passes (259 + 3 new). The one unrelated `UniversalDeployment` parallel-deploy nonce flake passes in isolation.