### PR TITLE
fix(open-channel): verify proposed terms match negotiation before co-signing

### DIFF
--- a/src/rpc/services/openChannelNegotiation/OpenChannelNegotiationHelpers.ts
+++ b/src/rpc/services/openChannelNegotiation/OpenChannelNegotiationHelpers.ts
@@ -1,9 +1,14 @@
+import { ethers, type BytesLike } from "ethers";
 import { getChecksumAddress } from "@/utils";
+import type { OpenChannelStruct } from "@typechain-types/contracts/V1/types/DataTypes";
 
 export type Address = string;
 
 export const DEFAULT_JOIN_AMOUNT = 500;
 export const NEGOTIATION_TIMEOUT_MS = 20_000;
+// Seconds the proposer adds to the current time for the open-channel deadline.
+// The receiver bounds the proposed deadline against this.
+export const OPEN_CHANNEL_DEADLINE_SECONDS = 60;
 
 export const compareAddresses = (a: Address, b: Address): number => {
     const aBig = BigInt(getChecksumAddress(a));
@@ -12,3 +17,67 @@ export const compareAddresses = (a: Address, b: Address): number => {
     if (aBig > bBig) return 1;
     return 0;
 };
+
+/**
+ * Returns a reason string if a peer-proposed OpenChannel does not match the
+ * locally negotiated terms, or null if it matches. The receiver must only
+ * co-sign the exact terms it negotiated, never the peer's arbitrary fields.
+ */
+export function getOpenChannelProposalMismatch(
+    decoded: OpenChannelStruct,
+    expected: {
+        channelId: BytesLike;
+        participants: [Address, Address];
+        balances: OpenChannelStruct["balances"];
+    },
+    deadline: { nowSeconds: number; maxSeconds: number }
+): string | null {
+    if (
+        ethers.hexlify(decoded.channelId) !== ethers.hexlify(expected.channelId)
+    ) {
+        return "channelId mismatch";
+    }
+    if (decoded.participants.length !== expected.participants.length) {
+        return "participants length mismatch";
+    }
+    for (let i = 0; i < expected.participants.length; i++) {
+        if (
+            getChecksumAddress(String(decoded.participants[i])) !==
+            getChecksumAddress(expected.participants[i])
+        ) {
+            return `participant ${i} mismatch`;
+        }
+    }
+    if (decoded.balances.length !== expected.balances.length) {
+        return "balances length mismatch";
+    }
+    for (let i = 0; i < expected.balances.length; i++) {
+        if (
+            BigInt(decoded.balances[i].amount) !==
+            BigInt(expected.balances[i].amount)
+        ) {
+            return `balance ${i} amount mismatch`;
+        }
+        if (
+            ethers.hexlify(decoded.balances[i].data) !==
+            ethers.hexlify(expected.balances[i].data)
+        ) {
+            return `balance ${i} data mismatch`;
+        }
+    }
+    if (decoded.isAtomic !== true) {
+        return "isAtomic must be true";
+    }
+    if (ethers.hexlify(decoded.data) !== "0x") {
+        return "data must be empty";
+    }
+    const deadlineSeconds = Number(decoded.deadlineTimestamp);
+    if (
+        !Number.isFinite(deadlineSeconds) ||
+        deadlineSeconds <= deadline.nowSeconds ||
+        deadlineSeconds > deadline.maxSeconds
+    ) {
+        return "deadline out of range";
+    }
+    return null;
+}

--- a/src/rpc/services/openChannelNegotiation/OpenChannelNegotiationService.ts
+++ b/src/rpc/services/openChannelNegotiation/OpenChannelNegotiationService.ts
@@ -20,7 +20,9 @@ import OpenChannelNegotiationRpcMethods, {
 import {
     DEFAULT_JOIN_AMOUNT,
     NEGOTIATION_TIMEOUT_MS,
+    OPEN_CHANNEL_DEADLINE_SECONDS,
     compareAddresses,
+    getOpenChannelProposalMismatch,
     type Address
 } from "./OpenChannelNegotiationHelpers";
 
@@ -181,7 +183,8 @@ export default class OpenChannelNegotiationService extends ARpcService<
         if (!isLower) return;
 
         if (haveAmounts && !this.state.proposalSent) {
-            const deadlineTimestamp = Clock.getTimeInSeconds() + 60;
+            const deadlineTimestamp =
+                Clock.getTimeInSeconds() + OPEN_CHANNEL_DEADLINE_SECONDS;
             const openChannel: OpenChannelStruct = {
                 channelId,
                 participants,
@@ -226,7 +229,8 @@ export default class OpenChannelNegotiationService extends ARpcService<
             return;
         }
 
-        const { lower } = this.getParticipantsAndBalances(peer);
+        const { participants, balances, lower } =
+            this.getParticipantsAndBalances(peer);
         const isLower = me === lower;
         if (isLower) {
             this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(peer);
@@ -249,6 +253,44 @@ export default class OpenChannelNegotiationService extends ARpcService<
         if (recovered !== lower) {
             this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(peer);
             this.resetNegotiation("invalid lower signature");
+            return;
+        }
+
+        // Only co-sign once amounts were actually negotiated; otherwise the
+        // reconstructed balances would fall back to defaults and we'd validate
+        // against terms we never agreed.
+        if (typeof this.state.theirAmount !== "number") {
+            this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(peer);
+            this.resetNegotiation("openProposal - no negotiated amount");
+            return;
+        }
+
+        // The lower signature is valid, but it only proves the peer signed
+        // *these* bytes — not that they match what we negotiated. Reconstruct
+        // the expected terms and refuse to co-sign anything else, so a peer
+        // can't make our signer authorize attacker-chosen channel parameters.
+        const nowSeconds = Clock.getTimeInSeconds();
+        const mismatch = getOpenChannelProposalMismatch(
+            decoded,
+            {
+                channelId: this.p2pManager.stateManager.getChannelId(),
+                participants,
+                balances
+            },
+            {
+                nowSeconds,
+                // Generous upper bound (2x the proposer's deadline offset) so
+                // modest clock skew between peers can't reject a legitimate
+                // proposal; the deadline is a sanity bound, not fund-critical.
+                maxSeconds: nowSeconds + OPEN_CHANNEL_DEADLINE_SECONDS * 2
+            }
+        );
+        if (mismatch) {
+            this.logger.warn(
+                `openProposal - proposed terms do not match negotiation; rejecting (${mismatch})`
+            );
+            this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(peer);
+            this.resetNegotiation(`openProposal terms mismatch: ${mismatch}`);
             return;
         }
 

--- a/test/rpc/openChannelNegotiation/OpenChannelProposal.test.ts
+++ b/test/rpc/openChannelNegotiation/OpenChannelProposal.test.ts
@@ -1,0 +1,126 @@
+import { expect } from "chai";
+
+import { getOpenChannelProposalMismatch } from "@/rpc/services/openChannelNegotiation/OpenChannelNegotiationHelpers";
+import type { OpenChannelStruct } from "@typechain-types/contracts/V1/types/DataTypes";
+
+/**
+ * Regression: openProposal must only co-sign the exact OpenChannel it
+ * negotiated. A valid lower signature only proves the peer signed *those*
+ * bytes, not that they match local terms — so the receiver compares every
+ * security-sensitive field before signing.
+ */
+const A = "0x" + "11".repeat(20);
+const B = "0x" + "22".repeat(20);
+const CHANNEL_ID = "0x" + "33".repeat(32);
+const NOW = 1000;
+
+const expected = {
+    channelId: CHANNEL_ID,
+    participants: [A, B] as [string, string],
+    balances: [
+        { amount: 500, data: "0x" },
+        { amount: 700, data: "0x" }
+    ]
+};
+const deadline = {
+    nowSeconds: NOW,
+    maxSeconds: NOW + 60 + 10
+};
+
+// A proposal that matches the negotiated terms exactly.
+const matchingProposal = (): OpenChannelStruct =>
+    ({
+        channelId: CHANNEL_ID,
+        participants: [A, B],
+        balances: [
+            { amount: 500n, data: "0x" },
+            { amount: 700n, data: "0x" }
+        ],
+        deadlineTimestamp: 1030n,
+        isAtomic: true,
+        data: "0x"
+    }) as unknown as OpenChannelStruct;
+
+describe("getOpenChannelProposalMismatch", function () {
+    it("accepts a proposal that matches the negotiated terms", function () {
+        expect(
+            getOpenChannelProposalMismatch(
+                matchingProposal(),
+                expected,
+                deadline
+            )
+        ).to.equal(null);
+    });
+
+    it("rejects a tampered balance amount (no fund redirection)", function () {
+        const decoded = matchingProposal();
+        decoded.balances[1].amount = 999_999n;
+        expect(
+            getOpenChannelProposalMismatch(decoded, expected, deadline)
+        ).to.match(/balance 1 amount mismatch/);
+    });
+
+    it("rejects tampered balance data", function () {
+        const decoded = matchingProposal();
+        decoded.balances[0].data = "0xdeadbeef";
+        expect(
+            getOpenChannelProposalMismatch(decoded, expected, deadline)
+        ).to.match(/balance 0 data mismatch/);
+    });
+
+    it("rejects a different participant set", function () {
+        const decoded = matchingProposal();
+        decoded.participants = [A, "0x" + "44".repeat(20)];
+        expect(
+            getOpenChannelProposalMismatch(decoded, expected, deadline)
+        ).to.match(/participant 1 mismatch/);
+    });
+
+    it("rejects a different channelId", function () {
+        const decoded = matchingProposal();
+        decoded.channelId = "0x" + "55".repeat(32);
+        expect(
+            getOpenChannelProposalMismatch(decoded, expected, deadline)
+        ).to.match(/channelId mismatch/);
+    });
+
+    it("rejects non-atomic opens", function () {
+        const decoded = matchingProposal();
+        decoded.isAtomic = false;
+        expect(
+            getOpenChannelProposalMismatch(decoded, expected, deadline)
+        ).to.match(/isAtomic/);
+    });
+
+    it("rejects arbitrary opening data", function () {
+        const decoded = matchingProposal();
+        decoded.data = "0xc0ffee";
+        expect(
+            getOpenChannelProposalMismatch(decoded, expected, deadline)
+        ).to.match(/data must be empty/);
+    });
+
+    it("rejects a deadline in the past", function () {
+        const decoded = matchingProposal();
+        decoded.deadlineTimestamp = BigInt(NOW - 1);
+        expect(
+            getOpenChannelProposalMismatch(decoded, expected, deadline)
+        ).to.match(/deadline out of range/);
+    });
+
+    it("rejects a deadline beyond the allowed window", function () {
+        const decoded = matchingProposal();
+        decoded.deadlineTimestamp = BigInt(deadline.maxSeconds + 1);
+        expect(
+            getOpenChannelProposalMismatch(decoded, expected, deadline)
+        ).to.match(/deadline out of range/);
+    });
+
+    it("matches participants and channelId irrespective of address casing", function () {
+        const decoded = matchingProposal();
+        decoded.participants = [A.toUpperCase().replace("0X", "0x"), B];
+        expect(
+            getOpenChannelProposalMismatch(decoded, expected, deadline)
+        ).to.equal(null);
+    });
+});


### PR DESCRIPTION
## Summary

The `openProposal` receiver in `OpenChannelNegotiationService` verified only that the lower-sorting participant signed the peer-supplied `OpenChannel` bytes, then co-signed those same bytes with the local participant key and submitted them on-chain. A valid lower signature only proves the peer signed **those** bytes — not that they match what was locally negotiated. A lower-sorting handshaked peer could therefore make the local signer authorize attacker-chosen `channelId` / `participants` / `balances` / `data` / `deadline`.

(Impact is bounded — `open()` is non-payable and balances are funded from each participant's own on-chain deposit, so there's no fund redirection — but the victim could still be co-signed into an unwanted channel/terms.)

### Fix
Before signing, reconstruct the expected `OpenChannel` from local negotiation state (`getParticipantsAndBalances(peer)` + `getChannelId()`, `isAtomic: true`, empty `data`) and reject (disconnect + blacklist) if any security-sensitive field differs:
- `channelId`, `participants` (and order), each balance `amount` + `data`, `isAtomic`, `data`, and a sane `deadline` window.

Also:
- Require amounts to have actually been negotiated (`theirAmount` set) before co-signing, so the reconstructed balances can't silently fall back to defaults.
- Extracted the proposer's deadline offset into a shared `OPEN_CHANNEL_DEADLINE_SECONDS` constant used on both the build and validate sides; the receiver's deadline upper bound is generous (2x the offset) so modest clock skew can't reject a legitimate proposal.

The comparison lives in a pure helper (`getOpenChannelProposalMismatch`) for direct unit testing; the honest flow's reconstruction matches `maybeProgress` field-for-field.

## Test Plan
- New unit tests (`test/rpc/openChannelNegotiation/OpenChannelProposal.test.ts`): a matching proposal is accepted; tampered balance amount, balance data, participant set, channelId, `isAtomic`, `data`, and out-of-range deadlines are each rejected; address casing is normalized.
- `yarn tsc --noEmit` — clean.