### PR TITLE
fix(rpc): bound the pre-handshake RPC queue

### DIFF
--- a/src/rpc/guards/HandshakeCompletedGuard.ts
+++ b/src/rpc/guards/HandshakeCompletedGuard.ts
@@ -1,4 +1,4 @@
-import Rpc from "@/rpc/Rpc";
+import Rpc, { serializeRpc } from "@/rpc/Rpc";
 import ATransport from "@/transport/ATransport";
 import { AGuard } from "@/rpc/guards/AGuard";
 import ARpcService from "@/rpc/ARpcService";
@@ -8,12 +8,36 @@ export interface HandshakeCompletedGuardOptions {
     onFailure?: (rpc: Rpc, transport: ATransport) => void;
 }
 
-class RpcQueue {
+// Bound the per-transport queue of RPCs buffered while a handshake is still
+// negotiating, so an unauthenticated peer can't grow it without limit.
+export const MAX_PREAUTH_QUEUED_RPCS = 64;
+export const MAX_PREAUTH_QUEUED_BYTES = 1_000_000;
+
+export class RpcQueue {
     private readonly queue: Rpc[] = [];
     private waiting = false;
+    private totalBytes = 0;
 
-    enqueue(rpc: Rpc): void {
+    constructor(
+        private readonly maxCount: number = MAX_PREAUTH_QUEUED_RPCS,
+        private readonly maxBytes: number = MAX_PREAUTH_QUEUED_BYTES
+    ) {}
+
+    /**
+     * Returns false if enqueuing would exceed the count or byte budget; the
+     * caller treats a full queue as abuse and disconnects the peer.
+     */
+    enqueue(rpc: Rpc): boolean {
+        const size = serializeRpc(rpc).length;
+        if (
+            this.queue.length >= this.maxCount ||
+            this.totalBytes + size > this.maxBytes
+        ) {
+            return false;
+        }
         this.queue.push(rpc);
+        this.totalBytes += size;
+        return true;
     }
 
     isWaiting(): boolean {
@@ -30,10 +54,12 @@ class RpcQueue {
             if (!next) break;
             handler(next);
         }
+        this.totalBytes = 0;
     }
 
     clear(): void {
         this.queue.length = 0;
+        this.totalBytes = 0;
         this.waiting = false;
     }
 }
@@ -76,7 +102,28 @@ export class HandshakeCompletedGuard extends AGuard<ARpcService<ARpcMethods>> {
         // agreementTime for it to complete and retry the RPC (return early via EventBarrier).
         if (initHandshakeService.isNegotiating(transport)) {
             const queue = this.getQueue(transport);
-            queue.enqueue(rpc);
+
+            // A full pre-handshake queue means the unauthenticated peer is
+            // flooding us; treat it as abuse and disconnect.
+            if (!queue.enqueue(rpc)) {
+                queue.clear();
+                this.service.logger.warn(
+                    "Pre-handshake RPC queue limit exceeded; disconnecting",
+                    {
+                        service: rpc.service,
+                        method: rpc.method,
+                        peerAddress: transport.peerAddress
+                    }
+                );
+                if (transport.peerAddress) {
+                    this.service.p2pManager.disconnectAndBlacklistPeerByEvmAddress(
+                        transport.peerAddress
+                    );
+                    return;
+                }
+                this.service.p2pManager.disconnectAndBlacklistPeer(transport);
+                return;
+            }
 
             // Only start one waiter per transport; additional RPCs enqueue behind it.
             if (queue.isWaiting()) {

--- a/test/rpc/guards/RpcQueue.test.ts
+++ b/test/rpc/guards/RpcQueue.test.ts
@@ -1,0 +1,68 @@
+import { expect } from "chai";
+
+import {
+    RpcQueue,
+    MAX_PREAUTH_QUEUED_RPCS
+} from "@/rpc/guards/HandshakeCompletedGuard";
+import type Rpc from "@/rpc/Rpc";
+
+/**
+ * Regression: the per-transport queue that buffers guarded RPCs during handshake
+ * negotiation must be bounded, so an unauthenticated peer cannot grow it without
+ * limit. enqueue returns false on overflow; the guard treats that as abuse.
+ */
+const makeRpc = (overrides: Partial<Rpc> = {}): Rpc => ({
+    service: "s",
+    method: "m",
+    params: [],
+    ...overrides
+});
+
+describe("RpcQueue - pre-handshake buffering bounds", function () {
+    it("accepts up to the count limit, then rejects", function () {
+        const queue = new RpcQueue(2, 1_000_000);
+
+        expect(queue.enqueue(makeRpc())).to.equal(true);
+        expect(queue.enqueue(makeRpc())).to.equal(true);
+        expect(queue.enqueue(makeRpc())).to.equal(false);
+    });
+
+    it("rejects once the byte budget is exceeded", function () {
+        // Each makeRpc() serializes to well under 100 bytes; a tiny budget admits
+        // one then rejects the next.
+        const queue = new RpcQueue(100, 60);
+
+        expect(queue.enqueue(makeRpc())).to.equal(true);
+        expect(queue.enqueue(makeRpc())).to.equal(false);
+    });
+
+    it("frees capacity after clear()", function () {
+        const queue = new RpcQueue(1, 1_000_000);
+
+        expect(queue.enqueue(makeRpc())).to.equal(true);
+        expect(queue.enqueue(makeRpc())).to.equal(false);
+
+        queue.clear();
+        expect(queue.enqueue(makeRpc())).to.equal(true);
+    });
+
+    it("frees capacity (count and bytes) after drain()", function () {
+        const queue = new RpcQueue(1, 1_000_000);
+        expect(queue.enqueue(makeRpc())).to.equal(true);
+
+        const drained: Rpc[] = [];
+        queue.drain((rpc) => drained.push(rpc));
+        expect(drained.length).to.equal(1);
+
+        // Byte counter reset too, so the next enqueue is admitted.
+        expect(queue.enqueue(makeRpc())).to.equal(true);
+    });
+
+    it("defaults to a sane count bound", function () {
+        const queue = new RpcQueue();
+        for (let i = 0; i < MAX_PREAUTH_QUEUED_RPCS; i++) {
+            expect(queue.enqueue(makeRpc())).to.equal(true);
+        }
+        expect(queue.enqueue(makeRpc())).to.equal(false);
+    });
+});


### PR DESCRIPTION
## Summary

`HandshakeCompletedGuard` buffers guarded RPCs received while a handshake is still negotiating, in a per-transport `RpcQueue`. `enqueue` was a bare `push` with no bound, so an unauthenticated (still-negotiating) peer could grow the queue without limit during the negotiation window.

### Fix
Bound the queue by **count** (`MAX_PREAUTH_QUEUED_RPCS = 64`) and **total bytes** (`MAX_PREAUTH_QUEUED_BYTES = 1_000_000`, sized via the existing `serializeRpc`). `enqueue` now returns `false` on overflow, and the guard treats a full queue as abuse — it clears the queue and disconnects/blacklists the peer. `clear`/`drain` reset the byte counter.

The window was already time-bounded (`2 × agreementTime`) and per-transport, so this is defense-in-depth, but it removes the unbounded-growth primitive. Guarded RPCs reaching the queue always originate from `deserializeRpc` (JSON), so `serializeRpc` can't hit a bigint here.

## Test Plan
- New unit tests (`test/rpc/guards/RpcQueue.test.ts`): count cap, byte cap, capacity freed after `clear()` and after `drain()`, and the default count bound.
- `yarn tsc --noEmit` — clean.