### PR TITLE
fix(rpc): bound RPC frame size and require array params

### DIFF
--- a/src/P2PManager.ts
+++ b/src/P2PManager.ts
@@ -3,6 +3,7 @@ import type StateManager from "@/stateManager";
 import Rpc, {
     deserializeRpc,
     deserializeRpcResponse,
+    MAX_RPC_FRAME_BYTES,
     RpcResponse
 } from "@/rpc/Rpc";
 import MainRpcService from "@/rpc/MainRpcService";
@@ -202,6 +203,17 @@ class P2PManager<TCustomRpc extends MainRpcService = MainRpcService>
     }
     public onRpc(serializedRpc: string, transport: ATransport) {
         try {
+            // Reject oversized frames before parsing so a peer can't force
+            // unbounded JSON.parse/dispatch work.
+            if (serializedRpc.length > MAX_RPC_FRAME_BYTES) {
+                this.logger.warn("Oversized RPC frame; disconnecting", {
+                    bytes: serializedRpc.length,
+                    transportType: TransportType[transport.transportType],
+                    peerAddress: transport.peerAddress
+                });
+                this.disconnectConnection(transport);
+                return;
+            }
             const response = deserializeRpcResponse(serializedRpc);
             if (response) {
                 this.handleRpcResponse(response, transport);
@@ -231,7 +243,12 @@ class P2PManager<TCustomRpc extends MainRpcService = MainRpcService>
             }
         } catch (e) {
             this.disconnectConnection(transport);
-            console.error(e);
+            this.logger.error("onRpc - error handling RPC frame", {
+                error: e instanceof Error ? e.message : String(e),
+                stack: e instanceof Error ? e.stack : undefined,
+                transportType: TransportType[transport.transportType],
+                peerAddress: transport.peerAddress
+            });
         }
     }
     public async tryOpenConnectionToChannel(channelId: string) {

--- a/src/rpc/Rpc.ts
+++ b/src/rpc/Rpc.ts
@@ -22,6 +22,12 @@ export type RpcResponse = {
     error?: string;
 };
 
+// Upper bound on a single RPC frame's size, enforced before parsing/dispatch so
+// an oversized frame can't force unbounded JSON.parse/handler work. Generous so
+// no legitimate payload (e.g. an encoded sync payload) is rejected; it only
+// caps absurd floods.
+export const MAX_RPC_FRAME_BYTES = 16 * 1024 * 1024;
+
 // RPC params/results must be JSON-serializable: every `*RpcMethods` endpoint
 // takes and returns plain values, with bigint-bearing ethers structs crossing as
 // `Codec.encode`d `encoded*` strings (one serialization mechanism — Codec). A
@@ -39,7 +45,9 @@ export function deserializeRpc(serializedRpc: string): Rpc | undefined {
             !rpc ||
             typeof rpc.service !== "string" ||
             typeof rpc.method !== "string" ||
-            !rpc.params
+            // `params` must be an array — the dispatcher spreads it
+            // (`method(...rpc.params)`), so a non-array would mis-dispatch.
+            !Array.isArray(rpc.params)
         ) {
             return undefined;
         }

--- a/test/rpc/Rpc.test.ts
+++ b/test/rpc/Rpc.test.ts
@@ -1,0 +1,69 @@
+import { expect } from "chai";
+
+import { deserializeRpc, serializeRpc, MAX_RPC_FRAME_BYTES } from "@/rpc/Rpc";
+
+/**
+ * Regression: deserializeRpc must require `params` to be an array. The
+ * dispatcher spreads it (`method(...rpc.params)`), so a non-array (string,
+ * object, number) would mis-dispatch or amplify work. Previously only
+ * truthiness was checked.
+ */
+describe("deserializeRpc - params schema", function () {
+    it("accepts a well-formed RPC with array params", function () {
+        const rpc = deserializeRpc(
+            serializeRpc({ service: "s", method: "m", params: [1, "a"] })
+        );
+        expect(rpc).to.not.equal(undefined);
+        expect(rpc!.params).to.deep.equal([1, "a"]);
+    });
+
+    it("preserves requestId for request-style RPCs", function () {
+        const rpc = deserializeRpc(
+            JSON.stringify({
+                service: "s",
+                method: "m",
+                params: [],
+                requestId: "abc"
+            })
+        );
+        expect(rpc?.requestId).to.equal("abc");
+    });
+
+    for (const [label, params] of [
+        ["string", '"not-an-array"'],
+        ["object", "{}"],
+        ["number", "5"],
+        ["boolean", "true"],
+        ["null", "null"]
+    ] as const) {
+        it(`rejects params that are a ${label}`, function () {
+            const rpc = deserializeRpc(
+                `{"service":"s","method":"m","params":${params}}`
+            );
+            expect(rpc).to.equal(undefined);
+        });
+    }
+
+    it("rejects when params is missing entirely", function () {
+        expect(deserializeRpc('{"service":"s","method":"m"}')).to.equal(
+            undefined
+        );
+    });
+
+    it("rejects a non-string service or method", function () {
+        expect(
+            deserializeRpc('{"service":1,"method":"m","params":[]}')
+        ).to.equal(undefined);
+        expect(
+            deserializeRpc('{"service":"s","method":2,"params":[]}')
+        ).to.equal(undefined);
+    });
+
+    it("returns undefined on invalid JSON", function () {
+        expect(deserializeRpc("not json")).to.equal(undefined);
+    });
+
+    it("exposes a positive frame-size bound", function () {
+        expect(MAX_RPC_FRAME_BYTES).to.be.greaterThan(0);
+    });
+});


### PR DESCRIPTION
## Summary

Network RPC frames were parsed and dispatched with no size budget, and `deserializeRpc` accepted any truthy `params` even though the dispatcher spreads it (`rpc_method[method](...rpc.params)`) — a non-array `params` would mis-dispatch (e.g. a string spreads into per-char args).

### Fix
- **Frame-size cap**: `onRpc` rejects (disconnects) any frame longer than `MAX_RPC_FRAME_BYTES` (16 MiB) **before** parsing, so a peer can't force unbounded `JSON.parse`/dispatch work. The bound is applied before both the response and request deserialize paths. 16 MiB is generous — well above the largest legitimate frame (an encoded spectate `SyncPayload`), so no real traffic is rejected.
- **Params schema**: `deserializeRpc` now requires `Array.isArray(rpc.params)`. Legitimate RPCs always build `params` from a rest parameter (`RpcHandleProxy`), so this is invisible to real traffic (including zero-arg calls → `[]`).
- Replaced a `console.error(e)` on the frame-error path with the internal logger (the project forbids `console.*`, and that pipeline collects logs for analysis).

## Test Plan
- New unit tests (`test/rpc/Rpc.test.ts`): array params accepted (incl. zero-arg and `requestId`); string/object/number/boolean/null/missing params rejected; non-string service/method rejected; invalid JSON → undefined.
- `yarn tsc --noEmit` — clean.
- Ping E2E (real RPC traffic) passes; verified `params` is always array-constructed so legit traffic is unaffected.

Note: one unrelated custom-RPC E2E is flaky (30s-timeout) on `dispute` independent of this change.