### PR TITLE
Request/response for RPC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,11 @@
 - For post-edit validation, run the narrowest relevant test first when available.
 - Run `yarn tsc --noEmit -p tsconfig.json` for TypeScript typechecking.
 - Run `yarn compile` for compile-level validation when changes affect the build or exported package surface.
+- Don't disturb the user's working tree or index to inspect another revision.
+  Prefer a throwaway worktree (`git worktree add <tmp> <ref>`) over `git stash`.
+  If you must stash, preserve staging: restore with `git stash pop --index` so
+  files the user had staged come back staged — never leave them re-reviewing
+  files they'd already staged.
 
 ## Conventions
 
@@ -26,6 +31,12 @@ Applies to `src/rpc/services/*` and `test/fixtures/customRpc/**`.
 ### Comments
 
 - Keep comments simple and to the point. No long essays.
+- When refactoring or moving code (extracting a method, moving a body to another
+  file/service), carry over all original comments verbatim — do not drop or
+  condense them, including large explanatory/strategy blocks and numbered step
+  comments. If a comment genuinely needs to change, call it out rather than
+  dropping it silently; flag stale commented-out dead code instead of removing
+  it without mention.
 
 ### Type safety
 

--- a/src/rpc/services/initHandshake/InitHandshakeRpcMethods.ts
+++ b/src/rpc/services/initHandshake/InitHandshakeRpcMethods.ts
@@ -1,9 +1,11 @@
 import Clock from "@/Clock";
 import ARpcMethods from "@/rpc/ARpcMethods";
-import { ATransport, TransportType } from "@/transport";
-import { Hash, Signature, Timestamp } from "@/types/types";
+import { ATransport } from "@/transport";
+import { Hash, Timestamp } from "@/types/types";
 import { ethers } from "ethers";
-import InitHandshakeService from "./InitHandshakeService";
+import InitHandshakeService, {
+    HandshakeResponse
+} from "./InitHandshakeService";
 import { LoggerUtils } from "@/utils/LoggerUtils";
 
 class InitHandshakeRpcMethods extends ARpcMethods {
@@ -13,7 +15,17 @@ class InitHandshakeRpcMethods extends ARpcMethods {
         this.service = service;
     }
 
-    public async onInitHandshakeRequest(challengeHash: Hash, time: Timestamp) {
+    /**
+     * Request/response: the challenger sends its challenge and awaits the signed
+     * response directly (`.request(...)`). The signed challenge + responder's
+     * preferred transport are returned to the caller rather than delivered via a
+     * separate `onInitHandshakeResponse` endpoint. A thrown error rejects the
+     * caller's request and tears down the connection on both ends.
+     */
+    public async onInitHandshakeRequest(
+        challengeHash: Hash,
+        time: Timestamp
+    ): Promise<HandshakeResponse> {
         const localTime = Clock.getTimeInSeconds();
         const agreementTime =
             this.p2pManager.stateManager.timeConfig.agreementTime;
@@ -43,7 +55,7 @@ class InitHandshakeRpcMethods extends ARpcMethods {
                 }
             );
             this.p2pManager.disconnectConnection(this.senderTransport);
-            return;
+            throw new Error("malformed handshake request (challenge/time)");
         }
         const timeDifference = time - localTime;
         if (Math.abs(timeDifference) > agreementTime) {
@@ -62,7 +74,7 @@ class InitHandshakeRpcMethods extends ARpcMethods {
                 }
             );
             this.p2pManager.disconnectConnection(this.senderTransport);
-            return;
+            throw new Error("request time outside agreement window");
         }
         const challengeMessage =
             InitHandshakeService.buildHandshakeChallengeMessage(challengeHash);
@@ -79,167 +91,15 @@ class InitHandshakeRpcMethods extends ARpcMethods {
                 preferredTransport: this.p2pManager.preferredTransport
             }
         );
-        this.remoteRpc.initHandshakeService
-            .onInitHandshakeResponse(
-                signature,
-                localTime,
-                this.p2pManager.preferredTransport
-            )
-            .sendOne(this.senderTransport);
+        // We've authenticated their challenge and replied; from here we expect
+        // their ack. Mark the negotiation and arm the ack timeout.
+        this.service.markHandshakeInFlight(this.senderTransport);
         this.service.ensureHandshakeAckTimeoutScheduled(this.senderTransport);
-    }
-
-    public async onInitHandshakeResponse(
-        signature: Signature,
-        responseTime: Timestamp,
-        preferredTransport: TransportType
-    ) {
-        const challenge = this.service.getChallenge(this.senderTransport);
-        this.service.mapTransportToChallenge.delete(this.senderTransport);
-        if (!challenge) {
-            LoggerUtils.logInitHandshakeMessage(
-                this.service.logger,
-                this.senderTransport,
-                {
-                    direction: "receive",
-                    message: "rejected",
-                    responseTime,
-                    preferredTransport,
-                    reason: "response did not match an active challenge"
-                }
-            );
-            this.p2pManager.disconnectConnection(this.senderTransport);
-            return;
-        }
-        const localTime = Clock.getTimeInSeconds();
-        const rtt = localTime - challenge.initTime;
-        const agreementTime =
-            this.p2pManager.stateManager.timeConfig.agreementTime;
-        if (rtt > agreementTime) {
-            LoggerUtils.logInitHandshakeMessage(
-                this.service.logger,
-                this.senderTransport,
-                {
-                    direction: "receive",
-                    message: "rejected",
-                    challengeHash: challenge.randomChallengeHash,
-                    challengeInitTime: challenge.initTime,
-                    responseTime,
-                    preferredTransport,
-                    rttSeconds: rtt,
-                    timeDifferenceSeconds: rtt,
-                    absoluteTimeDifferenceSeconds: Math.abs(rtt),
-                    agreementTimeSeconds: agreementTime,
-                    reason: "response RTT outside agreement window"
-                }
-            );
-            this.p2pManager.disconnectConnection(this.senderTransport);
-            return;
-        }
-        const responseTimeDifference = responseTime - challenge.initTime;
-        if (Math.abs(responseTimeDifference) > agreementTime) {
-            LoggerUtils.logInitHandshakeMessage(
-                this.service.logger,
-                this.senderTransport,
-                {
-                    direction: "receive",
-                    message: "rejected",
-                    challengeHash: challenge.randomChallengeHash,
-                    challengeInitTime: challenge.initTime,
-                    responseTime,
-                    preferredTransport,
-                    rttSeconds: rtt,
-                    timeDifferenceSeconds: responseTimeDifference,
-                    absoluteTimeDifferenceSeconds: Math.abs(
-                        responseTimeDifference
-                    ),
-                    agreementTimeSeconds: agreementTime,
-                    reason: "response timestamp outside agreement window"
-                }
-            );
-            this.p2pManager.disconnectConnection(this.senderTransport);
-            return;
-        }
-        //verify signature
-        const challengeMessage =
-            InitHandshakeService.buildHandshakeChallengeMessage(
-                challenge.randomChallengeHash
-            );
-        const signerAddress = ethers.verifyMessage(challengeMessage, signature);
-        LoggerUtils.logInitHandshakeMessage(
-            this.service.logger,
-            this.senderTransport,
-            {
-                direction: "receive",
-                message: "response",
-                challengeHash: challenge.randomChallengeHash,
-                challengeInitTime: challenge.initTime,
-                responseTime,
-                preferredTransport,
-                rttSeconds: rtt,
-                signerAddress
-            }
-        );
-        // Check if this peer is blacklisted
-        // TODO - we destory the profile, so we wouldn't have this information
-        if (this.p2pManager.isBlacklisted(signerAddress)) {
-            LoggerUtils.logInitHandshakeMessage(
-                this.service.logger,
-                this.senderTransport,
-                {
-                    direction: "local",
-                    message: "rejected",
-                    challengeHash: challenge.randomChallengeHash,
-                    challengeInitTime: challenge.initTime,
-                    responseTime,
-                    preferredTransport,
-                    rttSeconds: rtt,
-                    signerAddress,
-                    reason: "response signer is blacklisted"
-                }
-            );
-            this.p2pManager.disconnectConnection(this.senderTransport);
-            return;
-        }
-
-        this.service.recordVerifiedPeerAddress(
-            this.senderTransport,
-            signerAddress
-        );
-
-        this.service.setRemotePreferredTransport(
-            this.senderTransport,
-            preferredTransport
-        );
-
-        this.service.maybeFinalizeHandshakeOnceFromTransport(
-            this.senderTransport
-        );
-
-        // Inform the remote that we've authenticated them.
-        LoggerUtils.logInitHandshakeMessage(
-            this.service.logger,
-            this.senderTransport,
-            {
-                direction: "send",
-                message: "ack",
-                challengeHash: challenge.randomChallengeHash,
-                signerAddress
-            }
-        );
-        this.remoteRpc.initHandshakeService
-            .onInitHandshakeAck(challenge.randomChallengeHash)
-            .sendOne(this.senderTransport);
-        //TODO! TEST!!
-        // this.rpcProxy
-        //     .onSignJoinChannelTEST(
-        //         this.p2pManager.p2pSigner.signedJc.encodedJoinChannel,
-        //         this.p2pManager.p2pSigner.signedJc.signature
-        //     )
-        //     .broadcast();
-
-        // Ensure we have a timeout path in case ack gets lost.
-        this.service.ensureHandshakeAckTimeoutScheduled(this.senderTransport);
+        return {
+            signature,
+            responseTime: localTime,
+            preferredTransport: this.p2pManager.preferredTransport
+        };
     }
 
     /**

--- a/src/rpc/services/initHandshake/InitHandshakeService.ts
+++ b/src/rpc/services/initHandshake/InitHandshakeService.ts
@@ -10,14 +10,20 @@ import type P2PManager from "@/P2PManager";
 import { TimeoutManager } from "@/utils/TimeoutManager";
 import EventBarrier from "@/utils/EventBarrier";
 import { Status } from "@/types";
-import { Hash } from "@/types/types";
+import { Hash, Signature, Timestamp } from "@/types/types";
 import { DetachedPromises, getChecksumAddress } from "@/utils";
 import { LoggerUtils } from "@/utils/LoggerUtils";
 import { EventBarrierCapturedError } from "@/utils/EventBarrier";
 
-type ConnectionChallenge = {
-    randomChallengeHash: string;
-    initTime: number;
+/**
+ * Value returned by the responder from `onInitHandshakeRequest` and resolved to
+ * the challenger's `.request(...)` call. Replaces the old standalone
+ * `onInitHandshakeResponse` endpoint.
+ */
+export type HandshakeResponse = {
+    signature: Signature;
+    responseTime: Timestamp;
+    preferredTransport: TransportType;
 };
 
 class InitHandshakeService extends ARpcService<InitHandshakeRpcMethods> {
@@ -40,9 +46,14 @@ class InitHandshakeService extends ARpcService<InitHandshakeRpcMethods> {
         return `${InitHandshakeService.HANDSHAKE_DOMAIN}:${ethers.hexlify(challengeHash)}`;
     }
 
-    mapTransportToChallenge: WeakMap<ATransport, ConnectionChallenge> =
-        new WeakMap<ATransport, ConnectionChallenge>();
     timeoutManager: TimeoutManager;
+
+    // Transports with an in-flight handshake negotiation (challenge sent and
+    // awaiting response, or response sent and awaiting ack). Lets `isNegotiating`
+    // gate guarded RPCs while the handshake is still completing. The challenge
+    // itself now lives in the initiator's `runHandshake` closure, so no shared
+    // challenge map is needed.
+    private inFlightHandshakeTransports: WeakSet<ATransport> = new WeakSet();
 
     // Internal ack map: tracks whether we received the handshake ack on a transport.
     // Needed because ack can arrive before we have verified/created a PeerProfile.
@@ -71,61 +82,184 @@ class InitHandshakeService extends ARpcService<InitHandshakeRpcMethods> {
         return new InitHandshakeRpcMethods(transport, this);
     }
 
-    //Called locally to initiate the handshake
+    // Called locally to initiate the handshake. Fire-and-forget entry point; the
+    // request/response exchange runs in `runHandshake`.
     public initHandshake(transport: ATransport) {
+        void this.runHandshake(transport);
+    }
+
+    private async runHandshake(transport: ATransport): Promise<void> {
         const randomChallengeHash = ethers.keccak256(ethers.randomBytes(32));
-        const time = Clock.getTimeInSeconds();
-        this.setChallenge(transport, { randomChallengeHash, initTime: time });
+        const initTime = Clock.getTimeInSeconds();
+        const agreementTime =
+            this.p2pManager.stateManager.timeConfig.agreementTime;
         LoggerUtils.logInitHandshakeMessage(this.logger, transport, {
             direction: "send",
             message: "request",
             challengeHash: randomChallengeHash,
-            messageTime: time
+            messageTime: initTime
+        });
+        this.markHandshakeInFlight(transport);
+
+        // Request/response: send the challenge and await the signed response.
+        // A timeout/rejection means no valid response arrived -> disconnect.
+        let response: HandshakeResponse;
+        try {
+            response = await this.remoteRpc.initHandshakeService
+                .onInitHandshakeRequest(randomChallengeHash, initTime)
+                .request(transport, { timeoutMs: agreementTime * 1000 });
+        } catch (error) {
+            LoggerUtils.logInitHandshakeMessage(this.logger, transport, {
+                direction: "local",
+                message: "response-timeout",
+                challengeHash: randomChallengeHash,
+                challengeInitTime: initTime,
+                reason:
+                    error instanceof Error
+                        ? `handshake response not received in time: ${error.message}`
+                        : "handshake response not received in time"
+            });
+            this.p2pManager.disconnectConnection(transport);
+            return;
+        }
+
+        // Processing verifies a peer-supplied signature; junk (e.g. a malformed
+        // signature) makes `ethers.verifyMessage` throw. Guard it so a bad
+        // response disconnects the peer instead of escaping as an unhandled
+        // rejection from this background task.
+        try {
+            await this.handleHandshakeResponse(
+                transport,
+                randomChallengeHash,
+                initTime,
+                response
+            );
+        } catch (error) {
+            LoggerUtils.logInitHandshakeMessage(this.logger, transport, {
+                direction: "local",
+                message: "rejected",
+                challengeHash: randomChallengeHash,
+                challengeInitTime: initTime,
+                reason:
+                    error instanceof Error
+                        ? `invalid handshake response: ${error.message}`
+                        : "invalid handshake response"
+            });
+            this.p2pManager.disconnectConnection(transport);
+        }
+    }
+
+    /**
+     * Validates and applies a handshake response received via `.request(...)`.
+     * Was the body of the old `onInitHandshakeResponse` endpoint; the challenge
+     * now comes from the initiator's closure instead of a shared map.
+     */
+    private async handleHandshakeResponse(
+        transport: ATransport,
+        challengeHash: string,
+        initTime: number,
+        response: HandshakeResponse
+    ): Promise<void> {
+        const { signature, responseTime, preferredTransport } = response;
+        const localTime = Clock.getTimeInSeconds();
+        const rtt = localTime - initTime;
+        const agreementTime =
+            this.p2pManager.stateManager.timeConfig.agreementTime;
+        if (rtt > agreementTime) {
+            LoggerUtils.logInitHandshakeMessage(this.logger, transport, {
+                direction: "receive",
+                message: "rejected",
+                challengeHash,
+                challengeInitTime: initTime,
+                responseTime,
+                preferredTransport,
+                rttSeconds: rtt,
+                timeDifferenceSeconds: rtt,
+                absoluteTimeDifferenceSeconds: Math.abs(rtt),
+                agreementTimeSeconds: agreementTime,
+                reason: "response RTT outside agreement window"
+            });
+            this.p2pManager.disconnectConnection(transport);
+            return;
+        }
+        const responseTimeDifference = responseTime - initTime;
+        if (Math.abs(responseTimeDifference) > agreementTime) {
+            LoggerUtils.logInitHandshakeMessage(this.logger, transport, {
+                direction: "receive",
+                message: "rejected",
+                challengeHash,
+                challengeInitTime: initTime,
+                responseTime,
+                preferredTransport,
+                rttSeconds: rtt,
+                timeDifferenceSeconds: responseTimeDifference,
+                absoluteTimeDifferenceSeconds: Math.abs(responseTimeDifference),
+                agreementTimeSeconds: agreementTime,
+                reason: "response timestamp outside agreement window"
+            });
+            this.p2pManager.disconnectConnection(transport);
+            return;
+        }
+        //verify signature
+        const challengeMessage =
+            InitHandshakeService.buildHandshakeChallengeMessage(challengeHash);
+        const signerAddress = ethers.verifyMessage(challengeMessage, signature);
+        LoggerUtils.logInitHandshakeMessage(this.logger, transport, {
+            direction: "receive",
+            message: "response",
+            challengeHash,
+            challengeInitTime: initTime,
+            responseTime,
+            preferredTransport,
+            rttSeconds: rtt,
+            signerAddress
+        });
+        // Check if this peer is blacklisted
+        // TODO - we destory the profile, so we wouldn't have this information
+        if (this.p2pManager.isBlacklisted(signerAddress)) {
+            LoggerUtils.logInitHandshakeMessage(this.logger, transport, {
+                direction: "local",
+                message: "rejected",
+                challengeHash,
+                challengeInitTime: initTime,
+                responseTime,
+                preferredTransport,
+                rttSeconds: rtt,
+                signerAddress,
+                reason: "response signer is blacklisted"
+            });
+            this.p2pManager.disconnectConnection(transport);
+            return;
+        }
+
+        this.recordVerifiedPeerAddress(transport, signerAddress);
+
+        this.setRemotePreferredTransport(transport, preferredTransport);
+
+        void this.maybeFinalizeHandshakeOnceFromTransport(transport);
+
+        // Inform the remote that we've authenticated them.
+        LoggerUtils.logInitHandshakeMessage(this.logger, transport, {
+            direction: "send",
+            message: "ack",
+            challengeHash,
+            signerAddress
         });
         this.remoteRpc.initHandshakeService
-            .onInitHandshakeRequest(randomChallengeHash, time)
+            .onInitHandshakeAck(challengeHash)
             .sendOne(transport);
-        // expect a response or disconnect
-        this.timeoutManager.scheduleTask(
-            () => {
-                if (!this.didRespond(transport)) {
-                    const challenge = this.getChallenge(transport);
-                    LoggerUtils.logInitHandshakeMessage(
-                        this.logger,
-                        transport,
-                        {
-                            direction: "local",
-                            message: "response-timeout",
-                            challengeHash: challenge?.randomChallengeHash,
-                            challengeInitTime: challenge?.initTime,
-                            reason: "handshake response not received in time"
-                        }
-                    );
-                    this.p2pManager.disconnectConnection(transport);
-                }
-            },
-            this.p2pManager.stateManager.timeConfig.agreementTime * 1000,
-            "InitHandshakeService - initHandshake timeout"
-        );
+
+        // Ensure we have a timeout path in case ack gets lost.
+        this.ensureHandshakeAckTimeoutScheduled(transport);
     }
 
-    public setChallenge(transport: ATransport, challenge: ConnectionChallenge) {
-        this.mapTransportToChallenge.set(transport, challenge);
-    }
-
-    public getChallenge(
-        transport: ATransport
-    ): ConnectionChallenge | undefined {
-        return this.mapTransportToChallenge.get(transport);
-    }
-
-    public didRespond(transport: ATransport): boolean {
-        return !this.getChallenge(transport);
+    public markHandshakeInFlight(transport: ATransport) {
+        this.inFlightHandshakeTransports.add(transport);
     }
 
     public isNegotiating(transport: ATransport): boolean {
         return (
-            this.mapTransportToChallenge.has(transport) ||
+            this.inFlightHandshakeTransports.has(transport) ||
             this.remotePreferredTransportMap.has(transport) ||
             this.verifiedPeerAddressByTransport.has(transport) ||
             this.didReceiveAck(transport)
@@ -277,6 +411,7 @@ class InitHandshakeService extends ARpcService<InitHandshakeRpcMethods> {
         transport.peerAddress = verifiedPeerAddress;
 
         profile.setIsHandshakeCompleted(true);
+        this.inFlightHandshakeTransports.delete(transport);
 
         const completedPeerAddress = profile.getEvmAddress().toString();
         LoggerUtils.logInitHandshakeMessage(this.logger, transport, {

--- a/src/rpc/services/isForkDisputedService/IsForkDisputedRpcMethods.ts
+++ b/src/rpc/services/isForkDisputedService/IsForkDisputedRpcMethods.ts
@@ -12,21 +12,35 @@ class IsForkDisputedRpcMethods extends ARpcMethods {
     }
 
     /**
-     * Peer receives dispute acknowledgment request
-     * Check if fork is disputed and respond accordingly
+     * Peer receives a dispute acknowledgment request. Request/response: resolves
+     * to `true` once we confirm the fork is disputed (recording that we
+     * acknowledged it to this peer). A fork that isn't disputed, a missing peer
+     * address, or a duplicate request is a protocol violation: we disconnect the
+     * requester and throw so its `.request(...)` rejects.
      */
     public async onDisputeAcknowledgmentRequest(
         channelId: ChannelId,
         forkId: ForkId
-    ) {
+    ): Promise<boolean> {
         const peerAddress = this.senderTransport.peerAddress;
         if (!peerAddress) {
             this.service.logger.error(
                 `onDisputeAcknowledgmentRequest - missing peer address`
             );
-            return this.p2pManager.disconnectAndBlacklistPeer(
-                this.senderTransport
+            this.p2pManager.disconnectAndBlacklistPeer(this.senderTransport);
+            throw new Error(
+                "onDisputeAcknowledgmentRequest - missing peer address"
             );
+        }
+
+        // A second request for a fork we already acknowledged to this peer is a
+        // protocol violation.
+        if (this.service.didIAcknowledgeDisputedFork(peerAddress, forkId)) {
+            this.service.logger.debug(
+                `Already acknowledged fork ${forkId} to ${peerAddress}, disconnecting`
+            );
+            this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(peerAddress);
+            throw new Error("duplicate dispute acknowledgment request");
         }
 
         // Check if fork is disputed locally
@@ -38,7 +52,7 @@ class IsForkDisputedRpcMethods extends ARpcMethods {
 
         if (!isDisputed) {
             this.service.logger.verbose(
-                `Fork ${forkId} is NOT disputed on local diamond, responding`
+                `Fork ${forkId} is NOT disputed on local diamond, checking on-chain`
             );
             // check on-chain
             isDisputed =
@@ -47,52 +61,21 @@ class IsForkDisputedRpcMethods extends ARpcMethods {
                     forkId
                 );
         }
-        if (isDisputed) {
-            this.service.logger.verbose(
-                `Fork ${forkId} is disputed on-chain, responding`
+
+        if (!isDisputed) {
+            // Fork is not disputed - disconnect
+            this.service.logger.debug(
+                `Fork ${forkId} is not disputed, disconnecting`
             );
-            return this.service.respondToDisputeAcknowledgment(
-                peerAddress,
-                channelId,
-                forkId
-            );
+            this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(peerAddress);
+            throw new Error("fork not disputed");
         }
 
-        // Fork is not disputed - disconnect
-        this.service.logger.debug(
-            `Fork ${forkId} is not disputed, disconnecting`
-        );
-        return this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(
-            peerAddress
-        );
-    }
-
-    /**
-     * Receive acknowledgment response from a peer
-     */
-    public async onDisputeAcknowledgmentResponse(
-        channelId: ChannelId,
-        forkId: ForkId
-    ) {
         this.service.logger.verbose(
-            `Received dispute acknowledgment response for fork ${forkId}`
+            `Fork ${forkId} is disputed, acknowledging to ${peerAddress}`
         );
-
-        const peerAddress = this.senderTransport.peerAddress;
-        if (!peerAddress) {
-            this.service.logger.error(
-                `onDisputeAcknowledgmentResponse - missing peer address`
-            );
-            return;
-        }
-
-        // Mark that this peer has acknowledged (from our perspective)
-        this.service.peerAcknowledgesDisputedFork(peerAddress, forkId);
-
-        // Fire event hook for dispute acknowledgment
-        this.p2pManager.stateManager.p2pEventHooks?.onDisputeAcknowledgment?.(
-            peerAddress
-        );
+        this.service.IAcknowledgeDisputedFork(peerAddress, forkId);
+        return true;
     }
 }
 

--- a/src/rpc/services/isForkDisputedService/IsForkDisputedService.ts
+++ b/src/rpc/services/isForkDisputedService/IsForkDisputedService.ts
@@ -4,14 +4,12 @@ import { ChannelId, ForkId } from "@/types/types";
 import ATransport from "@/transport/ATransport";
 import type P2PManager from "@/P2PManager";
 import IsForkDisputedRpcMethods from "./IsForkDisputedRpcMethods";
-import { TimeoutManager } from "@/utils/TimeoutManager";
 
 class IsForkDisputedService extends ARpcService<IsForkDisputedRpcMethods> {
     // Track acknowledged disputed forks
     peerAcknowledgementsByAddress: Map<string, Set<ForkId>> = new Map();
     myAcknowledgementsByAddress: Map<string, Set<ForkId>> = new Map();
     disputedForks: Set<ForkId> = new Set();
-    timeoutManager: TimeoutManager;
 
     constructor(p2pManager: P2PManager) {
         super(
@@ -20,7 +18,6 @@ class IsForkDisputedService extends ARpcService<IsForkDisputedRpcMethods> {
                 component: "IsForkDisputedService"
             })
         );
-        this.timeoutManager = p2pManager.stateManager.timeoutManager;
 
         this.guards = [new HandshakeCompletedGuard(this)];
     }
@@ -31,7 +28,12 @@ class IsForkDisputedService extends ARpcService<IsForkDisputedRpcMethods> {
 
     /**
      * Request all peers to acknowledge a disputed fork
-     * This should be called when a dispute window is created on-chain
+     * This should be called when a dispute window is created on-chain.
+     *
+     * Each peer is asked directly via request/response: the reply resolves to
+     * `true` once the peer confirms the fork is disputed (recorded for later
+     * Byzantine-build detection). A peer that rejects (fork not disputed),
+     * errors, or doesn't answer within the window is disconnected.
      */
     public requestDisputeAcknowledgment(
         channelId: ChannelId,
@@ -51,81 +53,52 @@ class IsForkDisputedService extends ARpcService<IsForkDisputedRpcMethods> {
         // Snapshot peer identities (EVM addresses) at request time.
         // Transport instances can change (e.g. WebRTC upgrade), and we also
         // don't want to disconnect peers that connect after we sent the request.
-        const snapshotAddresses = this.p2pManager.getConnectedPeers();
+        const snapshotAddresses = [...this.p2pManager.getConnectedPeers()];
+        const timeoutMs =
+            2 * this.p2pManager.stateManager.timeConfig.agreementTime * 1000;
 
-        // Broadcast the request
-        this.remoteRpc.isForkDisputedService
-            .onDisputeAcknowledgmentRequest(channelId, forkId)
-            .broadcast();
-
-        this.timeoutManager.scheduleTask(
-            () => {
-                this.logger.debug(
-                    `Checking dispute acknowledgment for fork ${forkId}`
-                );
-
-                // Disconnect snapshot peers that haven't acknowledged.
-                for (const peerAddress of snapshotAddresses) {
-                    if (
-                        this.didPeerAddressAcknowledgeDisputedFork(
-                            peerAddress.toString(),
-                            forkId
-                        )
-                    ) {
-                        continue;
+        void Promise.all(
+            snapshotAddresses.map(async (peerAddress) => {
+                try {
+                    const acknowledged =
+                        await this.remoteRpc.isForkDisputedService
+                            .onDisputeAcknowledgmentRequest(channelId, forkId)
+                            .request(peerAddress, { timeoutMs });
+                    if (!acknowledged) {
+                        this.logger.debug(
+                            `Peer did not acknowledge disputed fork ${forkId}, disconnecting`,
+                            { peerAddress }
+                        );
+                        this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(
+                            peerAddress
+                        );
+                        return;
                     }
-
+                    this.peerAcknowledgesDisputedFork(
+                        peerAddress.toString(),
+                        forkId
+                    );
+                    this.p2pManager.stateManager.p2pEventHooks?.onDisputeAcknowledgment?.(
+                        peerAddress
+                    );
+                } catch (error) {
                     this.logger.debug(
-                        `Peer did not acknowledge disputed fork ${forkId}, disconnecting`,
-                        { peerAddress }
+                        `Dispute acknowledgment request failed for fork ${forkId}, disconnecting`,
+                        {
+                            peerAddress,
+                            error:
+                                error instanceof Error
+                                    ? error.message
+                                    : String(error)
+                        }
                     );
                     this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(
                         peerAddress
                     );
                 }
-            },
-            2 * this.p2pManager.stateManager.timeConfig.agreementTime * 1000,
-            "isForkDisputedService:awaitingDisputeAcknowledgments"
+            })
         );
         return true;
-    }
-
-    private didPeerAddressAcknowledgeDisputedFork(
-        peerAddress: string,
-        forkId: ForkId
-    ): boolean {
-        return this.hasAddressAcknowledged(
-            this.peerAcknowledgementsByAddress,
-            peerAddress,
-            forkId
-        );
-    }
-
-    public respondToDisputeAcknowledgment(
-        peerAddress: string,
-        channelId: ChannelId,
-        forkId: ForkId
-    ): Promise<void> | void {
-        if (this.didIAcknowledgeDisputedFork(peerAddress, forkId)) {
-            this.logger.debug(
-                `Already responded for fork ${forkId} to ${peerAddress}, disconnecting`
-            );
-            return this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(
-                peerAddress
-            );
-        }
-
-        this.IAcknowledgeDisputedFork(peerAddress, forkId);
-        this.logger.debug(
-            `I Acknowledge disputed fork ${forkId} to ${peerAddress}`
-        );
-
-        const handler =
-            this.remoteRpc.isForkDisputedService.onDisputeAcknowledgmentResponse(
-                channelId,
-                forkId
-            );
-        handler.sendOne(peerAddress);
     }
 
     /**

--- a/src/rpc/services/spectate/SpectateRpcMethods.ts
+++ b/src/rpc/services/spectate/SpectateRpcMethods.ts
@@ -1,12 +1,9 @@
 import ARpcMethods from "@/rpc/ARpcMethods";
 import { ATransport } from "@/transport";
 import SpectateService, { SyncRequest } from "./SpectateService";
-import { Bytes, ChannelId } from "@/types";
+import { Bytes } from "@/types";
 import Clock from "@/Clock";
-import { ethers } from "ethers";
-import { Codec, hash, Type } from "@/utils";
-import { Block, StateSnapshot } from "@/models";
-import type { DisputeWindowVerification } from "@/types";
+import { Codec, Type } from "@/utils";
 
 class SpectateServiceRpcMethods extends ARpcMethods {
     service: SpectateService;
@@ -15,14 +12,22 @@ class SpectateServiceRpcMethods extends ARpcMethods {
         this.service = service;
     }
 
-    public async onSpectateRequest(syncRequest: SyncRequest) {
+    /**
+     * Request/response: prove the latest possible snapshot for the requested
+     * channel and return it encoded to the spectator's `.request(...)`. A missing
+     * peer address or an unprovable channel disconnects the spectator and throws
+     * so its request rejects.
+     */
+    public async onSpectateRequest(
+        syncRequest: SyncRequest
+    ): Promise<{ encodedSyncPayload: Bytes }> {
         const senderTransport = this.senderTransport;
         const peerAddress = senderTransport.peerAddress;
         if (!peerAddress) {
             // HandshakeCompletedGuard should guarantee peerAddress is present.
             // If it's not, treat as malicious/broken peer.
             this.service.p2pManager.disconnectAndBlacklistPeer(senderTransport);
-            return;
+            throw new Error("onSpectateRequest - missing peer address");
         }
 
         const localTime = Clock.getTimeInSeconds();
@@ -43,363 +48,13 @@ class SpectateServiceRpcMethods extends ARpcMethods {
             this.service.p2pManager.disconnectAndBlacklistPeerByEvmAddress(
                 peerAddress
             );
-            return;
+            throw new Error("onSpectateRequest - no sync payload to prove");
         }
-        const encodedSyncPayload = Codec.encode(syncPayload, Type.SyncPayload);
 
         this.service.logger.debug(`onSpectateRequest - done`);
-        this.remoteRpc.spectateService
-            .onSpectateResponse(syncRequest.channelId, encodedSyncPayload)
-            .sendOne(peerAddress);
-    }
-
-    public async onSpectateResponse(
-        channelId: ChannelId,
-        encodedSyncPayload: Bytes
-    ) {
-        const syncPayload = Codec.decode(encodedSyncPayload, Type.SyncPayload);
-        this.service.logger.debug(`Sync payload received`, {
-            syncPayload
-        });
-        const senderTransport = this.senderTransport;
-        const peerAddress = senderTransport.peerAddress;
-        if (!peerAddress) {
-            // HandshakeCompletedGuard should guarantee peerAddress is present.
-            // If it's not, treat as malicious/broken peer.
-            this.service.p2pManager.disconnectAndBlacklistPeer(senderTransport);
-            return;
-        }
-
-        try {
-            const syncRequest =
-                this.service.takePendingRequestByPeerAddress(peerAddress);
-            if (!syncRequest) {
-                this.service.logger.debug(
-                    "onSpectateResponse - no pending request for peer; aborting",
-                    { peerAddress }
-                );
-                return this.service.abort(peerAddress);
-            }
-
-            // Bind the response to the channel we actually requested. Every
-            // fetch/verify/persist below trusts `channelId`; without this a peer
-            // could answer a request for one channel with a (valid) payload for
-            // another and corrupt our local state.
-            if (
-                ethers.hexlify(channelId) !==
-                ethers.hexlify(syncRequest.channelId)
-            ) {
-                this.service.logger.warn(
-                    "onSpectateResponse - response channelId does not match the pending request; aborting",
-                    {
-                        peerAddress,
-                        requestedChannelId: syncRequest.channelId,
-                        responseChannelId: channelId
-                    }
-                );
-                return this.service.abort(peerAddress);
-            }
-
-            const localTime = Clock.getTimeInSeconds();
-            const rtt = localTime - syncRequest.initTime;
-
-            this.service.logger.debug(
-                `onSpectateResponse - RTT: ${rtt}s, initTime: ${syncRequest.initTime}, responseTime: ${localTime}`
-            );
-
-            // If RTT is too high, disconnect from all peers
-            if (rtt > this.p2pManager.stateManager.timeConfig.agreementTime) {
-                // in general this check is not needed since we're measuring response time on request submission
-                this.service.logger.debug(
-                    `onSpectateResponse - RTT too high (${rtt}s), disconnecting from all peers`
-                );
-                return;
-            }
-
-            // What we ultimately want to do here is:
-            // 1) Sync/Fetch all the relevant EVM storage data from the chain and persist it in our localEVM
-            // 2) Run/reuse the 'updateStateSnapshotFork' & 'updateStateSnapshotSameFork' as a function of:
-            //      2.1) The fetched/synced EVM on-chain state which we know is true
-            //      2.2) The provided SyncPayload which will be verified against the fetched data
-            // 3) While reusing 'updateStateSnapshotFork' & 'updateStateSnapshotSameFork' perform the call as `eth_call` would work on an RPC node
-            // This essentially simulates a 'tx' (allows 'store' and other state mutating opcodes and creates logs), but does NOT persist the changes (so we keep our EVM state consistent to the one on-chain)
-            // This verifies/proves to us that the payload is correct and that the state can really be 'teleported' to what the other peer is claiming to be the latest state and that the data provided to us is correct
-            // 4) Deconstruct the SyncPayload and persist its component normally in our local 'storage'
-            // This allows us to manually update the snapshot later at will AT LEAST to the state that we were synced (that's why we're reusing the solidity function, so we know that the TX will succeed)
-            //
-            // Up to this point we've verified the last finalized state given to us
-            // What do we do next?
-            // queue all the un-finalized stateProof blocks
-            // (other blocks that we're incoming would also be queued while we sync)
-            // set some syncFlag to true that will start executing the onBlockConfirmation pipeline with `SpectateStrategy`
-
-            // So what we'll actually do here until the above stuff is implemented:
-            // 1) Fetch the onChainSnapshot and persist/update the local EVM with it
-            // 2) Fetch all disputeWindows that where provided in the SyncPayload:
-            //      2.1) persist/update the localEVM with them
-            //      2.2) verify that they're expired - if they're not expired abort
-            //      2.3) reduce them if they're not already reduced (do this locally + package calldata for a single multicall later to the RPC node) - this may be a divergence from the on-chain state, but the on-chain one will have to reduce to the same one if expired - think of it as a CRDT where this time we're leading/ahead locally and the chain will eventualy reflect the same state
-            //      Later this will be `eth_call`(multicall(reduceAll,updateStateSnapshotFork,updateStateSnapshotSameFork)) a single atomic transaction that doesn't persist the state locally, so we don't have edge cases when we 'do' persit and when we 'do not'
-            //      2.4) ** If more than 1  has to be reduced -> abort **
-            //      2.5) verify that they reduce to the correct forks as given in the SyncPayload -> abort otherwise
-            //      2.6) verify final genesisSnapshot is correct -> abort otherwise
-            //      2.7) verify outboundMessageBlocks from onChainSnapshot to final genesisSnapshot | TODO - think do we need to verify joinChannelBlocks
-            //      2.8) verify that genesisSnapshot.forkId is not disputed on-chain -> abort otherwise
-            //      2.9) verify stateProof proves latest state -> abort otherwise
-            //      2.10) verify outboundMessageBlocks from final genesisSnapshot to latestFinalizedSnapshot
-            //      2.11) verify balance invariant of the latestFinalizedState -> abort otherwise
-            // 3) Finally - On the RPC node as a staticcall `eth_call`(multicall(reduceAll,updateStateSnapshotFork,updateStateSnapshotSameFork)) to deduct failure/success -> on failure abort
-            // 4) Deconstruct the SyncPayload and persist its component normally in our local 'storage'
-            // This allows us to manually update the snapshot later at will AT LEAST to the state that we were synced (that's why we're reusing the solidity function, so we know that the TX will succeed)
-            //
-            // 5) set some syncFlag to true that will start executing the onBlockConfirmation pipeline with `SpectateStrategy` from un-finalized blocks
-
-            // ******* TODO - updateStateSnapshotFork/updateStateSnapshotSameFork need dummy contracts to process withdrawals
-            const stateManager = this.p2pManager.stateManager;
-            const diamondStateMachine = stateManager.diamondStateMachine;
-
-            // 1) Fetch the onChainSnapshot and persist/update the local EVM with it
-            const onChainSnapshot =
-                await this.service.fetchAndPersistOnChainSnapshot(channelId);
-            let finalForkId = onChainSnapshot.forkID;
-
-            // 2) & 2.1) Fetch all disputeWindows that where provided in the SyncPayload:
-            const forkIds = syncPayload.disputeWindows.map(
-                (disputeWindow) => disputeWindow.forkId
-            );
-            await this.service.fetchAndPersistOnChainDisputeWindows(
-                channelId,
-                forkIds
-            );
-
-            let notReducedCount = 0;
-            const disputeWindowsThatNeedToBeReducedOnChain: DisputeWindowVerification[] =
-                [];
-            for (const dw of syncPayload.disputeWindows) {
-                // 2.2) verify that they're expired - if they're not expired abort
-                const { isExpired } =
-                    await diamondStateMachine.localDiamondContract.isKillPeriodExpired(
-                        channelId,
-                        dw.forkId
-                    );
-                if (!isExpired) return this.service.abort(peerAddress);
-
-                // 2.3) reduce them if they're not already reduced
-                const isReducedAndFinal =
-                    await diamondStateMachine.localDiamondContract.isReduceChallengePeriodExpired(
-                        channelId,
-                        dw.forkId
-                    );
-                if (!isReducedAndFinal) {
-                    disputeWindowsThatNeedToBeReducedOnChain.push(dw);
-                    await diamondStateMachine.localDiamondContract.reduceAndFinalize(
-                        dw.disputeConfirmations.map((disputeConfirmation) =>
-                            Codec.decode(
-                                disputeConfirmation.signedDispute
-                                    .encodedDispute,
-                                Type.Dispute
-                            )
-                        ),
-                        dw.latestStateSnapshot,
-                        dw.latestEncodedStateMachineState,
-                        dw.inboundMessageBlocksAppliedInReduce,
-                        dw.reducedForkId
-                    );
-                    // 2.4) ** If more than 1  has to be reduced -> abort **
-                    if (++notReducedCount > 1)
-                        return this.service.abort(peerAddress);
-                }
-
-                // 2.5) verify that they reduce to the correct forks as given in the SyncPayload
-                const _dw = (
-                    await diamondStateMachine.localDiamondContract.getDisputeWindows(
-                        channelId,
-                        [dw.forkId]
-                    )
-                )[0];
-                if (_dw.reducedResult.forkId != dw.reducedForkId)
-                    return this.service.abort(peerAddress);
-                // if the above call fails -> local evm will throw -> catch and abort
-                finalForkId = dw.reducedForkId;
-            }
-
-            // 2.6) verify final genesisSnapshot is correct -> abort otherwise
-            // Three checks: forkId resolves to this snapshot, forkId == keccak256(snapshotData)
-            // and encoded state matches the declared hash.
-            const finalForkIdMatchesGenesisForkId =
-                finalForkId === syncPayload.latestForkGenesisSnapshot.forkId;
-            const isGenesisValid =
-                await diamondStateMachine.localDiamondContract.isGenesisSnapshotWithoutTimeCheck(
-                    syncPayload.latestForkGenesisSnapshot
-                );
-            const stateHashMatch =
-                syncPayload.latestForkGenesisSnapshot.snapshotData
-                    .stateMachineStateHash ===
-                hash(syncPayload.latestForkGenesisEncodedState);
-            const isCorrectGenesis =
-                finalForkIdMatchesGenesisForkId &&
-                isGenesisValid &&
-                stateHashMatch;
-
-            if (!isCorrectGenesis) return this.service.abort(peerAddress);
-
-            // optimization: if the on-chain snapshot is on the same fork but more advanced than what
-            // peers proved, reject before running any contract verification.
-            const latestFinalizedSnapshot =
-                syncPayload.milestoneSnapshots.length > 0
-                    ? syncPayload.milestoneSnapshots.at(-1)!
-                    : syncPayload.latestForkGenesisSnapshot;
-            if (
-                onChainSnapshot.forkID ===
-                    syncPayload.latestForkGenesisSnapshot.forkId &&
-                onChainSnapshot.blockHeight >
-                    Number(latestFinalizedSnapshot.blockHeight)
-            ) {
-                this.service.logger.debug(
-                    `onSpectateResponse - on-chain block height (${onChainSnapshot.blockHeight}) exceeds proved height (${Number(latestFinalizedSnapshot.blockHeight)}); aborting`
-                );
-                return this.service.abort(peerAddress);
-            }
-
-            // 2.7) verify outboundMessageBlocks from onChainSnapshot (lower/older) to final genesisSnapshot (upper/newer)
-            const genesisSnapshot = StateSnapshot.from(
-                syncPayload.latestForkGenesisSnapshot
-            );
-            const { lowerOutboundSnapshot, upperOutboundSnapshot } =
-                SpectateService.orderOutboundSnapshots(
-                    onChainSnapshot,
-                    genesisSnapshot
-                );
-
-            let areValidExitBlocks =
-                await diamondStateMachine.localDiamondContract.verifyOutboundMessageBlocks(
-                    syncPayload.outboundMessageBlocksUpToLatestGenesis,
-                    lowerOutboundSnapshot.toStruct().snapshotData,
-                    upperOutboundSnapshot.toStruct().snapshotData
-                );
-
-            if (!areValidExitBlocks) return this.service.abort(peerAddress);
-
-            // 2.8) Depending are we syncing to the 'latest state' (spectating) or some requested state (forkId,blockHeight), verify that:
-            // 2.8.1) (spectating) genesisSnapshot.forkId is not disputed on-chain -> abort otherwise
-            // 2.8.2) (requested) genesisSnapshot.forkId == syncRequest.forkId -> abort otherwise
-            if (!syncRequest.forkId) {
-                // 2.8.1) (spectating)
-                const _timestamp =
-                    await stateManager.stateChannelManagerContract.getDisputeWindowCreationTimestamp(
-                        channelId,
-                        finalForkId
-                    );
-                if (Number(_timestamp) != 0)
-                    return this.service.abort(peerAddress);
-            } else {
-                // 2.8.2) (requested)
-                if (finalForkId != syncRequest.forkId)
-                    return this.service.abort(peerAddress);
-            }
-
-            // 2.9) verify stateProof proves latest state -> abort otherwise
-            const isValid =
-                await diamondStateMachine.localDiamondContract.verifyMilestones.staticCall(
-                    syncPayload.latestForkGenesisSnapshot.forkId,
-                    syncPayload.stateProof.milestones,
-                    syncPayload.milestoneSnapshots,
-                    syncPayload.latestForkGenesisSnapshot
-                );
-            if (!isValid) return this.service.abort(peerAddress);
-
-            if (
-                latestFinalizedSnapshot.snapshotData.stateMachineStateHash !=
-                hash(syncPayload.latestFinalizedEncodedState)
-            )
-                return this.service.abort(peerAddress);
-
-            // 2.10) verify outboundMessageBlocks from final genesisSnapshot to latestFinalizedSnapshot
-            areValidExitBlocks =
-                await diamondStateMachine.localDiamondContract.verifyOutboundMessageBlocks(
-                    syncPayload.outboundMessageBlocksOfTheLatestFork,
-                    syncPayload.latestForkGenesisSnapshot.snapshotData,
-                    latestFinalizedSnapshot.snapshotData
-                );
-            if (!areValidExitBlocks) return this.service.abort(peerAddress);
-
-            // 2.11) verify balance invariant of the latestFinalizedState -> abort otherwise
-            const isValidBalance =
-                await stateManager.stateChannelManagerContract.verifyBalanceInvariantCheckSnapshot.staticCall(
-                    channelId,
-                    latestFinalizedSnapshot.snapshotData,
-                    syncPayload.latestFinalizedEncodedState
-                );
-            if (!isValidBalance) return this.service.abort(peerAddress);
-
-            // 3) Finally - On the RPC node as a staticcall `eth_call`(multicall(reduceAll,updateStateSnapshotFork,updateStateSnapshotSameFork)) to deduct failure/success -> on failure abort
-            const isMulticallSuccess =
-                await this.service.tryMulticallSnapshotUpdate(
-                    channelId,
-                    onChainSnapshot.toStruct(),
-                    syncPayload,
-                    disputeWindowsThatNeedToBeReducedOnChain
-                );
-            if (!isMulticallSuccess) return this.service.abort(peerAddress);
-
-            // 4) Deconstruct the SyncPayload and persist its component normally in our local 'storage'
-            const { shouldAbort } =
-                await this.service.persistSyncPayload(syncPayload);
-            if (shouldAbort) return this.service.abort(peerAddress);
-
-            // 5) Start executing the onBlockConfirmation pipeline with unfinalized blocks
-            const blockConfirmations =
-                await diamondStateMachine.localDiamondContract.getUnfinalizedBlockConfirmationsFromStateProof(
-                    syncPayload.stateProof
-                );
-            this.service.logger.debug(
-                `Spectate sync - next block height before pipeline ${stateManager.storage.blocks.getNextBlockHeight(finalForkId)}`
-            );
-            this.service.logger.debug(
-                `Spectate sync - BlockConfirmation pipeline for ${blockConfirmations.length} unfinalized block`,
-                blockConfirmations.map((bc) => {
-                    const _block = Block.fromBlockConfirmation(bc);
-                    return {
-                        blockHeight: _block.height,
-                        signerAddress: _block.author
-                    };
-                })
-            );
-            for (const bc of blockConfirmations) {
-                try {
-                    const isOk = await stateManager.onBlockConfirmation(bc);
-                    if (!isOk) return this.service.abort(peerAddress);
-                } catch (e) {
-                    this.service.logger.error(
-                        `Error processing block confirmation during spectate sync`,
-                        { error: e }
-                    );
-                    return this.service.abort(peerAddress);
-                }
-            }
-            this.service.logger.debug(
-                `Spectate sync - next block height after pipeline ${stateManager.storage.blocks.getNextBlockHeight(finalForkId)}`
-            );
-            // 6) If state requested (forkId,blockHeight) - check if blockHeight reached
-            if (syncRequest.blockHeight !== undefined) {
-                const [hasBlock, latestBlock] =
-                    await diamondStateMachine.localDiamondContract.getLatestBlockFromStateProof(
-                        syncPayload.stateProof
-                    );
-                if (!hasBlock) return this.service.abort(peerAddress);
-                if (
-                    Number(latestBlock.transaction.header.transactionCnt) !=
-                    syncRequest.blockHeight
-                )
-                    return this.service.abort(peerAddress);
-            }
-            this.service.logger.debug(
-                "Spectator successfully synced to latest proven state"
-            );
-        } catch (e) {
-            this.service.logger.warn(e);
-            return this.service.abort(peerAddress);
-        }
+        return {
+            encodedSyncPayload: Codec.encode(syncPayload, Type.SyncPayload)
+        };
     }
 }
 

--- a/src/rpc/services/spectate/SpectateService.ts
+++ b/src/rpc/services/spectate/SpectateService.ts
@@ -1,15 +1,27 @@
 import ARpcService from "@/rpc/ARpcService";
-import { Address, ChannelId, Timestamp, Hash, ForkId } from "@/types/types";
+import {
+    Address,
+    Bytes,
+    ChannelId,
+    Timestamp,
+    Hash,
+    ForkId
+} from "@/types/types";
 import { Block, StateSnapshot } from "@/models";
 import Clock from "@/Clock";
 import ATransport from "@/transport/ATransport";
-import { Codec, getChecksumAddress, tryDecodeCustomError, Type } from "@/utils";
+import {
+    Codec,
+    getChecksumAddress,
+    hash,
+    tryDecodeCustomError,
+    Type
+} from "@/utils";
 import { ethers } from "ethers";
 import { StateProofStruct } from "@typechain-types/contracts/V1/types/ProofTypes";
 import { StateSnapshotStruct } from "@typechain-types/contracts/V1/types/DataTypes";
 import SpectateServiceRpcMethods from "./SpectateRpcMethods";
 import type P2PManager from "@/P2PManager";
-import { TimeoutManager } from "@/utils/TimeoutManager";
 import { Status } from "@/types";
 import { HandshakeCompletedGuard } from "@/rpc/guards";
 import { DisputeWindowVerification, SyncPayload } from "@/types";
@@ -20,9 +32,11 @@ export interface SyncRequest {
     blockHeight?: number;
 }
 class SpectateService extends ARpcService<SpectateServiceRpcMethods> {
-    private readonly requestMapByPeerAddress: Map<string, SyncRequest> =
-        new Map();
-    timeoutManager: TimeoutManager;
+    // Peers with a sync request currently in flight. Guards against launching a
+    // second concurrent sync to the same peer. The request payload itself now
+    // lives in `sync`'s closure (request/response), so no per-peer request map
+    // is needed.
+    private readonly inFlightByPeerAddress: Set<string> = new Set();
 
     constructor(p2pManager: P2PManager) {
         super(
@@ -31,7 +45,6 @@ class SpectateService extends ARpcService<SpectateServiceRpcMethods> {
                 component: "SpectateService"
             })
         );
-        this.timeoutManager = p2pManager.stateManager.timeoutManager;
         this.guards = [new HandshakeCompletedGuard(this)];
     }
 
@@ -39,7 +52,8 @@ class SpectateService extends ARpcService<SpectateServiceRpcMethods> {
         return new SpectateServiceRpcMethods(transport, this);
     }
 
-    // Called locally to initiate spectate sync
+    // Called locally to initiate spectate sync. Fire-and-forget entry point: the
+    // request/response exchange and payload verification run in the background.
     public sync(
         peerAddress: Address,
         channelId: ChannelId,
@@ -54,7 +68,7 @@ class SpectateService extends ARpcService<SpectateServiceRpcMethods> {
         });
         const normalizedPeerAddress = getChecksumAddress(peerAddress);
 
-        if (this.requestMapByPeerAddress.has(normalizedPeerAddress)) {
+        if (this.inFlightByPeerAddress.has(normalizedPeerAddress)) {
             this.logger.debug(
                 "spectateSync - sync already in-flight; ignoring",
                 { peerAddress: normalizedPeerAddress }
@@ -68,46 +82,360 @@ class SpectateService extends ARpcService<SpectateServiceRpcMethods> {
             forkId,
             blockHeight
         };
+        this.inFlightByPeerAddress.add(normalizedPeerAddress);
+        const timeoutMs =
+            this.p2pManager.stateManager.timeConfig.agreementTime * 1000;
 
-        this.timeoutManager.scheduleTask(
-            () => {
-                const pending = this.requestMapByPeerAddress.get(
-                    normalizedPeerAddress
+        void (async () => {
+            try {
+                // Transport can change (e.g. WebRTC upgrade). Always send by
+                // address. A rejection (timeout / peer couldn't prove / guard)
+                // means the peer didn't help us sync -> blacklist it.
+                // `applySyncResponse` handles payload-validation failures itself
+                // (via abort), so the catch here is the request path plus a
+                // defensive backstop.
+                const { encodedSyncPayload } =
+                    await this.remoteRpc.spectateService
+                        .onSpectateRequest(syncRequest)
+                        .request(normalizedPeerAddress, { timeoutMs });
+
+                await this.applySyncResponse(
+                    normalizedPeerAddress,
+                    syncRequest,
+                    encodedSyncPayload
                 );
-                if (!pending) return;
-                if (pending.initTime !== syncRequest.initTime) return;
-
-                this.requestMapByPeerAddress.delete(normalizedPeerAddress);
-
-                this.logger.debug(
-                    "SpectateService - spectateSync timeout; blacklisting peer",
-                    { peerAddress: normalizedPeerAddress }
-                );
-
+            } catch (error) {
+                this.logger.debug("spectateSync - failed; blacklisting peer", {
+                    peerAddress: normalizedPeerAddress,
+                    error:
+                        error instanceof Error ? error.message : String(error)
+                });
                 this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(
                     normalizedPeerAddress
                 );
-            },
-            this.p2pManager.stateManager.timeConfig.agreementTime * 1000,
-            `SpectateService - spectateSync timeout - peer ${normalizedPeerAddress}`
-        );
-
-        this.requestMapByPeerAddress.set(normalizedPeerAddress, syncRequest);
-
-        // Transport can change (e.g. WebRTC upgrade). Always send by address.
-        this.remoteRpc.spectateService
-            .onSpectateRequest(syncRequest)
-            .sendOne(normalizedPeerAddress);
+            } finally {
+                this.inFlightByPeerAddress.delete(normalizedPeerAddress);
+            }
+        })();
     }
 
-    public takePendingRequestByPeerAddress(
-        peerAddress: string
-    ): SyncRequest | undefined {
-        const pending = this.requestMapByPeerAddress.get(peerAddress);
-        if (!pending) return undefined;
+    /**
+     * Validate and apply a sync payload returned by `onSpectateRequest`. Was the
+     * body of the old `onSpectateResponse` endpoint; the request now lives in
+     * `sync`'s closure, so the channel is taken from our own `syncRequest`
+     * (never the peer's echo) and the previous channel-binding check is moot.
+     * Any failure aborts the spectate sync.
+     */
+    public async applySyncResponse(
+        peerAddress: string,
+        syncRequest: SyncRequest,
+        encodedSyncPayload: Bytes
+    ): Promise<void> {
+        const channelId = syncRequest.channelId;
 
-        this.requestMapByPeerAddress.delete(peerAddress);
-        return pending;
+        try {
+            // Decode inside the try: a malicious/broken peer can return bytes
+            // that aren't a valid Codec.encode(SyncPayload). A decode throw must
+            // be treated as a failed sync (abort/disconnect), not propagate as an
+            // unhandled rejection from the background sync task.
+            const syncPayload = Codec.decode(
+                encodedSyncPayload,
+                Type.SyncPayload
+            );
+            this.logger.debug(`Sync payload received`, { syncPayload });
+
+            const localTime = Clock.getTimeInSeconds();
+            const rtt = localTime - syncRequest.initTime;
+
+            this.logger.debug(
+                `applySyncResponse - RTT: ${rtt}s, initTime: ${syncRequest.initTime}, responseTime: ${localTime}`
+            );
+
+            // If RTT is too high, abort.
+            if (rtt > this.p2pManager.stateManager.timeConfig.agreementTime) {
+                this.logger.debug(
+                    `applySyncResponse - RTT too high (${rtt}s), aborting`
+                );
+                return this.abort(peerAddress);
+            }
+
+            // What we ultimately want to do here is:
+            // 1) Sync/Fetch all the relevant EVM storage data from the chain and persist it in our localEVM
+            // 2) Run/reuse the 'updateStateSnapshotFork' & 'updateStateSnapshotSameFork' as a function of:
+            //      2.1) The fetched/synced EVM on-chain state which we know is true
+            //      2.2) The provided SyncPayload which will be verified against the fetched data
+            // 3) While reusing 'updateStateSnapshotFork' & 'updateStateSnapshotSameFork' perform the call as `eth_call` would work on an RPC node
+            // This essentially simulates a 'tx' (allows 'store' and other state mutating opcodes and creates logs), but does NOT persist the changes (so we keep our EVM state consistent to the one on-chain)
+            // This verifies/proves to us that the payload is correct and that the state can really be 'teleported' to what the other peer is claiming to be the latest state and that the data provided to us is correct
+            // 4) Deconstruct the SyncPayload and persist its component normally in our local 'storage'
+            // This allows us to manually update the snapshot later at will AT LEAST to the state that we were synced (that's why we're reusing the solidity function, so we know that the TX will succeed)
+            //
+            // Up to this point we've verified the last finalized state given to us
+            // What do we do next?
+            // queue all the un-finalized stateProof blocks
+            // (other blocks that we're incoming would also be queued while we sync)
+            // set some syncFlag to true that will start executing the onBlockConfirmation pipeline with `SpectateStrategy`
+
+            // So what we'll actually do here until the above stuff is implemented:
+            // 1) Fetch the onChainSnapshot and persist/update the local EVM with it
+            // 2) Fetch all disputeWindows that where provided in the SyncPayload:
+            //      2.1) persist/update the localEVM with them
+            //      2.2) verify that they're expired - if they're not expired abort
+            //      2.3) reduce them if they're not already reduced (do this locally + package calldata for a single multicall later to the RPC node) - this may be a divergence from the on-chain state, but the on-chain one will have to reduce to the same one if expired - think of it as a CRDT where this time we're leading/ahead locally and the chain will eventualy reflect the same state
+            //      Later this will be `eth_call`(multicall(reduceAll,updateStateSnapshotFork,updateStateSnapshotSameFork)) a single atomic transaction that doesn't persist the state locally, so we don't have edge cases when we 'do' persit and when we 'do not'
+            //      2.4) ** If more than 1  has to be reduced -> abort **
+            //      2.5) verify that they reduce to the correct forks as given in the SyncPayload -> abort otherwise
+            //      2.6) verify final genesisSnapshot is correct -> abort otherwise
+            //      2.7) verify outboundMessageBlocks from onChainSnapshot to final genesisSnapshot | TODO - think do we need to verify joinChannelBlocks
+            //      2.8) verify that genesisSnapshot.forkId is not disputed on-chain -> abort otherwise
+            //      2.9) verify stateProof proves latest state -> abort otherwise
+            //      2.10) verify outboundMessageBlocks from final genesisSnapshot to latestFinalizedSnapshot
+            //      2.11) verify balance invariant of the latestFinalizedState -> abort otherwise
+            // 3) Finally - On the RPC node as a staticcall `eth_call`(multicall(reduceAll,updateStateSnapshotFork,updateStateSnapshotSameFork)) to deduct failure/success -> on failure abort
+            // 4) Deconstruct the SyncPayload and persist its component normally in our local 'storage'
+            // This allows us to manually update the snapshot later at will AT LEAST to the state that we were synced (that's why we're reusing the solidity function, so we know that the TX will succeed)
+            //
+            // 5) set some syncFlag to true that will start executing the onBlockConfirmation pipeline with `SpectateStrategy` from un-finalized blocks
+
+            // ******* TODO - updateStateSnapshotFork/updateStateSnapshotSameFork need dummy contracts to process withdrawals
+            const stateManager = this.p2pManager.stateManager;
+            const diamondStateMachine = stateManager.diamondStateMachine;
+
+            // 1) Fetch the onChainSnapshot and persist/update the local EVM with it
+            const onChainSnapshot =
+                await this.fetchAndPersistOnChainSnapshot(channelId);
+            let finalForkId = onChainSnapshot.forkID;
+
+            // 2) & 2.1) Fetch all disputeWindows that where provided in the SyncPayload:
+            const forkIds = syncPayload.disputeWindows.map(
+                (disputeWindow) => disputeWindow.forkId
+            );
+            await this.fetchAndPersistOnChainDisputeWindows(channelId, forkIds);
+
+            let notReducedCount = 0;
+            const disputeWindowsThatNeedToBeReducedOnChain: DisputeWindowVerification[] =
+                [];
+            for (const dw of syncPayload.disputeWindows) {
+                // 2.2) verify that they're expired - if they're not expired abort
+                const { isExpired } =
+                    await diamondStateMachine.localDiamondContract.isKillPeriodExpired(
+                        channelId,
+                        dw.forkId
+                    );
+                if (!isExpired) return this.abort(peerAddress);
+
+                // 2.3) reduce them if they're not already reduced
+                const isReducedAndFinal =
+                    await diamondStateMachine.localDiamondContract.isReduceChallengePeriodExpired(
+                        channelId,
+                        dw.forkId
+                    );
+                if (!isReducedAndFinal) {
+                    disputeWindowsThatNeedToBeReducedOnChain.push(dw);
+                    await diamondStateMachine.localDiamondContract.reduceAndFinalize(
+                        dw.disputeConfirmations.map((disputeConfirmation) =>
+                            Codec.decode(
+                                disputeConfirmation.signedDispute
+                                    .encodedDispute,
+                                Type.Dispute
+                            )
+                        ),
+                        dw.latestStateSnapshot,
+                        dw.latestEncodedStateMachineState,
+                        dw.inboundMessageBlocksAppliedInReduce,
+                        dw.reducedForkId
+                    );
+                    // 2.4) ** If more than 1  has to be reduced -> abort **
+                    if (++notReducedCount > 1) return this.abort(peerAddress);
+                }
+
+                // 2.5) verify that they reduce to the correct forks as given in the SyncPayload
+                const _dw = (
+                    await diamondStateMachine.localDiamondContract.getDisputeWindows(
+                        channelId,
+                        [dw.forkId]
+                    )
+                )[0];
+                if (_dw.reducedResult.forkId != dw.reducedForkId)
+                    return this.abort(peerAddress);
+                // if the above call fails -> local evm will throw -> catch and abort
+                finalForkId = dw.reducedForkId;
+            }
+
+            // 2.6) verify final genesisSnapshot is correct -> abort otherwise
+            // Three checks: forkId resolves to this snapshot, forkId == keccak256(snapshotData)
+            // and encoded state matches the declared hash.
+            const finalForkIdMatchesGenesisForkId =
+                finalForkId === syncPayload.latestForkGenesisSnapshot.forkId;
+            const isGenesisValid =
+                await diamondStateMachine.localDiamondContract.isGenesisSnapshotWithoutTimeCheck(
+                    syncPayload.latestForkGenesisSnapshot
+                );
+            const stateHashMatch =
+                syncPayload.latestForkGenesisSnapshot.snapshotData
+                    .stateMachineStateHash ===
+                hash(syncPayload.latestForkGenesisEncodedState);
+            const isCorrectGenesis =
+                finalForkIdMatchesGenesisForkId &&
+                isGenesisValid &&
+                stateHashMatch;
+
+            if (!isCorrectGenesis) return this.abort(peerAddress);
+
+            // optimization: if the on-chain snapshot is on the same fork but more advanced than what
+            // peers proved, reject before running any contract verification.
+            const latestFinalizedSnapshot =
+                syncPayload.milestoneSnapshots.length > 0
+                    ? syncPayload.milestoneSnapshots.at(-1)!
+                    : syncPayload.latestForkGenesisSnapshot;
+            if (
+                onChainSnapshot.forkID ===
+                    syncPayload.latestForkGenesisSnapshot.forkId &&
+                onChainSnapshot.blockHeight >
+                    Number(latestFinalizedSnapshot.blockHeight)
+            ) {
+                this.logger.debug(
+                    `applySyncResponse - on-chain block height (${onChainSnapshot.blockHeight}) exceeds proved height (${Number(latestFinalizedSnapshot.blockHeight)}); aborting`
+                );
+                return this.abort(peerAddress);
+            }
+
+            // 2.7) verify outboundMessageBlocks from onChainSnapshot (lower/older) to final genesisSnapshot (upper/newer)
+            const genesisSnapshot = StateSnapshot.from(
+                syncPayload.latestForkGenesisSnapshot
+            );
+            const { lowerOutboundSnapshot, upperOutboundSnapshot } =
+                SpectateService.orderOutboundSnapshots(
+                    onChainSnapshot,
+                    genesisSnapshot
+                );
+
+            let areValidExitBlocks =
+                await diamondStateMachine.localDiamondContract.verifyOutboundMessageBlocks(
+                    syncPayload.outboundMessageBlocksUpToLatestGenesis,
+                    lowerOutboundSnapshot.toStruct().snapshotData,
+                    upperOutboundSnapshot.toStruct().snapshotData
+                );
+
+            if (!areValidExitBlocks) return this.abort(peerAddress);
+
+            // 2.8) Depending are we syncing to the 'latest state' (spectating) or some requested state (forkId,blockHeight), verify that:
+            // 2.8.1) (spectating) genesisSnapshot.forkId is not disputed on-chain -> abort otherwise
+            // 2.8.2) (requested) genesisSnapshot.forkId == syncRequest.forkId -> abort otherwise
+            if (!syncRequest.forkId) {
+                // 2.8.1) (spectating)
+                const _timestamp =
+                    await stateManager.stateChannelManagerContract.getDisputeWindowCreationTimestamp(
+                        channelId,
+                        finalForkId
+                    );
+                if (Number(_timestamp) != 0) return this.abort(peerAddress);
+            } else {
+                // 2.8.2) (requested)
+                if (finalForkId != syncRequest.forkId)
+                    return this.abort(peerAddress);
+            }
+
+            // 2.9) verify stateProof proves latest state -> abort otherwise
+            const isValid =
+                await diamondStateMachine.localDiamondContract.verifyMilestones.staticCall(
+                    syncPayload.latestForkGenesisSnapshot.forkId,
+                    syncPayload.stateProof.milestones,
+                    syncPayload.milestoneSnapshots,
+                    syncPayload.latestForkGenesisSnapshot
+                );
+            if (!isValid) return this.abort(peerAddress);
+
+            if (
+                latestFinalizedSnapshot.snapshotData.stateMachineStateHash !=
+                hash(syncPayload.latestFinalizedEncodedState)
+            )
+                return this.abort(peerAddress);
+
+            // 2.10) verify outboundMessageBlocks from final genesisSnapshot to latestFinalizedSnapshot
+            areValidExitBlocks =
+                await diamondStateMachine.localDiamondContract.verifyOutboundMessageBlocks(
+                    syncPayload.outboundMessageBlocksOfTheLatestFork,
+                    syncPayload.latestForkGenesisSnapshot.snapshotData,
+                    latestFinalizedSnapshot.snapshotData
+                );
+            if (!areValidExitBlocks) return this.abort(peerAddress);
+
+            // 2.11) verify balance invariant of the latestFinalizedState -> abort otherwise
+            const isValidBalance =
+                await stateManager.stateChannelManagerContract.verifyBalanceInvariantCheckSnapshot.staticCall(
+                    channelId,
+                    latestFinalizedSnapshot.snapshotData,
+                    syncPayload.latestFinalizedEncodedState
+                );
+            if (!isValidBalance) return this.abort(peerAddress);
+
+            // 3) Finally - staticcall multicall to deduct failure/success -> on failure abort
+            const isMulticallSuccess = await this.tryMulticallSnapshotUpdate(
+                channelId,
+                onChainSnapshot.toStruct(),
+                syncPayload,
+                disputeWindowsThatNeedToBeReducedOnChain
+            );
+            if (!isMulticallSuccess) return this.abort(peerAddress);
+
+            // 4) Deconstruct the SyncPayload and persist its component normally in our local 'storage'
+            const { shouldAbort } = await this.persistSyncPayload(syncPayload);
+            if (shouldAbort) return this.abort(peerAddress);
+
+            // 5) Start executing the onBlockConfirmation pipeline with unfinalized blocks
+            const blockConfirmations =
+                await diamondStateMachine.localDiamondContract.getUnfinalizedBlockConfirmationsFromStateProof(
+                    syncPayload.stateProof
+                );
+            this.logger.debug(
+                `Spectate sync - next block height before pipeline ${stateManager.storage.blocks.getNextBlockHeight(finalForkId)}`
+            );
+            this.logger.debug(
+                `Spectate sync - BlockConfirmation pipeline for ${blockConfirmations.length} unfinalized block`,
+                blockConfirmations.map((bc) => {
+                    const _block = Block.fromBlockConfirmation(bc);
+                    return {
+                        blockHeight: _block.height,
+                        signerAddress: _block.author
+                    };
+                })
+            );
+            for (const bc of blockConfirmations) {
+                try {
+                    const isOk = await stateManager.onBlockConfirmation(bc);
+                    if (!isOk) return this.abort(peerAddress);
+                } catch (e) {
+                    this.logger.error(
+                        `Error processing block confirmation during spectate sync`,
+                        { error: e }
+                    );
+                    return this.abort(peerAddress);
+                }
+            }
+            this.logger.debug(
+                `Spectate sync - next block height after pipeline ${stateManager.storage.blocks.getNextBlockHeight(finalForkId)}`
+            );
+            // 6) If state requested (forkId,blockHeight) - check if blockHeight reached
+            if (syncRequest.blockHeight !== undefined) {
+                const [hasBlock, latestBlock] =
+                    await diamondStateMachine.localDiamondContract.getLatestBlockFromStateProof(
+                        syncPayload.stateProof
+                    );
+                if (!hasBlock) return this.abort(peerAddress);
+                if (
+                    Number(latestBlock.transaction.header.transactionCnt) !=
+                    syncRequest.blockHeight
+                )
+                    return this.abort(peerAddress);
+            }
+            this.logger.debug(
+                "Spectator successfully synced to latest proven state"
+            );
+        } catch (e) {
+            this.logger.warn(e);
+            return this.abort(peerAddress);
+        }
     }
 
     /**

--- a/test/e2e/E2E-InitHandshake.test.ts
+++ b/test/e2e/E2E-InitHandshake.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { TransportType } from "@/transport/TransportType";
-import { MathTestSession as TestSession, sleep } from "@test/harness";
+import { MathTestSession as TestSession } from "@test/harness";
 
 /**
  * E2E Tests for Handshake Initialization
@@ -126,24 +126,6 @@ describe("E2E: Init Handshake", function () {
 
         it("should disconnect peer that doesn't respond within agreementTime", async function () {
             const h = TestSession.getHarness();
-            await h.lifecycle.start(3, 0, {
-                autoConnect: false
-            });
-            await h.rpc.connectPeers([0, 1]);
-            await h.event.waitUntilEventOccurs("onConnection", 5000, [0, 1]);
-            await h.rpc.initiateHandshakeWithoutResponse({
-                fromPeer: 0,
-                toPeer: 1
-            });
-            await sleep(1500);
-            await h.assert.rpc.transportClosedOrGone({
-                fromPeer: 0,
-                toPeer: 1
-            });
-        });
-
-        it("should disconnect peer when handshake response RTT exceeds agreementTime", async function () {
-            const h = TestSession.getHarness();
             await h.lifecycle.start(3, 0, { autoConnect: false });
             await h.rpc.connectPeers([0, 1]);
             await h.event.waitUntilEventOccurs("onConnection", 5000, [0, 1]);
@@ -151,10 +133,11 @@ describe("E2E: Init Handshake", function () {
                 newPeerIndex: 2,
                 observingPeerIndex: 0
             });
-            await h.rpc.initiateHandshake({ fromPeer: 0, toPeer: 2 });
-            await h.rpc.sendSlowHandshakeResponse({
-                fromPeer: 2,
-                toPeer: 0,
+            // Peer 2 never answers the challenge in time -> peer 0's request
+            // times out and it disconnects peer 2.
+            await h.rpc.initiateHandshakeWithFaultyResponse({
+                initiatorPeer: 0,
+                responderPeer: 2,
                 delaySeconds: 100
             });
             await h.assert.rpc.peerDisconnectedFrom({
@@ -165,27 +148,27 @@ describe("E2E: Init Handshake", function () {
 
         it("should disconnect peer when handshake response time doesn't match init time", async function () {
             const h = TestSession.getHarness();
-            await h.lifecycle.start(2, 0, { autoConnect: true });
-            await h.event.waitUntilEventOccurs("onConnection", 5000);
-            await h.rpc.clearHandshakeChallenge({
-                peerIndex: 0,
-                targetPeer: 1
+            await h.lifecycle.start(3, 0, { autoConnect: false });
+            await h.rpc.connectPeers([0, 1]);
+            await h.event.waitUntilEventOccurs("onConnection", 5000, [0, 1]);
+            await h.rpc.newPeerJoins({
+                newPeerIndex: 2,
+                observingPeerIndex: 0
             });
-            await h.rpc.initiateHandshake({ fromPeer: 0, toPeer: 1 });
-            await h.rpc.sendSlowHandshakeResponse({
-                fromPeer: 1,
-                toPeer: 0,
-                delaySeconds: 10
+            // Peer 2 answers promptly but with a response timestamp far outside
+            // the agreement window -> peer 0 rejects and disconnects peer 2.
+            await h.rpc.initiateHandshakeWithFaultyResponse({
+                initiatorPeer: 0,
+                responderPeer: 2,
+                responseTimeOffsetSeconds: 1000
             });
             await h.assert.rpc.peerDisconnectedFrom({
                 peerIndex: 0,
-                expectedFinalCount: 0
+                expectedFinalCount: 1
             });
         });
-    });
 
-    describe("Unsolicited Messages", function () {
-        it("should disconnect peer sending unsolicited handshake response", async function () {
+        it("should disconnect peer answering with an undecodable (junk) signature", async function () {
             const h = TestSession.getHarness();
             await h.lifecycle.start(3, 0, { autoConnect: false });
             await h.rpc.connectPeers([0, 1]);
@@ -194,9 +177,13 @@ describe("E2E: Init Handshake", function () {
                 newPeerIndex: 2,
                 observingPeerIndex: 0
             });
-            await h.rpc.sendUnsolicitedHandshakeResponse({
-                fromPeer: 2,
-                toPeer: 0
+            // Peer 2 replies with junk bytes for the signature -> peer 0's
+            // signature verification throws and it disconnects peer 2 instead of
+            // crashing with an unhandled rejection.
+            await h.rpc.initiateHandshakeWithFaultyResponse({
+                initiatorPeer: 0,
+                responderPeer: 2,
+                corruptSignature: true
             });
             await h.assert.rpc.peerDisconnectedFrom({
                 peerIndex: 0,

--- a/test/e2e/E2E-InitHandshake.test.ts
+++ b/test/e2e/E2E-InitHandshake.test.ts
@@ -133,12 +133,13 @@ describe("E2E: Init Handshake", function () {
                 newPeerIndex: 2,
                 observingPeerIndex: 0
             });
-            // Peer 2 never answers the challenge in time -> peer 0's request
-            // times out and it disconnects peer 2.
+            // Peer 2 delays its reply well past the request window
+            // (agreementTime), so peer 0's `.request(...)` times out and it
+            // disconnects peer 2.
             await h.rpc.initiateHandshakeWithFaultyResponse({
                 initiatorPeer: 0,
                 responderPeer: 2,
-                delaySeconds: 100
+                delayMs: 100_000
             });
             await h.assert.rpc.peerDisconnectedFrom({
                 peerIndex: 0,
@@ -188,6 +189,24 @@ describe("E2E: Init Handshake", function () {
             await h.assert.rpc.peerDisconnectedFrom({
                 peerIndex: 0,
                 expectedFinalCount: 1
+            });
+        });
+    });
+
+    describe("Duplicate ack", function () {
+        it("should disconnect + blacklist a peer that sends a duplicate handshake ack", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(2, 0, { autoConnect: true });
+            await h.event.waitUntilEventOccurs("onConnection", 5000);
+            await h.assert.rpc.handshakeCompleted({ peer1: 0, peer2: 1 });
+
+            // The handshake already exchanged acks; a second ack from peer 0
+            // over the already-acked transport is a protocol violation, so
+            // peer 1 must disconnect + blacklist peer 0.
+            await h.rpc.sendDuplicateHandshakeAck({ fromPeer: 0, toPeer: 1 });
+            await h.assert.rpc.peerDisconnectedFrom({
+                peerIndex: 1,
+                expectedFinalCount: 0
             });
         });
     });

--- a/test/e2e/E2E-IsForkDisputed.test.ts
+++ b/test/e2e/E2E-IsForkDisputed.test.ts
@@ -45,25 +45,23 @@ describe("E2E: Is Fork Disputed", function () {
             });
         });
 
-        it("should disconnect peer sending duplicate acknowledgment responses", async function () {
+        it("should disconnect peer sending duplicate acknowledgment requests", async function () {
             const h = TestSession.getHarness();
             await h.scenario.activeChannelWithDispute({
                 numPeers: 3,
                 numBlocks: 2,
                 byzantinePeer: 1
             });
-            await h.rpc.sendDuplicateAcknowledgmentResponse({
+            // Peer 0 receives a dispute-ack request from peer 2 for the
+            // genuinely disputed fork and acknowledges it.
+            await h.rpc.sendDisputeAckRequest({ fromPeer: 2, toPeer: 0 });
+            await h.assert.rpc.firstAcknowledgmentRecorded({
                 respondingPeer: 0,
                 requestingPeer: 2
             });
-            h.assert.rpc.firstAcknowledgmentRecorded({
-                respondingPeer: 0,
-                requestingPeer: 2
-            });
-            await h.rpc.sendDuplicateAcknowledgmentResponse({
-                respondingPeer: 0,
-                requestingPeer: 2
-            });
+            // A second request for the same already-acknowledged fork is a
+            // protocol violation -> peer 0 disconnects the requester.
+            await h.rpc.sendDisputeAckRequest({ fromPeer: 2, toPeer: 0 });
             await h.assert.rpc.peerDisconnectedFrom({
                 peerIndex: 0,
                 expectedFinalCount: 0

--- a/test/e2e/E2E-Spectate.test.ts
+++ b/test/e2e/E2E-Spectate.test.ts
@@ -68,12 +68,16 @@ describe("E2E: Spectate Service", function () {
                     sm.p2pManager.localRpc.stub.capturedInitHandshakeTransport;
                 if (!transport)
                     throw new Error("no captured handshake transport");
-                sm.p2pManager.remoteRpc.spectateService
+                // Fire it as a request over the pre-handshake transport. The
+                // guard rejects it before dispatch (recording the block); the
+                // rejected promise is expected, so swallow it.
+                void sm.p2pManager.remoteRpc.spectateService
                     .onSpectateRequest({
                         channelId: sm.channelId,
                         initTime: Date.now()
                     })
-                    .sendOne(transport);
+                    .request(transport)
+                    .catch(() => {});
             });
 
             // Peer 1's guard should have blocked it (handshake never completed).
@@ -97,126 +101,11 @@ describe("E2E: Spectate Service", function () {
         });
     });
 
-    describe("Channel Binding", function () {
-        it("aborts before any chain read when a peer answers with a mismatched channelId", async function () {
-            const h = TestSession.getHarness();
-            await h.lifecycle.start(2, 0);
-            await h.transition.advanceState({ count: 1 });
-            await h.assert.sync.peersInSyncWait({ peerIndices: [0, 1] });
-
-            const realChannelId = h.channelId!;
-            const forkId = h.activeForkId!;
-            const wrongChannelId = ethers.keccak256(
-                ethers.toUtf8Bytes("spectate-wrong-channel")
-            );
-            expect(wrongChannelId).to.not.equal(String(realChannelId));
-
-            const peer1Address = h.getPeer(1).address;
-
-            // A valid, decodable payload for the REAL channel, so the decode at
-            // the top of onSpectateResponse succeeds and the channel-binding
-            // guard — not a decode error — is what aborts.
-            const blockInfo = await h
-                .control(h.getPeer(1))
-                .query.getLatestBlockInfo(forkId)
-                .request();
-            expect(blockInfo).to.not.be.null;
-            const blockHeight = Number(
-                Codec.decode(blockInfo!.encodedBlock, Type.Block).transaction
-                    .header.transactionCnt
-            );
-            const encodedSyncPayload = await h
-                .control(h.getPeer(1))
-                .spectate.generateSyncPayload(
-                    realChannelId,
-                    forkId,
-                    blockHeight
-                )
-                .request();
-            expect(encodedSyncPayload).to.not.be.null;
-
-            // Drive onSpectateResponse host-side: a pending request for the REAL
-            // channel, but the response claims a DIFFERENT channel.
-            const result = await h.execOnHost(
-                h.getPeer(0),
-                async (sm, args) => {
-                    const spectateService =
-                        sm.p2pManager.localRpc.spectateService;
-                    const profile =
-                        sm.p2pManager.profileManager.getProfileByEvmAddress(
-                            args.peer1Address
-                        );
-                    const transport = profile?.transport;
-                    if (!transport?.peerAddress) {
-                        throw new Error("no handshaked transport to peer 1");
-                    }
-                    const internal = spectateService as unknown as {
-                        requestMapByPeerAddress: Map<
-                            string,
-                            { channelId: unknown; initTime: number }
-                        >;
-                        fetchAndPersistOnChainSnapshot: (
-                            channelId: unknown
-                        ) => Promise<unknown>;
-                    };
-
-                    internal.requestMapByPeerAddress.set(
-                        transport.peerAddress,
-                        {
-                            channelId: args.realChannelId,
-                            initTime: Math.floor(Date.now() / 1000)
-                        }
-                    );
-
-                    // Trip a flag if execution ever reaches the first on-chain read.
-                    let fetchCalled = false;
-                    const originalFetch =
-                        internal.fetchAndPersistOnChainSnapshot.bind(
-                            spectateService
-                        );
-                    internal.fetchAndPersistOnChainSnapshot = async (
-                        cid: unknown
-                    ) => {
-                        fetchCalled = true;
-                        return originalFetch(cid);
-                    };
-
-                    try {
-                        await spectateService
-                            .createRPCMethods(transport)
-                            .onSpectateResponse(
-                                args.wrongChannelId,
-                                args.encodedSyncPayload
-                            );
-                    } finally {
-                        internal.fetchAndPersistOnChainSnapshot = originalFetch;
-                    }
-
-                    return {
-                        fetchCalled,
-                        stillPending: internal.requestMapByPeerAddress.has(
-                            transport.peerAddress
-                        )
-                    };
-                },
-                {
-                    peer1Address,
-                    realChannelId,
-                    wrongChannelId,
-                    encodedSyncPayload: encodedSyncPayload!
-                }
-            );
-
-            expect(
-                result.fetchCalled,
-                "mismatched channelId must abort before any on-chain read"
-            ).to.equal(false);
-            expect(
-                result.stillPending,
-                "pending request should be consumed by the rejected response"
-            ).to.equal(false);
-        });
-    });
+    // NOTE: the former "Channel Binding" test is obsolete. With request/response
+    // the spectator uses its own `syncRequest.channelId` to verify the payload
+    // and never trusts a channelId echoed by the responder, so a mismatched-
+    // channel response is structurally impossible — there is no separate
+    // `onSpectateResponse` endpoint to feed a forged channelId into.
 
     describe("Same Fork Spectating", function () {
         it("should spectate successfully when on-chain snapshot is already on the same fork", async function () {

--- a/test/e2e/E2E-Spectate.test.ts
+++ b/test/e2e/E2E-Spectate.test.ts
@@ -976,4 +976,49 @@ describe("E2E: Spectate Service", function () {
             });
         });
     });
+
+    describe("Concurrent sync dedup", function () {
+        it("collapses two concurrent sync() calls for the same peer into a single on-the-wire request", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(2, 2);
+            await h.assert.sync.peersInSyncWait({ peerIndices: [0, 1] });
+
+            // Count spectate requests arriving at peer 1 (counter resets on
+            // install, so only the requests we trigger below are counted).
+            const restore = await h.rpcStub.stubCountSpectateRequests(1);
+
+            const peer1Address = h.getPeer(1).address;
+            // Fire two sync() calls for the same peer back-to-back on peer 0's
+            // host. `sync()` marks `inFlightByPeerAddress` synchronously before
+            // sending, so the second call must be dropped before it hits the wire.
+            await h.execOnHost(
+                h.getPeer(0),
+                (sm, args) => {
+                    const channelId = sm.channelId;
+                    sm.p2pManager.localRpc.spectateService.sync(
+                        args.peer1Address,
+                        channelId
+                    );
+                    sm.p2pManager.localRpc.spectateService.sync(
+                        args.peer1Address,
+                        channelId
+                    );
+                },
+                { peer1Address }
+            );
+
+            // Wait for the single request to land, then assert it stayed at one
+            // (the deduped second call never produced a second request).
+            await waitFor(
+                async () => (await h.rpcStub.getSpectateRequestCount(1)) >= 1,
+                5000
+            );
+            expect(await h.rpcStub.getSpectateRequestCount(1)).to.equal(
+                1,
+                "two concurrent sync() calls for the same peer must collapse to one on-the-wire request"
+            );
+
+            await restore();
+        });
+    });
 });

--- a/test/e2e/E2E-SpectateStaleProofGuard.test.ts
+++ b/test/e2e/E2E-SpectateStaleProofGuard.test.ts
@@ -49,7 +49,7 @@ describe("E2E: Spectate stale-proof guard", function () {
     it("aborts sync when a peer answers with undecodable junk bytes", async function () {
         const h = TestSession.getHarness();
 
-        await h.lifecycle.start(2, 0, {
+        await h.lifecycle.start(2, 2, {
             timeConfig: {
                 p2pTime: 5,
                 agreementTime: 2,
@@ -57,12 +57,6 @@ describe("E2E: Spectate stale-proof guard", function () {
                 evidenceTime: 10
             }
         });
-
-        await h.transition.advanceState({
-            count: 2,
-            waitForFinalization: true
-        });
-        await h.transition.postSnapshotWait();
 
         // Both participants reply to spectate requests with bytes that are NOT a
         // valid encoded SyncPayload, so the spectator's Codec.decode throws and

--- a/test/e2e/E2E-SpectateStaleProofGuard.test.ts
+++ b/test/e2e/E2E-SpectateStaleProofGuard.test.ts
@@ -45,4 +45,48 @@ describe("E2E: Spectate stale-proof guard", function () {
             await h.control(spectator).query.getOpenConnectionCount().request()
         ).to.equal(0, "Spectator should have 0 open connections after abort");
     });
+
+    it("aborts sync when a peer answers with undecodable junk bytes", async function () {
+        const h = TestSession.getHarness();
+
+        await h.lifecycle.start(2, 0, {
+            timeConfig: {
+                p2pTime: 5,
+                agreementTime: 2,
+                chainFallbackTime: 2,
+                evidenceTime: 10
+            }
+        });
+
+        await h.transition.advanceState({
+            count: 2,
+            waitForFinalization: true
+        });
+        await h.transition.postSnapshotWait();
+
+        // Both participants reply to spectate requests with bytes that are NOT a
+        // valid encoded SyncPayload, so the spectator's Codec.decode throws and
+        // it must abort every sync attempt instead of crashing/hanging.
+        await h.rpcStub.stubSpectateJunkPayload([0, 1]);
+
+        let threwTimeout = false;
+        try {
+            await h.join.addSpectatorWait({ statusTimeoutMs: 5000 });
+        } catch {
+            threwTimeout = true;
+        }
+
+        expect(threwTimeout).to.equal(
+            true,
+            "Spectator should not have reached SYNCED with junk payloads"
+        );
+
+        const spectator = h.getPeer(2);
+        expect(
+            await h.control(spectator).query.getOpenConnectionCount().request()
+        ).to.equal(
+            0,
+            "Spectator should have 0 open connections after aborting on junk"
+        );
+    });
 });

--- a/test/fixtures/customRpc/harnessControl/services/handshake/HandshakeRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/handshake/HandshakeRpcMethods.ts
@@ -2,13 +2,7 @@ import ARpcMethods from "@/rpc/ARpcMethods";
 import type ATransport from "@/transport/ATransport";
 import type { TransportType } from "@/transport/TransportType";
 import Block from "@/models/Block";
-import type {
-    Address,
-    ChannelId,
-    ForkId,
-    Hash,
-    Signature
-} from "@/types/types";
+import type { Address, ChannelId, ForkId, Hash } from "@/types/types";
 import { Codec, Type } from "@/utils";
 import type { HandshakeService } from "./HandshakeService";
 
@@ -40,26 +34,6 @@ export class HandshakeRpcMethods extends ARpcMethods {
         return true;
     }
 
-    public getChallenge(
-        otherAddress: Address
-    ): { randomChallengeHash: string; initTime: number } | null {
-        const challenge = this.service.initHandshake.getChallenge(
-            this.service.transportTo(otherAddress)
-        );
-        return challenge
-            ? {
-                  randomChallengeHash: challenge.randomChallengeHash,
-                  initTime: challenge.initTime
-              }
-            : null;
-    }
-
-    public clearChallenge(otherAddress: Address): boolean {
-        return this.service.initHandshake.mapTransportToChallenge.delete(
-            this.service.transportTo(otherAddress)
-        );
-    }
-
     public isHandshakeCompleted(otherAddress: Address): boolean {
         const profile =
             this.p2pManager.profileManager.getProfileByEvmAddress(otherAddress);
@@ -86,25 +60,17 @@ export class HandshakeRpcMethods extends ARpcMethods {
         challengeHash: Hash,
         time: number
     ): Promise<boolean> {
-        await this.service.initHandshake
-            .createRPCMethods(this.service.transportTo(fromAddress))
-            .onInitHandshakeRequest(challengeHash, time);
-        return true;
-    }
-
-    public async deliverHandshakeResponse(
-        fromAddress: Address,
-        signature: Signature,
-        responseTime: number,
-        preferredTransport: TransportType
-    ): Promise<boolean> {
-        await this.service.initHandshake
-            .createRPCMethods(this.service.transportTo(fromAddress))
-            .onInitHandshakeResponse(
-                signature,
-                responseTime,
-                preferredTransport
-            );
+        // `onInitHandshakeRequest` is now request/response and throws on
+        // malformed/out-of-window input (after disconnecting the requester).
+        // Swallow the rejection so the control call resolves; the side effect
+        // (disconnect) is what the test asserts.
+        try {
+            await this.service.initHandshake
+                .createRPCMethods(this.service.transportTo(fromAddress))
+                .onInitHandshakeRequest(challengeHash, time);
+        } catch {
+            // expected for invalid requests
+        }
         return true;
     }
 
@@ -120,27 +86,21 @@ export class HandshakeRpcMethods extends ARpcMethods {
         );
     }
 
-    public async respondToDisputeAcknowledgment(
-        requestingAddress: Address,
-        channelId: ChannelId,
-        forkId: ForkId
-    ): Promise<boolean> {
-        await this.service.isForkDisputed.respondToDisputeAcknowledgment(
-            String(requestingAddress),
-            channelId,
-            forkId
-        );
-        return true;
-    }
-
     public async deliverDisputeAckRequest(
         fromAddress: Address,
         channelId: ChannelId,
         forkId: ForkId
     ): Promise<boolean> {
-        await this.service.isForkDisputed
-            .createRPCMethods(this.service.transportTo(fromAddress))
-            .onDisputeAcknowledgmentRequest(channelId, forkId);
+        // `onDisputeAcknowledgmentRequest` is now request/response and throws on
+        // protocol violations (not-disputed / duplicate) after disconnecting the
+        // requester. Swallow the rejection; the disconnect is what tests assert.
+        try {
+            await this.service.isForkDisputed
+                .createRPCMethods(this.service.transportTo(fromAddress))
+                .onDisputeAcknowledgmentRequest(channelId, forkId);
+        } catch {
+            // expected for not-disputed / duplicate requests
+        }
         return true;
     }
 

--- a/test/fixtures/customRpc/harnessControl/services/handshake/HandshakeRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/handshake/HandshakeRpcMethods.ts
@@ -74,6 +74,21 @@ export class HandshakeRpcMethods extends ARpcMethods {
         return true;
     }
 
+    /**
+     * Deliver an init-handshake ack as if from `fromAddress`. Used to drive the
+     * duplicate-ack protocol-violation path: a second ack over an already-acked
+     * transport must disconnect + blacklist the sender.
+     */
+    public async deliverHandshakeAck(
+        fromAddress: Address,
+        challengeHash?: Hash
+    ): Promise<boolean> {
+        await this.service.initHandshake
+            .createRPCMethods(this.service.transportTo(fromAddress))
+            .onInitHandshakeAck(challengeHash);
+        return true;
+    }
+
     // ===== Dispute acknowledgment =====
 
     public requestDisputeAcknowledgment(

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -7,6 +7,8 @@ import type { Address } from "@/types/types";
 import type SpectateServiceRpcMethods from "@/rpc/services/spectate/SpectateRpcMethods";
 import type { SyncRequest } from "@/rpc/services/spectate/SpectateService";
 import type IsForkDisputedRpcMethods from "@/rpc/services/isForkDisputedService/IsForkDisputedRpcMethods";
+import InitHandshakeRpcMethods from "@/rpc/services/initHandshake/InitHandshakeRpcMethods";
+import type { Hash, Timestamp } from "@/types/types";
 import type { HarnessControlRpc } from "../../HarnessControlRpc";
 import type { StubService } from "./StubService";
 
@@ -252,17 +254,23 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
                 syncRequest: SyncRequest
             ) {
                 const peerAddress = this.senderTransport.peerAddress;
-                if (!peerAddress) return;
+                if (!peerAddress) {
+                    throw new Error("stubSpectateStaleProof - missing peer");
+                }
                 const syncPayload = await this.service.generateSyncPayload(
                     syncRequest.channelId,
                     syncRequest.forkId,
                     staleBlockHeight
                 );
-                if (!syncPayload) return;
-                const encoded = Codec.encode(syncPayload, Type.SyncPayload);
-                this.remoteRpc.spectateService
-                    .onSpectateResponse(syncRequest.channelId, encoded)
-                    .sendOne(peerAddress);
+                if (!syncPayload) {
+                    throw new Error("stubSpectateStaleProof - no payload");
+                }
+                return {
+                    encodedSyncPayload: Codec.encode(
+                        syncPayload,
+                        Type.SyncPayload
+                    )
+                };
             };
             return methods;
         };
@@ -278,6 +286,38 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
         service.createRPCMethods = original as typeof service.createRPCMethods;
         this.service.stubOriginals.delete("spectateCreateRpcMethods");
         return true;
+    }
+
+    /**
+     * Make `spectateService.onSpectateRequest` answer with bytes that are NOT a
+     * valid `Codec.encode(SyncPayload)`, so the spectator's decode throws and it
+     * must abort/disconnect (junk-payload handling).
+     */
+    public stubSpectateJunkPayload(): boolean {
+        const service = this.p2pManager.localRpc.spectateService;
+        if (!this.service.stubOriginals.has("spectateCreateRpcMethods")) {
+            this.service.stubOriginals.set(
+                "spectateCreateRpcMethods",
+                service.createRPCMethods.bind(service)
+            );
+        }
+        const original = this.service.stubOriginals.get(
+            "spectateCreateRpcMethods"
+        ) as typeof service.createRPCMethods;
+        service.createRPCMethods = (transport: ATransport) => {
+            const methods = original(transport);
+            methods.onSpectateRequest = async function (
+                this: SpectateServiceRpcMethods
+            ) {
+                return { encodedSyncPayload: "0xdeadbeef" };
+            };
+            return methods;
+        };
+        return true;
+    }
+
+    public restoreSpectateJunkPayload(): boolean {
+        return this.restoreSpectateStaleProof();
     }
 
     /**
@@ -301,8 +341,9 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
             const methods = original(transport);
             methods.onDisputeAcknowledgmentRequest = async function (
                 this: IsForkDisputedRpcMethods
-            ) {
+            ): Promise<boolean> {
                 stubService.disputeAckRequestCalled = true;
+                return false;
             };
             return methods;
         };
@@ -408,6 +449,76 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
             stubService.capturedInitHandshakeTransport = transport;
             return original.call(service, transport);
         };
+        return true;
+    }
+
+    /**
+     * Make this peer answer handshake challenges (`onInitHandshakeRequest`) with
+     * a faulty response so the *initiator* rejects it:
+     * - `responseTimeOffsetSeconds` skews the returned `responseTime` so the
+     *   initiator's response-timestamp check fails.
+     * - `delayMs` delays the reply so the initiator's request times out (no
+     *   response within the agreement window).
+     * - `corruptSignature` replaces the signature with junk so the initiator's
+     *   `ethers.verifyMessage` throws.
+     * The real handler still runs first (validates + signs), so only the reply
+     * is corrupted.
+     */
+    public stubHandshakeResponse(
+        delayMs: number,
+        responseTimeOffsetSeconds: number,
+        corruptSignature: boolean
+    ): boolean {
+        const service = this.p2pManager.localRpc.initHandshakeService;
+        if (!this.service.stubOriginals.has("initHandshakeCreateRpcMethods")) {
+            this.service.stubOriginals.set(
+                "initHandshakeCreateRpcMethods",
+                service.createRPCMethods.bind(service)
+            );
+        }
+        const original = this.service.stubOriginals.get(
+            "initHandshakeCreateRpcMethods"
+        ) as typeof service.createRPCMethods;
+        const realRequest =
+            InitHandshakeRpcMethods.prototype.onInitHandshakeRequest;
+        service.createRPCMethods = (transport: ATransport) => {
+            const methods = original(transport);
+            methods.onInitHandshakeRequest = async function (
+                this: InitHandshakeRpcMethods,
+                challengeHash: Hash,
+                time: Timestamp
+            ) {
+                const response = await realRequest.call(
+                    this,
+                    challengeHash,
+                    time
+                );
+                if (responseTimeOffsetSeconds) {
+                    response.responseTime += responseTimeOffsetSeconds;
+                }
+                if (corruptSignature) {
+                    response.signature = "0xdeadbeef";
+                }
+                if (delayMs > 0) {
+                    await new Promise((resolve) =>
+                        setTimeout(resolve, delayMs)
+                    );
+                }
+                return response;
+            };
+            return methods;
+        };
+        return true;
+    }
+
+    public restoreHandshakeResponse(): boolean {
+        const original = this.service.stubOriginals.get(
+            "initHandshakeCreateRpcMethods"
+        );
+        if (original === undefined) return false;
+        const service = this.p2pManager.localRpc.initHandshakeService;
+        service.createRPCMethods = original as typeof service.createRPCMethods;
+        this.service.stubOriginals.delete("initHandshakeCreateRpcMethods");
         return true;
     }
 }

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -1,7 +1,7 @@
 import ARpcMethods from "@/rpc/ARpcMethods";
 import type P2PManager from "@/P2PManager";
 import type ATransport from "@/transport/ATransport";
-import { Codec, Type } from "@/utils";
+import { Codec, sleep, Type } from "@/utils";
 import { HandshakeCompletedGuard } from "@/rpc/guards";
 import type { Address } from "@/types/types";
 import type SpectateServiceRpcMethods from "@/rpc/services/spectate/SpectateRpcMethods";
@@ -321,6 +321,45 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
     }
 
     /**
+     * Count incoming `onSpectateRequest` calls (still running the real handler),
+     * resetting the counter on install. Lets a test assert that two concurrent
+     * `sync()` calls for the same peer collapse to a single on-the-wire request.
+     */
+    public stubCountSpectateRequests(): boolean {
+        const service = this.p2pManager.localRpc.spectateService;
+        if (!this.service.stubOriginals.has("spectateCreateRpcMethods")) {
+            this.service.stubOriginals.set(
+                "spectateCreateRpcMethods",
+                service.createRPCMethods.bind(service)
+            );
+        }
+        this.service.spectateRequestCount = 0;
+        const original = this.service.stubOriginals.get(
+            "spectateCreateRpcMethods"
+        ) as typeof service.createRPCMethods;
+        const stubService = this.service;
+        service.createRPCMethods = (transport: ATransport) => {
+            const methods = original(transport);
+            const realOnSpectateRequest =
+                methods.onSpectateRequest.bind(methods);
+            methods.onSpectateRequest = (syncRequest: SyncRequest) => {
+                stubService.spectateRequestCount++;
+                return realOnSpectateRequest(syncRequest);
+            };
+            return methods;
+        };
+        return true;
+    }
+
+    public getSpectateRequestCount(): number {
+        return this.service.spectateRequestCount;
+    }
+
+    public restoreCountSpectateRequests(): boolean {
+        return this.restoreSpectateStaleProof();
+    }
+
+    /**
      * Replace `isForkDisputedService.onDisputeAcknowledgmentRequest` with a
      * no-op that records it was called (queried via `wasDisputeAckRequestCalled`).
      */
@@ -457,10 +496,11 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
      * a faulty response so the *initiator* rejects it:
      * - `responseTimeOffsetSeconds` skews the returned `responseTime` so the
      *   initiator's response-timestamp check fails.
-     * - `delayMs` delays the reply so the initiator's request times out (no
-     *   response within the agreement window).
-     * - `corruptSignature` replaces the signature with junk so the initiator's
-     *   `ethers.verifyMessage` throws.
+     * - `delayMs` delays the reply; only a delay that exceeds the initiator's
+     *   request window (agreementTime) makes its `.request(...)` time out — a
+     *   small delay just slows a still-successful response.
+     * - `corruptSignature` flips the signature's recovery byte so the
+     *   initiator's `ethers.verifyMessage` throws.
      * The real handler still runs first (validates + signs), so only the reply
      * is corrupted.
      */
@@ -497,12 +537,16 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
                     response.responseTime += responseTimeOffsetSeconds;
                 }
                 if (corruptSignature) {
-                    response.signature = "0xdeadbeef";
+                    // Keep the real 65-byte signature shape but flip its
+                    // recovery (v) byte to an invalid value, so
+                    // ethers.verifyMessage throws — closer to a real corrupted
+                    // signature than an obviously-fake short value. (The handler
+                    // signs to a hex string, so String() is identity here.)
+                    const sigHex = String(response.signature);
+                    response.signature = `${sigHex.slice(0, -2)}ff`;
                 }
                 if (delayMs > 0) {
-                    await new Promise((resolve) =>
-                        setTimeout(resolve, delayMs)
-                    );
+                    await sleep(delayMs);
                 }
                 return response;
             };

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -47,6 +47,8 @@ export class StubService extends ARpcService<
     capturedInitHandshakeTransport?: ATransport;
     /** Set by the record-spectate-abort stub when `abort` fires. */
     spectateAbortCalled = false;
+    /** Incremented by the count-spectate-requests stub per onSpectateRequest. */
+    spectateRequestCount = 0;
 
     constructor(p2pManager: P2PManager<HarnessControlRpc>) {
         super(

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -18,6 +18,7 @@ export type StubKey =
     | "unsafeSetLatestState"
     | "blockedInitHandshake"
     | "captureInitHandshake"
+    | "initHandshakeCreateRpcMethods"
     | "maybePostBlockOnChain"
     | "spectateAbort";
 

--- a/test/harness/actions/RPCActions.ts
+++ b/test/harness/actions/RPCActions.ts
@@ -205,6 +205,25 @@ export class RPCActions<
             .request();
     }
 
+    /**
+     * Deliver a second handshake ack from `fromPeer` to `toPeer` (whose
+     * handshake already completed and recorded the first ack). The duplicate
+     * is a protocol violation: `toPeer` must disconnect + blacklist `fromPeer`.
+     */
+    async sendDuplicateHandshakeAck(options: {
+        fromPeer: number;
+        toPeer: number;
+    }): Promise<void> {
+        const { fromPeer, toPeer } = options;
+        const fromAddress = this.harness.getPeer(fromPeer).address;
+        const toPeerObj = this.harness.getPeer(toPeer);
+
+        await this.harness
+            .control(toPeerObj)
+            .handshake.deliverHandshakeAck(fromAddress)
+            .request();
+    }
+
     async initiateHandshake(options: {
         fromPeer: number;
         toPeer: number;
@@ -221,27 +240,27 @@ export class RPCActions<
 
     /**
      * Make `responderPeer` reply to handshake challenges with a faulty response,
-     * then have `initiatorPeer` initiate a handshake to it. With `delaySeconds`
-     * the initiator's request times out; with `responseTimeOffsetSeconds` the
-     * response timestamp falls outside the agreement window. Either way the
-     * initiator is expected to disconnect the responder.
+     * then have `initiatorPeer` initiate a handshake to it. With `delayMs`
+     * beyond the request window the initiator's request times out; with
+     * `responseTimeOffsetSeconds` the response timestamp falls outside the
+     * agreement window; with `corruptSignature` verification throws. Either way
+     * the initiator is expected to disconnect the responder.
      */
     async initiateHandshakeWithFaultyResponse(options: {
         initiatorPeer: number;
         responderPeer: number;
-        delaySeconds?: number;
+        delayMs?: number;
         responseTimeOffsetSeconds?: number;
         corruptSignature?: boolean;
     }): Promise<void> {
         const {
             initiatorPeer,
             responderPeer,
-            delaySeconds,
+            delayMs,
             responseTimeOffsetSeconds,
             corruptSignature
         } = options;
 
-        const delayMs = delaySeconds === undefined ? 0 : delaySeconds * 1000;
         await this.harness.rpcStub.stubHandshakeResponse(responderPeer, {
             delayMs,
             responseTimeOffsetSeconds,

--- a/test/harness/actions/RPCActions.ts
+++ b/test/harness/actions/RPCActions.ts
@@ -1,9 +1,7 @@
 import { PeerTestHarness } from "@test/fixtures/PeerTestHarness";
 import type { HarnessControlRpc } from "@test/fixtures/customRpc/harnessControl/HarnessControlRpc";
-import type { TestPeer } from "@test/harness/core/types";
 import { Logger } from "@/utils";
 import { ForkId, Address } from "@/types/types";
-import InitHandshakeService from "@/rpc/services/initHandshake/InitHandshakeService";
 import { hash as fakeHash } from "@test/factory";
 import Clock from "@/Clock";
 
@@ -221,134 +219,65 @@ export class RPCActions<
             .request();
     }
 
-    async sendSlowHandshakeResponse(options: {
+    /**
+     * Make `responderPeer` reply to handshake challenges with a faulty response,
+     * then have `initiatorPeer` initiate a handshake to it. With `delaySeconds`
+     * the initiator's request times out; with `responseTimeOffsetSeconds` the
+     * response timestamp falls outside the agreement window. Either way the
+     * initiator is expected to disconnect the responder.
+     */
+    async initiateHandshakeWithFaultyResponse(options: {
+        initiatorPeer: number;
+        responderPeer: number;
+        delaySeconds?: number;
+        responseTimeOffsetSeconds?: number;
+        corruptSignature?: boolean;
+    }): Promise<void> {
+        const {
+            initiatorPeer,
+            responderPeer,
+            delaySeconds,
+            responseTimeOffsetSeconds,
+            corruptSignature
+        } = options;
+
+        const delayMs = delaySeconds === undefined ? 0 : delaySeconds * 1000;
+        await this.harness.rpcStub.stubHandshakeResponse(responderPeer, {
+            delayMs,
+            responseTimeOffsetSeconds,
+            corruptSignature
+        });
+
+        await this.initiateHandshake({
+            fromPeer: initiatorPeer,
+            toPeer: responderPeer
+        });
+    }
+
+    /**
+     * Deliver a dispute-ack request for the active (genuinely disputed) fork to
+     * `toPeer`, as if sent by `fromPeer`. Used to drive the duplicate-request
+     * protocol-violation path (a second request for an already-acknowledged fork
+     * must disconnect the requester).
+     */
+    async sendDisputeAckRequest(options: {
         fromPeer: number;
         toPeer: number;
-        delaySeconds: number;
-    }): Promise<void> {
-        const { fromPeer, toPeer, delaySeconds } = options;
-        const fromPeerObj = this.harness.getPeer(fromPeer);
-        const toPeerObj = this.harness.getPeer(toPeer);
-
-        const challenge = await this.harness
-            .control(toPeerObj)
-            .handshake.getChallenge(fromPeerObj.address)
-            .request();
-        if (!challenge) {
-            throw new Error("No challenge found - initiate handshake first");
-        }
-
-        const agreementTime = await this.harness
-            .control(toPeerObj)
-            .handshake.getAgreementTime()
-            .request();
-        const slowResponseTime =
-            challenge.initTime + agreementTime + delaySeconds;
-
-        await this.deliverResponse(
-            fromPeerObj,
-            toPeerObj,
-            challenge.randomChallengeHash,
-            slowResponseTime
-        );
-    }
-
-    async sendUnsolicitedHandshakeResponse(options: {
-        fromPeer: number;
-        toPeer: number;
-    }): Promise<void> {
-        const { fromPeer, toPeer } = options;
-        const fromPeerObj = this.harness.getPeer(fromPeer);
-        const toPeerObj = this.harness.getPeer(toPeer);
-
-        const challenge = await this.harness
-            .control(toPeerObj)
-            .handshake.getChallenge(fromPeerObj.address)
-            .request();
-        if (challenge) {
-            throw new Error(
-                "Challenge already exists - this wouldn't be unsolicited"
-            );
-        }
-
-        await this.deliverResponse(
-            fromPeerObj,
-            toPeerObj,
-            fakeHash(),
-            Clock.getTimeInSeconds()
-        );
-    }
-
-    async clearHandshakeChallenge(options: {
-        peerIndex: number;
-        targetPeer: number;
-    }): Promise<void> {
-        const { peerIndex, targetPeer } = options;
-        const peer = this.harness.getPeer(peerIndex);
-        const targetAddress = this.harness.getPeer(targetPeer).address;
-
-        await this.harness
-            .control(peer)
-            .handshake.clearChallenge(targetAddress)
-            .request();
-    }
-
-    async sendValidHandshakeResponse(options: {
-        fromPeer: number;
-        toPeer: number;
-    }): Promise<void> {
-        const { fromPeer, toPeer } = options;
-        const fromPeerObj = this.harness.getPeer(fromPeer);
-        const toPeerObj = this.harness.getPeer(toPeer);
-
-        const challenge = await this.harness
-            .control(toPeerObj)
-            .handshake.getChallenge(fromPeerObj.address)
-            .request();
-        if (!challenge) {
-            throw new Error("No challenge found - initiate handshake first");
-        }
-
-        await this.deliverResponse(
-            fromPeerObj,
-            toPeerObj,
-            challenge.randomChallengeHash,
-            Clock.getTimeInSeconds()
-        );
-    }
-
-    async initiateHandshakeWithoutResponse(options: {
-        fromPeer: number;
-        toPeer: number;
-    }): Promise<void> {
-        const { fromPeer, toPeer } = options;
-        const fromPeerObj = this.harness.getPeer(fromPeer);
-        const toAddress = this.harness.getPeer(toPeer).address;
-
-        await this.harness
-            .control(fromPeerObj)
-            .handshake.initiateHandshake(toAddress)
-            .request();
-    }
-
-    async sendDuplicateAcknowledgmentResponse(options: {
-        respondingPeer: number;
-        requestingPeer: number;
         forkId?: ForkId;
     }): Promise<void> {
-        const { respondingPeer, requestingPeer, forkId } = options;
+        const { fromPeer, toPeer, forkId } = options;
         const activeForkId = forkId ?? this.harness.activeForkId;
         if (!activeForkId) {
             throw new Error("No active fork ID");
         }
 
-        const requestingAddress = this.harness.getPeer(requestingPeer).address;
-        const respondingPeerObj = this.harness.getPeer(respondingPeer);
+        const fromAddress = this.harness.getPeer(fromPeer).address;
+        const toPeerObj = this.harness.getPeer(toPeer);
 
         await this.harness
-            .control(respondingPeerObj)
-            .handshake.respondToDisputeAcknowledgment(
-                requestingAddress,
+            .control(toPeerObj)
+            .handshake.deliverDisputeAckRequest(
+                fromAddress,
                 this.harness.channelId!,
                 activeForkId
             )
@@ -378,41 +307,6 @@ export class RPCActions<
             .handshake.requestDisputeAcknowledgment(
                 this.harness.channelId!,
                 fakeForkId
-            )
-            .request();
-    }
-
-    /**
-     * Sign `challengeHash` as the responder and deliver an init-handshake
-     * response to the initiator (a two-peer flow: the initiator holds the
-     * challenge; the responder owns the signer).
-     */
-    private async deliverResponse(
-        responder: TestPeer<TCustomRpc>,
-        initiator: TestPeer<TCustomRpc>,
-        challengeHash: string,
-        responseTime: number
-    ): Promise<void> {
-        // Mirror production: the responder signs the domain-separated challenge
-        // message, not the bare hash, so the response verifies.
-        const challengeMessage =
-            InitHandshakeService.buildHandshakeChallengeMessage(challengeHash);
-        const signature = await this.harness
-            .control(responder)
-            .handshake.signMessage(challengeMessage)
-            .request();
-        const preferredTransport = await this.harness
-            .control(responder)
-            .handshake.getPreferredTransport()
-            .request();
-
-        await this.harness
-            .control(initiator)
-            .handshake.deliverHandshakeResponse(
-                responder.address,
-                signature,
-                responseTime,
-                preferredTransport
             )
             .request();
     }

--- a/test/harness/actions/rpcStubActions.ts
+++ b/test/harness/actions/rpcStubActions.ts
@@ -51,6 +51,37 @@ export class RpcStubActions<
     }
 
     /**
+     * Make the given peers answer every spectate request with undecodable junk
+     * bytes (a peer returning data that isn't a valid encoded SyncPayload).
+     * Returns a teardown.
+     */
+    async stubSpectateJunkPayload(
+        peerIndices: number[]
+    ): Promise<() => Promise<void>> {
+        await Promise.all(
+            peerIndices.map((i) =>
+                this.harness
+                    .control(this.harness.getPeer(i))
+                    .stub.stubSpectateJunkPayload()
+                    .request()
+            )
+        );
+        this.logger.debug(
+            `Stubbed spectate junk payload on peers [${peerIndices.join(", ")}]`
+        );
+        return async () => {
+            await Promise.all(
+                peerIndices.map((i) =>
+                    this.harness
+                        .control(this.harness.getPeer(i))
+                        .stub.restoreSpectateJunkPayload()
+                        .request()
+                )
+            );
+        };
+    }
+
+    /**
      * Replace a peer's `onDisputeAcknowledgmentRequest` with a no-op that records
      * the call. Returns a teardown.
      */
@@ -75,5 +106,40 @@ export class RpcStubActions<
             .control(this.harness.getPeer(peerIndex))
             .stub.wasDisputeAckRequestCalled()
             .request();
+    }
+
+    /**
+     * Make a peer reply to handshake challenges with a faulty response so the
+     * initiator rejects it. `delayMs` forces a request timeout; `responseTime
+     * OffsetSeconds` skews the response timestamp. Returns a teardown.
+     */
+    async stubHandshakeResponse(
+        peerIndex: number,
+        options: {
+            delayMs?: number;
+            responseTimeOffsetSeconds?: number;
+            corruptSignature?: boolean;
+        } = {}
+    ): Promise<() => Promise<void>> {
+        const {
+            delayMs = 0,
+            responseTimeOffsetSeconds = 0,
+            corruptSignature = false
+        } = options;
+        const peer = this.harness.getPeer(peerIndex);
+        await this.harness
+            .control(peer)
+            .stub.stubHandshakeResponse(
+                delayMs,
+                responseTimeOffsetSeconds,
+                corruptSignature
+            )
+            .request();
+        return async () => {
+            await this.harness
+                .control(peer)
+                .stub.restoreHandshakeResponse()
+                .request();
+        };
     }
 }

--- a/test/harness/actions/rpcStubActions.ts
+++ b/test/harness/actions/rpcStubActions.ts
@@ -109,6 +109,33 @@ export class RpcStubActions<
     }
 
     /**
+     * Count `onSpectateRequest` calls reaching the given peer (real handler still
+     * runs). Returns a teardown. Pair with `getSpectateRequestCount`.
+     */
+    async stubCountSpectateRequests(
+        peerIndex: number
+    ): Promise<() => Promise<void>> {
+        const peer = this.harness.getPeer(peerIndex);
+        await this.harness
+            .control(peer)
+            .stub.stubCountSpectateRequests()
+            .request();
+        return async () => {
+            await this.harness
+                .control(peer)
+                .stub.restoreCountSpectateRequests()
+                .request();
+        };
+    }
+
+    async getSpectateRequestCount(peerIndex: number): Promise<number> {
+        return await this.harness
+            .control(this.harness.getPeer(peerIndex))
+            .stub.getSpectateRequestCount()
+            .request();
+    }
+
+    /**
      * Make a peer reply to handshake challenges with a faulty response so the
      * initiator rejects it. `delayMs` forces a request timeout; `responseTime
      * OffsetSeconds` skews the response timestamp. Returns a teardown.


### PR DESCRIPTION
Before, all RPCs were implemented as `fire and forget` where each request/response had 2 different endpoints and state had to be tracked across the calls explicitly. With implementing a general request/response pattern for RPCs in one of my previous PRs all of this is implicitly available to all RPC Services. 
The result, we can write:
`const response = await remoteRpc.serviceName.serviceMethod(args).request(peerAddress)` 