### PR TITLE
avoid throw on legtimate race condition

### DIFF
--- a/src/eventHandlers/EventHandler.ts
+++ b/src/eventHandlers/EventHandler.ts
@@ -123,16 +123,17 @@ export class EventHandler {
                     this.stateManager.abort();
                     return;
                 }
-                this.logger.error(
-                    "onStateSnapshotUpdated - unknown snapshot while participant/pending, fatal",
+                // still a participant: StateSnapshotUpdated (from the reduction's
+                // updateStateSnapshotFork) can beat the local onStateSnapshotUpdated -> setGenesisState ->
+                // storeStateSnapshot of the same snapshot. ingest the
+                // authoritative on-chain state.
+                this.logger.warn(
+                    "onStateSnapshotUpdated - unknown snapshot while participant/pending (event raced local apply), ingesting",
                     {
                         channelId,
                         status,
                         hash: updatedSnapshot.hash
                     }
-                );
-                throw new Error(
-                    `onStateSnapshotUpdated: unknown snapshot ${updatedSnapshot.hash} while status=${status}`
                 );
             }
         }

--- a/src/eventHandlers/EventHandler.ts
+++ b/src/eventHandlers/EventHandler.ts
@@ -123,17 +123,22 @@ export class EventHandler {
                     this.stateManager.abort();
                     return;
                 }
-                // still a participant: StateSnapshotUpdated (from the reduction's
-                // updateStateSnapshotFork) can beat the local onStateSnapshotUpdated -> setGenesisState ->
-                // storeStateSnapshot of the same snapshot. ingest the
-                // authoritative on-chain state.
-                this.logger.warn(
-                    "onStateSnapshotUpdated - unknown snapshot while participant/pending (event raced local apply), ingesting",
-                    {
-                        channelId,
-                        status,
-                        hash: updatedSnapshot.hash
-                    }
+                const ingested =
+                    await this.stateManager.tryIngestReducedForkSnapshot(
+                        stateSnapshot
+                    );
+                if (!ingested) {
+                    this.logger.error(
+                        "onStateSnapshotUpdated - unknown snapshot could not be verified by re-reducing origin fork, fatal",
+                        { channelId, status, hash: updatedSnapshot.hash }
+                    );
+                    throw new Error(
+                        `onStateSnapshotUpdated: unverifiable unknown snapshot ${updatedSnapshot.hash} while status=${status}`
+                    );
+                }
+                this.logger.info(
+                    "onStateSnapshotUpdated - unknown snapshot verified by re-reducing origin fork, ingested",
+                    { channelId, status, hash: updatedSnapshot.hash }
                 );
             }
         }

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -514,14 +514,7 @@ class StateManager<
         }
     }
 
-    private async performReduction(
-        forkId: ForkId,
-        genesisTimestamp: Timestamp
-    ) {
-        const now = Clock.getTimeInSeconds();
-        this.logger.info(
-            `Performing reduction for fork ${forkId} with genesis timestamp ${genesisTimestamp}, in (${genesisTimestamp - now}s)`
-        );
+    private async deriveReducedSnapshot(forkId: ForkId) {
         const disputes = await this.agreementManager.getForkDisputes(
             this.channelId,
             forkId,
@@ -538,13 +531,10 @@ class StateManager<
             this.logger.warn(
                 `No disputes found while reducing disputed fork ${forkId}; initiating local dispute`
             );
-            await this.disputeManager.dispute(forkId);
-            return;
+            return undefined;
         }
-
         const reducedOutput =
             await this.stateChannelManagerContract.reduce.staticCall(disputes);
-
         const reduceData = await this.agreementManager.getReduceData(
             forkId,
             reducedOutput
@@ -561,9 +551,63 @@ class StateManager<
                 reduceData.encodedStateMachineState,
                 reduceData.inboundMessageBlocks
             );
-        const expectedReducedForkId = ethers.keccak256(
+        const reducedForkId = ethers.keccak256(
             Codec.encode(reducedSnapshotData, Type.SnapshotData)
         );
+        return {
+            disputes,
+            reduceData,
+            reducedSnapshotData,
+            reducedEncodedStateMachineState,
+            reducedOutboundMessageBlock,
+            reducedForkId
+        };
+    }
+
+    public async tryIngestReducedForkSnapshot(
+        stateSnapshot: StateSnapshotStruct
+    ): Promise<boolean> {
+        const originForkId = stateSnapshot.snapshotData.originForkId as ForkId;
+        const derived = await this.deriveReducedSnapshot(originForkId);
+        if (derived === undefined) return false;
+        if (derived.reducedForkId !== stateSnapshot.forkId) return false;
+        if (derived.reducedOutboundMessageBlock) {
+            this.storage.outboundMessages.store(
+                derived.reducedOutboundMessageBlock,
+                { justPersist: true }
+            );
+        }
+        await this.setGenesisState(
+            derived.reducedSnapshotData,
+            derived.reducedEncodedStateMachineState,
+            derived.reducedForkId,
+            Number(stateSnapshot.timestamp),
+            derived.reducedOutboundMessageBlock
+        );
+        return true;
+    }
+
+    private async performReduction(
+        forkId: ForkId,
+        genesisTimestamp: Timestamp
+    ) {
+        const now = Clock.getTimeInSeconds();
+        this.logger.info(
+            `Performing reduction for fork ${forkId} with genesis timestamp ${genesisTimestamp}, in (${genesisTimestamp - now}s)`
+        );
+        const derived = await this.deriveReducedSnapshot(forkId);
+        if (derived === undefined) {
+            await this.disputeManager.dispute(forkId);
+            return;
+        }
+        const {
+            disputes,
+            reduceData,
+            reducedSnapshotData,
+            reducedEncodedStateMachineState,
+            reducedOutboundMessageBlock,
+            reducedForkId
+        } = derived;
 
         // Pre-store the outbound message block so buildForkSnapshotCalldata can
         // find it via getMessageBlocksInRange.
@@ -579,7 +623,7 @@ class StateManager<
             )
         );
         const reducedGenesisSnapshot = StateSnapshot.from({
-            forkId: expectedReducedForkId,
+            forkId: reducedForkId,
             blockHeight: 0,
             timestamp: Number(genesisTimestamp),
             snapshotData: reducedSnapshotData
@@ -597,12 +641,12 @@ class StateManager<
                     reduceData.latestStateSnapshot,
                     reduceData.encodedStateMachineState,
                     reduceData.inboundMessageBlocks,
-                    expectedReducedForkId
+                    reducedForkId
                 ]
             );
 
         this.logger.info("Reduction transaction submit", {
-            reducedForkId: expectedReducedForkId,
+            reducedForkId: reducedForkId,
             channelId: this.channelId
         });
 
@@ -652,7 +696,7 @@ class StateManager<
                         },
                         RaceConditionReductionExpectationDoesntMatch: () => {
                             this.logger.error(
-                                `Reduction expectation mismatch for fork ${LoggerUtils.formatHash(forkId)} -> expected ${LoggerUtils.formatHash(expectedReducedForkId)}`
+                                `Reduction expectation mismatch for fork ${LoggerUtils.formatHash(forkId)} -> expected ${LoggerUtils.formatHash(reducedForkId)}`
                             );
                         },
                         RaceConditionBlockHeightTooOld: () => {
@@ -673,23 +717,19 @@ class StateManager<
 
         try {
             // Compute local state after reduction (optimistic - assume tx will succeed)
-            const snapshotData = reducedSnapshotData;
-            const encodedStateMachineState = reducedEncodedStateMachineState;
-            const outboundMessageBlock = reducedOutboundMessageBlock;
             this.logger.debug(
                 `Optimistic local reduction computed for fork ${LoggerUtils.formatHash(forkId)}`,
                 {
                     reducedSnapshotData:
-                        LoggerUtils.getSnapshotDataMetadata(snapshotData),
-                    outboundMessageBlock: outboundMessageBlock
+                        LoggerUtils.getSnapshotDataMetadata(
+                            reducedSnapshotData
+                        ),
+                    outboundMessageBlock: reducedOutboundMessageBlock
                         ? LoggerUtils.getMessageBlockMetadata(
-                              outboundMessageBlock
+                              reducedOutboundMessageBlock
                           )
                         : null
                 }
-            );
-            const reducedForkId = ethers.keccak256(
-                Codec.encode(snapshotData, Type.SnapshotData)
             );
 
             // Update local state to the reduced fork
@@ -697,11 +737,11 @@ class StateManager<
                 `Reduction complete (local): transitioning from fork ${LoggerUtils.formatHash(forkId)} to fork ${LoggerUtils.formatHash(reducedForkId)}`
             );
             await this.setGenesisState(
-                snapshotData,
-                encodedStateMachineState,
+                reducedSnapshotData,
+                reducedEncodedStateMachineState,
                 reducedForkId,
                 genesisTimestamp,
-                outboundMessageBlock
+                reducedOutboundMessageBlock
             );
         } catch (error) {
             const custom = tryDecodeCustomError(error);


### PR DESCRIPTION
there is a race condition between
- `StateManager.performaReduce` multicall to `updateStateSnapshotFork` -> event emitted -> `EventHandler.onStateSnapshotUpdated`

- `StateManager.performaReduce` -> `setGenesisState` -> `setLatestState` -> `unsafeSetLatestState` -> `storage.stateSnapshots.storeStateSnapshot`


sometimes, `EventHandler.onStateSnapshotUpdated` runs before `unsafeSetLatestState`    => the state snapshot is not yet in loacl storage -> `onStateSnapshotUpdated` throws

this shold not throw. 


this caused the test `"dispute.input.timeout.blockHeight = block whose calldata is on-chain; isForced=true → TimeoutCalldataPosted"`
to fail, due to honest peer (peer index 1) throwing