### PR TITLE
fix(scripts): prevent path traversal in crash-log server

### DIFF
--- a/scripts/logging/crash-log-server.js
+++ b/scripts/logging/crash-log-server.js
@@ -92,6 +92,11 @@ async function listChannelDirs() {
 }
 
 async function resolveChannelDir(channelId, options = {}) {
+    // channelId is attacker-controlled and used to build on-disk paths; sanitize
+    // it (same as peer segments) so it can't escape LOG_DIR via traversal.
+    // Both the write (POST) and read (GET) paths go through here, so the
+    // sanitized value stays consistent across them.
+    channelId = sanitizeSegment(channelId);
     const { rotateIfOld = false } = options;
     const nowMs = Date.now();
     const maxAgeMs = CHANNEL_DIR_MAX_AGE_MS;
@@ -177,7 +182,10 @@ async function resolveChannelDir(channelId, options = {}) {
 }
 
 function sanitizeSegment(value) {
-    return String(value).replace(/[\/]/g, "_");
+    // Strict allowlist: anything outside [0-9a-zA-Z_-] (path separators, dots,
+    // etc.) becomes "_", so a value used as a path segment can't traverse out
+    // of LOG_DIR. Legitimate channel ids / EVM addresses are hex and unchanged.
+    return String(value).replace(/[^0-9a-zA-Z_-]/g, "_");
 }
 
 function getRequestMeta(req) {
@@ -363,14 +371,20 @@ app.get("/logs/:channelId/:peerAddress", async (req, res) => {
 
 async function start() {
     await ensureLogDir();
-    app.listen(PORT, () => {
+    // Bind to loopback only — this is a local dev helper, not a public service.
+    app.listen(PORT, "127.0.0.1", () => {
         console.log(
             `[CrashLogServer] Server running on http://localhost:${PORT}`
         );
     });
 }
 
-start().catch((err) => {
-    console.error("[CrashLogServer] Failed to start:", err);
-    process.exit(1);
-});
+// Only auto-start when run directly; allows importing helpers (e.g. for tests).
+if (require.main === module) {
+    start().catch((err) => {
+        console.error("[CrashLogServer] Failed to start:", err);
+        process.exit(1);
+    });
+}
+
+module.exports = { sanitizeSegment };

--- a/test/scripts/crashLogServer.test.ts
+++ b/test/scripts/crashLogServer.test.ts
@@ -1,0 +1,49 @@
+import { expect } from "chai";
+import path from "path";
+
+// The crash-log server is a CommonJS dev script. Its start() is guarded by
+// `require.main === module`, so requiring it here only imports the helper and
+// does not spin up a server.
+const { sanitizeSegment } =
+    require("../../scripts/logging/crash-log-server.js") as {
+        sanitizeSegment: (value: unknown) => string;
+    };
+
+/**
+ * Regression: channelId / peerAddress are attacker-controlled and used to build
+ * on-disk paths under LOG_DIR. sanitizeSegment must neutralize any path
+ * traversal so a crafted value can't write/read outside the log directory.
+ */
+describe("crash-log-server sanitizeSegment - path traversal", function () {
+    const LOG_DIR = "/var/crash-logs";
+
+    it("leaves legitimate hex ids / addresses unchanged", function () {
+        const channelId = "0x" + "ab".repeat(32);
+        const address = "0x" + "cd".repeat(20);
+        expect(sanitizeSegment(channelId)).to.equal(channelId);
+        expect(sanitizeSegment(address)).to.equal(address);
+    });
+
+    it("replaces every disallowed character with _", function () {
+        expect(sanitizeSegment("a.b/c\\d:e")).to.equal("a_b_c_d_e");
+    });
+
+    it("keeps a sanitized segment contained under LOG_DIR", function () {
+        for (const evil of [
+            "../../../../tmp/pwn",
+            "..\\..\\windows",
+            "/etc/passwd",
+            "../secret",
+            ".."
+        ]) {
+            const safe = sanitizeSegment(evil);
+            // No separators survive...
+            expect(safe).to.not.match(/[/\\]/);
+            // ...and joining it under LOG_DIR cannot escape LOG_DIR.
+            const resolved = path.resolve(LOG_DIR, `${safe}_ts`);
+            expect(
+                resolved.startsWith(path.resolve(LOG_DIR) + path.sep)
+            ).to.equal(true);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

The crash-log dev helper (`scripts/logging/crash-log-server.js`) used a request-supplied `channelId` (from `req.body` on upload and `req.params` on retrieval) verbatim to build on-disk paths — `path.join(LOG_DIR, \`${channelId}_${ts}\`)` — with no sanitization, so a crafted `channelId` (e.g. `../../../../tmp/pwn`) could write/read **outside** the log directory. `peerAddress` was only partially sanitized (`/` replaced, but `..` and `\` survived).

This is a local dev helper (not shipped in the package, disabled by default, not started by any script), so severity is Low — but the traversal is real.

### Fix
- Sanitize `channelId` at the single `resolveChannelDir` chokepoint (covers both the write and read paths, so they stay consistent).
- Tighten `sanitizeSegment` to a strict `[0-9a-zA-Z_-]` allowlist so no path separators or dot-segments survive. Legitimate channel ids (`0x`+64 hex) and EVM addresses (`0x`+40 hex) are entirely within the allowlist, so they're unchanged.
- Bind the server to `127.0.0.1` (loopback) instead of all interfaces.
- Guard `start()` behind `require.main === module` and export `sanitizeSegment` so the helper is importable/testable without spinning up a server.

## Test Plan
- New unit test (`test/scripts/crashLogServer.test.ts`): legitimate hex ids/addresses pass through unchanged; disallowed chars become `_`; traversal sequences (`../../…`, `..\\..`, `/etc/passwd`, `..`) stay contained under `LOG_DIR` (verified via `path.resolve` containment).
- `yarn tsc --noEmit` — clean.