### PR TITLE
test(harness): export HarnessControlRpc from the test-harness entry

### DIFF
--- a/test-harness.ts
+++ b/test-harness.ts
@@ -1,5 +1,8 @@
 export { PeerTestHarness } from "./test/fixtures/PeerTestHarness";
 export { MathPeerTestHarness } from "./test/fixtures/MathPeerTestHarness";
+// The default TCustomRpc for PeerTestHarness — exported so external consumers
+// can name it when subclassing with a custom state machine.
+export { HarnessControlRpc } from "./test/fixtures/customRpc/harnessControl/HarnessControlRpc";
 export * from "./test/harness/core/types";
 export { ScenarioActions } from "./test/harness/actions/ScenarioActions";
 export { TestSession } from "./test/harness/session/TestSession";


### PR DESCRIPTION
## Merge order — read first

Part of a coordinated multi-repo change. Full merge order (downstream consumers
are in separate **private** repos):

1. 👉 **(this PR)** HarnessControlRpc export → `dispute`
2. contract-event delivery fix (#379) → `dispute`
3. downstream consumer migration → (private repo)
4. WebRTC main-thread bridge port (#376) → `dispute`
5. browser host-worker boot fixes (#380) → `dispute`
6. downstream app migration → (private repo)

The SDK PRs are independent of each other. The bridge port (#376) and the
browser host-worker boot fixes (#380) both merge before the downstream app
consumer (step 6). This PR (the export) only unblocks the downstream consumer
migration in step 3.

## Summary

Exports `HarnessControlRpc` from the `test-harness` entry so external consumers
that subclass `PeerTestHarness` with a custom state machine can name the default
`TCustomRpc`. It was only reachable internally before.

## Test Plan

- `yarn tsc --noEmit -p tsconfig.json` clean.
- Pure export addition — no behavior change; existing harness tests unaffected.
