### PR TITLE
Part 1 of getting back to green

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,19 @@
 
 These are project rules to follow (and persist any future "remember this" instructions here).
 
+### Testing changes to `src/`
+
+Every `src/` change ships with tests in the same pass — both kinds:
+
+- **Unit tests** for the isolated logic (no mocks, no junk data — see
+  `test/AGENTS.md`: factory-built domain objects, or a teleported harness
+  session when the component has collaborators).
+- **E2E tests** when the change affects peer-observable behavior (new
+  guard/punishment/queue semantics, protocol deviations, sync flows).
+
+Verify with the narrowest targeted run (`--grep` the touched files) before
+handing off.
+
 ### RPC services (`*Service` + `*RpcMethods`)
 
 Applies to `src/rpc/services/*` and `test/fixtures/customRpc/**`.
@@ -27,6 +40,38 @@ Applies to `src/rpc/services/*` and `test/fixtures/customRpc/**`.
   `this.service.*`. The service is where services coordinate shared state.
 - Each service lives in its own directory: `<name>/<Name>Service.ts` +
   `<name>/<Name>RpcMethods.ts`.
+
+### Block-validation deviations go through the strategy
+
+Applies to `src/stateManager/validationStrategy/*` and their call sites
+(`StateManager.onBlockConfirmation`, `tryMergeStoredBlockConfirmation`,
+`ValidationService`).
+
+- **Every deviation from the happy path is a method on `AValidationStrategy`**
+  (e.g. `notAllSingersAreParticipants`, `invalidStateTransitionDetected`,
+  `wrongGenesisDetected`). Never handle a deviation inline at the call site —
+  no matter how obvious the handling seems. Two reasons: (1) the strategy
+  interface is the single place to see all deviations; (2) the correct side
+  effect differs per pipeline (live gossip disconnects/blacklists; dispute
+  replay produces fraud-proof evidence against the submitter; spectating
+  drops the feed).
+- **Side effects live inside the strategy implementations**, not at the call
+  site. The call site only computes the inputs (pass precomputed sets — e.g.
+  the unexpected signers/signatures — so strategies don't recompute), calls
+  the hook, logs, and interprets the returned `BlockValidationResult`
+  (`SUCCESS` = continue the pipeline).
+- When adding a deviation, implement it on **all** strategies — a deliberate
+  `throw` ("should not be relevant/called") is a valid implementation when the
+  deviation is impossible for that pipeline.
+- **The pipeline's unit of work is the `QueuedBlockEntry`, never a bare
+  block + ad-hoc sender parameter.** Entries are CRDTs: copies merge
+  (signatures + signature -> source attribution) in `QueueStorage` until
+  scheduled, then the dequeued entry executes atomically and converges
+  through storage. Strategies resolve offenders from `entry.signatureSources`
+  / `entry.sourcePeers` and re-queue via `restoreEntry` so attribution
+  survives the not-ready cycle. Struct-only callers (dispute replay, spectate
+  sync) enter via `onBlockConfirmationStruct`, which wraps into a sourceless
+  entry.
 
 ### Comments
 
@@ -91,6 +136,10 @@ Applies to `src/rpc/services/*` and `test/fixtures/customRpc/**`.
 - Casts are only acceptable for genuinely untyped/private internals (e.g.
   monkey-patching a private SDK member in a stub) — not for public, already-typed
   surfaces.
+- **No `Awaited<ReturnType<...>>` wrappers for types that have a name.** If a
+  method returns `Promise<ReduceData>`, write `ReduceData` — import/export the
+  named type instead of deriving it through utility-type gymnastics. Derived
+  types are only for signatures that must mirror another surface (first bullet).
 - **Name `Codec`/ethers-encoded values `encoded*`.** When a field or variable
   holds an ABI/`Codec.encode`d hex string (e.g. crossing the runtime port),
   name it `encodedDispute`/`encodedSyncPayload`/… — bare `string` isn't

--- a/scripts/test-e2e-parallel.js
+++ b/scripts/test-e2e-parallel.js
@@ -32,7 +32,7 @@ let _teardown = () => {};
 function buildBaseEnv(threadModes) {
     return {
         ...process.env,
-        LOG_LEVEL: process.env.LOG_LEVEL || "error",
+        LOG_LEVEL: process.env.LOG_LEVEL || "verbose",
         NODE_OPTIONS: [
             process.env.NODE_OPTIONS,
             "--enable-source-maps",

--- a/src/eventHandlers/EventHandler.ts
+++ b/src/eventHandlers/EventHandler.ts
@@ -123,17 +123,44 @@ export class EventHandler {
                     this.stateManager.abort();
                     return;
                 }
-                this.logger.error(
-                    "onStateSnapshotUpdated - unknown snapshot while participant/pending, fatal",
-                    {
-                        channelId,
-                        status,
-                        hash: updatedSnapshot.hash
-                    }
-                );
-                throw new Error(
-                    `onStateSnapshotUpdated: unknown snapshot ${updatedSnapshot.hash} while status=${status}`
-                );
+                // The snapshot may be the committed result of a fork
+                // reduction our local processing hasn't produced yet (chain
+                // events carry no cross-event ordering). Reduce on the spot -
+                // single-flight with the other reduction entry points - and
+                // re-check.
+                try {
+                    await this.stateManager.reduceLocally(
+                        this.stateManager.forkId
+                    );
+                } catch (error) {
+                    this.logger.warn(
+                        "onStateSnapshotUpdated - on-the-spot reduction failed",
+                        {
+                            channelId,
+                            error:
+                                error instanceof Error
+                                    ? error.message
+                                    : String(error)
+                        }
+                    );
+                }
+                const converged =
+                    this.storage.stateSnapshots.getStateSnapshotByHash(
+                        updatedSnapshot.hash
+                    );
+                if (!converged) {
+                    this.logger.error(
+                        "onStateSnapshotUpdated - unknown snapshot while participant/pending, fatal",
+                        {
+                            channelId,
+                            status,
+                            hash: updatedSnapshot.hash
+                        }
+                    );
+                    throw new Error(
+                        `onStateSnapshotUpdated: unknown snapshot ${updatedSnapshot.hash} while status=${status}`
+                    );
+                }
             }
         }
 
@@ -824,36 +851,31 @@ export class EventHandler {
         reducedForkId: ForkId,
         _reductionTimestamp: Timestamp
     ): Promise<void> {
-        // enough for now - this will change later
-        if (this.stateManager.forkId == forkId) {
-            // Get the latest state snapshot - it should be reduced locally if not we'll reduce it on the spot
-            const latestStateSnapshot =
-                this.storage.stateSnapshots.getGenesisSnapshotByForkId(
-                    reducedForkId
-                );
-            if (!latestStateSnapshot) {
-                // TODO reduce localy
-                return;
-            }
-            const genesisStateMachineState =
-                this.storage.stateMachineStates.getStateMachineState(
-                    latestStateSnapshot.stateMachineStateHash
-                );
+        // TODO - this function is currently unused - come back to its implemntation when used
+        if (this.stateManager.forkId != forkId) return;
 
-            if (!genesisStateMachineState) {
-                // we need to compute it - should have computed it above while reducing
-                // TODO - solidity code that returns the encodedState
-            }
-            // Set fork and start building on it
-            // TODO
-            throw new Error(
-                "Not implemented yet - set fork for reduceCommitment"
+        // Reduce on the spot - single-flight with the other reduction entry
+        // points; resolved means the reduced genesis is stored and the fork
+        // switched.
+        await this.stateManager.reduceLocally(forkId);
+
+        const genesisSnapshot =
+            this.storage.stateSnapshots.getGenesisSnapshotByForkId(
+                reducedForkId
             );
-            // await this.stateManager.setGenesisState(
-            //     genesisStateMachineState!,
-            //     reducedForkId,
-            //     reductionTimestamp
-            // );
+        if (!genesisSnapshot) {
+            // The finalized on-chain reduction won and we could not derive it
+            // locally - we have diverged; stop building instead of advancing
+            // a fork the channel didn't agree on.
+            this.logger.error(
+                "Reduced result committed on-chain but the local reduction did not produce it - aborting participation",
+                {
+                    forkId,
+                    reducedForkId,
+                    localForkId: this.stateManager.forkId
+                }
+            );
+            this.stateManager.abort();
         }
     }
 }

--- a/src/evm/node/workerCpuProfiler.ts
+++ b/src/evm/node/workerCpuProfiler.ts
@@ -1,0 +1,68 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// Env-gated V8 CPU profiler for worker threads (diagnostics only). Enabled by
+// setting SCP_CPU_PROFILE_DIR; profiles land there as .cpuprofile files.
+//
+// Worker threads are force-terminated by the test harness, so a profile that
+// only writes on clean exit would be lost. Instead the profile is flushed in
+// chunks (SCP_CPU_PROFILE_FLUSH_MS, default 5s) and once more on
+// uncaughtException — the event-loop starvation watchdog throws, so the chunk
+// containing the stall is written before the parent terminates the thread.
+export function startCpuProfilerIfEnabled(label: string): void {
+    const dir = process.env.SCP_CPU_PROFILE_DIR;
+    if (!dir) return;
+    const flushMs = Number(process.env.SCP_CPU_PROFILE_FLUSH_MS) || 5000;
+
+    void (async () => {
+        const [inspector, workerThreads] = await Promise.all([
+            import("node:inspector"),
+            import("node:worker_threads")
+        ]);
+        const session = new inspector.Session();
+        session.connect();
+        const post = (method: string, params?: object): Promise<unknown> =>
+            new Promise((resolve, reject) =>
+                (session.post as Function)(
+                    method,
+                    params,
+                    (err: Error | null, result: unknown) =>
+                        err ? reject(err) : resolve(result)
+                )
+            );
+
+        fs.mkdirSync(dir, { recursive: true });
+        await post("Profiler.enable");
+        await post("Profiler.setSamplingInterval", { interval: 500 });
+        await post("Profiler.start");
+
+        const base = `${label}-pid${process.pid}-t${workerThreads.threadId}`;
+        let chunk = 0;
+        let flushing = false;
+        const flush = async () => {
+            if (flushing) return;
+            flushing = true;
+            try {
+                const { profile } = (await post("Profiler.stop")) as {
+                    profile: unknown;
+                };
+                fs.writeFileSync(
+                    path.join(dir, `${base}-c${chunk++}.cpuprofile`),
+                    JSON.stringify(profile)
+                );
+                await post("Profiler.start");
+            } catch {
+                // Session may be gone during teardown — ignore.
+            } finally {
+                flushing = false;
+            }
+        };
+
+        setInterval(() => void flush(), flushMs).unref();
+        // Run before other handlers so the stall chunk gets written even if the
+        // error is about to take the worker down.
+        process.prependListener("uncaughtException", () => void flush());
+    })().catch(() => {
+        // Profiling is best-effort; never take the worker down over it.
+    });
+}

--- a/src/evm/p2pRuntime/node/P2pRuntimeWorkerRuntime.ts
+++ b/src/evm/p2pRuntime/node/P2pRuntimeWorkerRuntime.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import * as fs from "node:fs";
 import { resolveWorkerResourceLimits } from "../../node/workerResourceLimits";
 import { instrumentWorkerStartup } from "../../node/workerStartupTiming";
+import { startCpuProfilerIfEnabled } from "../../node/workerCpuProfiler";
 import type {
     P2pRuntimeWorker,
     RuntimePort,
@@ -65,6 +66,7 @@ export function onWorkerBootstrap(
             "startP2pRuntimeWorker must be executed inside a worker thread"
         );
     }
+    startCpuProfilerIfEnabled("sdk");
     parentPort.on("message", (data) => handler(data as WorkerBootstrapMessage));
 }
 

--- a/src/models/Block.ts
+++ b/src/models/Block.ts
@@ -268,6 +268,16 @@ export default class Block {
         return this;
     }
 
+    /** Drop confirmation signatures (the author's original signature is kept). */
+    removeConfirmationSignatures(signatures: Set<Signature>): Block {
+        for (const signature of signatures) {
+            if (this._confirmationSignatures.delete(signature)) {
+                this._allSignerAddressesCache = undefined;
+            }
+        }
+        return this;
+    }
+
     getRelevantTimestamp(nextBlockAuthor: Address): Timestamp {
         const signature = this.findSignature(nextBlockAuthor);
 

--- a/src/rpc/services/spectate/SpectateService.ts
+++ b/src/rpc/services/spectate/SpectateService.ts
@@ -403,7 +403,8 @@ class SpectateService extends ARpcService<SpectateServiceRpcMethods> {
             );
             for (const bc of blockConfirmations) {
                 try {
-                    const isOk = await stateManager.onBlockConfirmation(bc);
+                    const isOk =
+                        await stateManager.onBlockConfirmationStruct(bc);
                     if (!isOk) return this.abort(peerAddress);
                 } catch (e) {
                     this.logger.error(

--- a/src/stateManager/BlockQueueManager.ts
+++ b/src/stateManager/BlockQueueManager.ts
@@ -21,7 +21,6 @@ export type IngestBlockConfirmationOptions = {
 export default class BlockQueueManager {
     private readonly timeoutHandles: Map<Hash, ReturnType<typeof setTimeout>> =
         new Map();
-    private readonly processingEntries: Map<Hash, QueuedBlockEntry> = new Map();
     private readonly logger: Logger;
 
     constructor(
@@ -73,9 +72,10 @@ export default class BlockQueueManager {
 
             if (this.isBlockStored(block)) {
                 this.scheduleStoredBlockConfirmationMerge(
-                    block,
-                    strategy,
-                    options?.senderAddress ? [options.senderAddress] : []
+                    this.stateManager.storage.queues.createEntry(block, {
+                        senderAddress: options?.senderAddress
+                    }),
+                    strategy
                 );
                 return true;
             }
@@ -165,8 +165,10 @@ export default class BlockQueueManager {
 
     private async queueTimeout(blockHash: Hash): Promise<void> {
         this.timeoutHandles.delete(blockHash);
-        const entry =
-            this.stateManager.storage.queues.getQueuedEntry(blockHash);
+        // Dequeue first: the timeout owns the entry it sees - no race with
+        // other tasks. Copies arriving from here on pool into a fresh entry
+        // that converges on its own.
+        const entry = this.stateManager.storage.queues.removeBlock(blockHash);
         if (!entry) return;
 
         if (
@@ -180,14 +182,10 @@ export default class BlockQueueManager {
         }
 
         if (this.isBlockStored(entry.block)) {
-            const strategy = this.stateManager.getActiveValidationStrategy();
             this.scheduleStoredBlockConfirmationMerge(
-                entry.block,
-                strategy,
-                Array.from(entry.sourcePeers)
+                entry,
+                this.stateManager.getActiveValidationStrategy()
             );
-            this.stateManager.storage.queues.removeBlock(blockHash);
-            this.cancelQueueTimeout(blockHash);
             return;
         }
 
@@ -195,12 +193,16 @@ export default class BlockQueueManager {
             entry.block.forkId
         );
 
-        if (entry.block.height > nextHeight) {
-            this.requestSync(entry);
+        if (entry.block.height <= nextHeight) {
+            this.scheduleQueuedEntryExecution(entry);
             return;
         }
 
-        this.scheduleQueueExecution(entry.block.forkId);
+        // Still in the future after the agreement window: discard (already
+        // dequeued) and ask the suppliers to sync us up - junk must not
+        // accumulate. A block posted as calldata can always be re-read from
+        // the chain if it turns out to be needed.
+        this.requestSync(entry);
     }
 
     public clearFork(forkId: ForkId): void {
@@ -216,18 +218,12 @@ export default class BlockQueueManager {
     }
 
     public disconnectPeersForSignatures(
-        blockHash: Hash,
+        entry: QueuedBlockEntry,
         signatures: Set<Signature>
     ): void {
         const disconnectedPeers = new Set<Address>();
-        const processingEntry = this.processingEntries.get(blockHash);
         for (const signature of signatures) {
-            const peers =
-                processingEntry?.signatureSources.get(signature) ??
-                this.stateManager.storage.queues.getSignatureSources(
-                    blockHash,
-                    signature
-                );
+            const peers = entry.signatureSources.get(signature);
             if (!peers) continue;
             for (const peer of peers) {
                 if (disconnectedPeers.has(peer)) continue;
@@ -239,26 +235,20 @@ export default class BlockQueueManager {
         }
         if (disconnectedPeers.size > 0) {
             this.logger.warn("Disconnected peers for invalid signatures", {
-                blockHash,
+                blockHash: entry.block.hash,
                 disconnectedPeers: Array.from(disconnectedPeers)
             });
         }
     }
 
     public scheduleStoredBlockConfirmationMerge(
-        block: Block,
-        strategy: AValidationStrategy,
-        sourcePeers: Address[] = []
+        entry: QueuedBlockEntry,
+        strategy: AValidationStrategy
     ): void {
         this.timeoutManager.scheduleTask(
-            () =>
-                this.handleStoredBlockConfirmationMerge(
-                    block,
-                    strategy,
-                    sourcePeers
-                ),
+            () => this.handleStoredBlockConfirmationMerge(entry, strategy),
             0,
-            `BlockQueueManager.handleStoredBlockConfirmationMerge - fork ${block.forkId} - block ${block.height}`
+            `BlockQueueManager.handleStoredBlockConfirmationMerge - fork ${entry.block.forkId} - block ${entry.block.height}`
         );
     }
 
@@ -302,15 +292,13 @@ export default class BlockQueueManager {
     }
 
     private async handleStoredBlockConfirmationMerge(
-        block: Block,
-        strategy: AValidationStrategy,
-        sourcePeers: Address[]
+        entry: QueuedBlockEntry,
+        strategy: AValidationStrategy
     ): Promise<void> {
         const validationResult =
             await this.stateManager.tryMergeStoredBlockConfirmation(
-                block,
-                strategy,
-                sourcePeers[0]
+                entry,
+                strategy
             );
         if (validationResult === undefined) return;
 
@@ -318,14 +306,14 @@ export default class BlockQueueManager {
             await strategy.interpretFinalValidationResult(validationResult);
 
         if (!shouldKeepConnection) {
-            for (const peer of sourcePeers) {
+            for (const peer of entry.sourcePeers) {
                 this.stateManager.p2pManager.disconnectAndBlacklistPeerByEvmAddress(
                     peer
                 );
             }
         }
         P2pEventHooksUtils.notifyBlockConfirmationProcessed({
-            blockHash: block.hash,
+            blockHash: entry.block.hash,
             keepConnection: shouldKeepConnection,
             p2pEventHooks: this.stateManager.p2pEventHooks
         });
@@ -334,37 +322,26 @@ export default class BlockQueueManager {
     private async executeQueuedEntry(entry: QueuedBlockEntry): Promise<void> {
         if (this.isBlockStored(entry.block)) {
             await this.handleStoredBlockConfirmationMerge(
-                entry.block,
-                this.stateManager.getActiveValidationStrategy(),
-                Array.from(entry.sourcePeers)
+                entry,
+                this.stateManager.getActiveValidationStrategy()
             );
             return;
         }
 
-        this.processingEntries.set(entry.block.hash, entry);
-        try {
-            const shouldKeepConnection =
-                await this.stateManager.onBlockConfirmation(
-                    entry.block.blockConfirmationStruct,
-                    {
-                        onChainTimestamp: entry.block.onChainTimestamp
-                    }
-                );
+        const shouldKeepConnection =
+            await this.stateManager.onBlockConfirmation(entry);
 
-            if (!shouldKeepConnection) {
-                this.logger.warn(
-                    "tryExecuteFromQueue - queued block failed canonical validation",
-                    {
-                        block: LoggerUtils.getBlockMetadata(
-                            entry.block,
-                            this.stateManager.storage
-                        ),
-                        sourcePeers: Array.from(entry.sourcePeers)
-                    }
-                );
-            }
-        } finally {
-            this.processingEntries.delete(entry.block.hash);
+        if (!shouldKeepConnection) {
+            this.logger.warn(
+                "tryExecuteFromQueue - queued block failed canonical validation",
+                {
+                    block: LoggerUtils.getBlockMetadata(
+                        entry.block,
+                        this.stateManager.storage
+                    ),
+                    sourcePeers: Array.from(entry.sourcePeers)
+                }
+            );
         }
     }
 

--- a/src/stateManager/DisputeValidationService.ts
+++ b/src/stateManager/DisputeValidationService.ts
@@ -220,7 +220,7 @@ export default class DisputeValidationService {
                 index,
                 this.logger
             );
-            const isOk = await this.stateManager.onBlockConfirmation(bc, {
+            const isOk = await this.stateManager.onBlockConfirmationStruct(bc, {
                 validationStrategy: disputeStrategy
             });
             if (!isOk) {

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -36,6 +36,7 @@ import P2PManager from "@/P2PManager";
 import StateChannelEventListener from "@/StateChannelEventListener";
 import ValidationService from "./ValidationService";
 import Storage from "@/storage";
+import type { QueuedBlockEntry } from "@/storage/QueueStorage";
 import { EventHandler } from "@/eventHandlers/EventHandler";
 import {
     tryDecodeCustomError,
@@ -64,7 +65,7 @@ import {
 } from "@/utils";
 import type { MutexLockOptions, MutexUnlockOptions } from "@/utils";
 // Types
-import { BlockValidationResult, Status, TimeConfig } from "@/types";
+import { BlockValidationResult, ReduceData, Status, TimeConfig } from "@/types";
 import {
     Address,
     BlockHeight,
@@ -95,6 +96,13 @@ import BlockQueueManager, {
 } from "./BlockQueueManager";
 
 const NULL = ZeroHash;
+
+type LocalReductionResult = {
+    disputes: DisputeStruct[];
+    reduceData: ReduceData;
+    reducedGenesisSnapshot: StateSnapshot;
+    expectedReducedForkId: ForkId;
+};
 
 type ParticipantChanges = {
     left: Set<Address>;
@@ -128,6 +136,10 @@ class StateManager<
     spectatingValidationStrategy: SpectatingValidationStrategy;
     eventHandler: EventHandler;
     reductionTriggerMap: Map<ForkId, ReductionTimeoutHandle> = new Map();
+    private readonly localReductions: Map<
+        ForkId,
+        Promise<LocalReductionResult | undefined>
+    > = new Map();
     status: Status = Status.NOT_OPENED;
     timeoutManager: TimeoutManager;
     logger: Logger;
@@ -224,11 +236,13 @@ class StateManager<
             this.storage,
             this.p2pManager,
             this.disputeManager,
+            this.blockQueueManager,
             this.logger
         );
         this.spectatingValidationStrategy = new SpectatingValidationStrategy(
             this.storage,
             this.p2pManager,
+            this.blockQueueManager,
             this.logger
         );
     }
@@ -495,11 +509,9 @@ class StateManager<
             );
         }
 
-        //TODO - see to put all genesisTimestamp logic in one place
-        const genesisTimestamp = Number(onChainKillTimestamp);
         // Step 4: Perform reduction
         try {
-            await this.performReduction(forkId, genesisTimestamp);
+            await this.performReduction(forkId);
         } catch (error) {
             if (
                 error instanceof Error &&
@@ -514,14 +526,48 @@ class StateManager<
         }
     }
 
-    private async performReduction(
-        forkId: ForkId,
-        genesisTimestamp: Timestamp
-    ) {
-        const now = Clock.getTimeInSeconds();
-        this.logger.info(
-            `Performing reduction for fork ${forkId} with genesis timestamp ${genesisTimestamp}, in (${genesisTimestamp - now}s)`
-        );
+    /**
+     * Reduce `forkId` locally and set the reduced genesis — single-flight, no
+     * on-chain submission. Every reduction entry point (kill-period timeout,
+     * chain events observing a committed result) awaits the same run;
+     * resolved means the reduced genesis is stored and the fork switched.
+     * Resolves to undefined when there is nothing to reduce (fork already
+     * left, kill period not expired, or no local dispute data).
+     */
+    public reduceLocally(
+        forkId: ForkId
+    ): Promise<LocalReductionResult | undefined> {
+        if (this.forkId !== forkId) return Promise.resolve(undefined);
+        let inFlight = this.localReductions.get(forkId);
+        if (!inFlight) {
+            inFlight = this.performLocalReduction(forkId).finally(() => {
+                this.localReductions.delete(forkId);
+            });
+            this.localReductions.set(forkId, inFlight);
+        }
+        return inFlight;
+    }
+
+    private async performLocalReduction(
+        forkId: ForkId
+    ): Promise<LocalReductionResult | undefined> {
+        // The kill timestamp doubles as the reduced genesis timestamp, so it
+        // must be the on-chain value — identical for every peer, or the local
+        // reduced snapshot hash won't match the committed one.
+        const { isExpired, killPeriodEnd } =
+            await this.stateChannelManagerContract.isKillPeriodExpired(
+                this.channelId,
+                forkId
+            );
+        if (!isExpired) {
+            // Guards event-driven callers: nothing to reduce (yet).
+            this.logger.debug(
+                `reduceLocally - kill period not expired for fork ${LoggerUtils.formatHash(forkId)}`
+            );
+            return undefined;
+        }
+        const genesisTimestamp = Number(killPeriodEnd);
+
         const disputes = await this.agreementManager.getForkDisputes(
             this.channelId,
             forkId,
@@ -529,7 +575,7 @@ class StateManager<
         );
 
         this.logger.debug(
-            `Performing reduction on disputes for fork ${LoggerUtils.formatHash(forkId)}`,
+            `Performing local reduction on disputes for fork ${LoggerUtils.formatHash(forkId)}`,
             {
                 disputes: disputes.map((d) => LoggerUtils.getDisputeMetadata(d))
             }
@@ -539,51 +585,95 @@ class StateManager<
                 `No disputes found while reducing disputed fork ${forkId}; initiating local dispute`
             );
             await this.disputeManager.dispute(forkId);
-            return;
+            return undefined;
         }
 
-        const reducedOutput =
-            await this.stateChannelManagerContract.reduce.staticCall(disputes);
+        try {
+            const reducedOutput =
+                await this.stateChannelManagerContract.reduce.staticCall(
+                    disputes
+                );
 
-        const reduceData = await this.agreementManager.getReduceData(
-            forkId,
-            reducedOutput
-        );
-        const [
-            reducedSnapshotData,
-            reducedEncodedStateMachineState,
-            reducedOutboundMessageBlock
-        ] =
-            await this.diamondStateMachine.localDiamondContract.reduceOutputToSnapshotData.staticCall(
+            const reduceData = await this.agreementManager.getReduceData(
                 forkId,
-                reducedOutput,
-                reduceData.latestStateSnapshot,
-                reduceData.encodedStateMachineState,
-                reduceData.inboundMessageBlocks
+                reducedOutput
             );
-        const expectedReducedForkId = ethers.keccak256(
-            Codec.encode(reducedSnapshotData, Type.SnapshotData)
-        );
+            const [
+                reducedSnapshotData,
+                reducedEncodedStateMachineState,
+                reducedOutboundMessageBlock
+            ] =
+                await this.diamondStateMachine.localDiamondContract.reduceOutputToSnapshotData.staticCall(
+                    forkId,
+                    reducedOutput,
+                    reduceData.latestStateSnapshot,
+                    reduceData.encodedStateMachineState,
+                    reduceData.inboundMessageBlocks
+                );
+            const expectedReducedForkId = ethers.keccak256(
+                Codec.encode(reducedSnapshotData, Type.SnapshotData)
+            );
 
-        // Pre-store the outbound message block so buildForkSnapshotCalldata can
-        // find it via getMessageBlocksInRange.
-        if (reducedOutboundMessageBlock) {
-            this.storage.outboundMessages.store(reducedOutboundMessageBlock, {
-                justPersist: true
+            // Pre-store the outbound message block so buildForkSnapshotCalldata
+            // can find it via getMessageBlocksInRange.
+            if (reducedOutboundMessageBlock) {
+                this.storage.outboundMessages.store(
+                    reducedOutboundMessageBlock,
+                    { justPersist: true }
+                );
+            }
+
+            const reducedGenesisSnapshot = StateSnapshot.from({
+                forkId: expectedReducedForkId,
+                blockHeight: 0,
+                timestamp: genesisTimestamp,
+                snapshotData: reducedSnapshotData
             });
+
+            this.logger.info(
+                `Reduction complete (local): transitioning from fork ${LoggerUtils.formatHash(forkId)} to fork ${LoggerUtils.formatHash(expectedReducedForkId)}`
+            );
+            await this.setGenesisState(
+                reducedSnapshotData,
+                reducedEncodedStateMachineState,
+                expectedReducedForkId,
+                genesisTimestamp,
+                reducedOutboundMessageBlock
+            );
+
+            return {
+                disputes,
+                reduceData,
+                reducedGenesisSnapshot,
+                expectedReducedForkId
+            };
+        } catch (error) {
+            const custom = tryDecodeCustomError(error);
+            this.logger.error("Error computing reduced snapshot data", {
+                custom,
+                error: error instanceof Error ? error.message : String(error)
+            });
+            throw error;
         }
+    }
+
+    private async performReduction(forkId: ForkId) {
+        // Local convergence first (shared with the event-driven entry
+        // points); the on-chain submission below is this path's extra step.
+        const reduction = await this.reduceLocally(forkId);
+        if (!reduction) return;
+        const {
+            disputes,
+            reduceData,
+            reducedGenesisSnapshot,
+            expectedReducedForkId
+        } = reduction;
 
         const currentOnChainSnapshot = StateSnapshot.from(
             await this.stateChannelManagerContract.getStateSnapshot(
                 this.channelId
             )
         );
-        const reducedGenesisSnapshot = StateSnapshot.from({
-            forkId: expectedReducedForkId,
-            blockHeight: 0,
-            timestamp: Number(genesisTimestamp),
-            snapshotData: reducedSnapshotData
-        });
         const { calldata: forkCalldata } = this.buildForkSnapshotCalldata(
             reducedGenesisSnapshot,
             currentOnChainSnapshot
@@ -673,47 +763,6 @@ class StateManager<
                 if (!success) throw error;
             });
         DetachedPromises.collect(txResponsePromise);
-
-        try {
-            // Compute local state after reduction (optimistic - assume tx will succeed)
-            const snapshotData = reducedSnapshotData;
-            const encodedStateMachineState = reducedEncodedStateMachineState;
-            const outboundMessageBlock = reducedOutboundMessageBlock;
-            this.logger.debug(
-                `Optimistic local reduction computed for fork ${LoggerUtils.formatHash(forkId)}`,
-                {
-                    reducedSnapshotData:
-                        LoggerUtils.getSnapshotDataMetadata(snapshotData),
-                    outboundMessageBlock: outboundMessageBlock
-                        ? LoggerUtils.getMessageBlockMetadata(
-                              outboundMessageBlock
-                          )
-                        : null
-                }
-            );
-            const reducedForkId = ethers.keccak256(
-                Codec.encode(snapshotData, Type.SnapshotData)
-            );
-
-            // Update local state to the reduced fork
-            this.logger.info(
-                `Reduction complete (local): transitioning from fork ${LoggerUtils.formatHash(forkId)} to fork ${LoggerUtils.formatHash(reducedForkId)}`
-            );
-            await this.setGenesisState(
-                snapshotData,
-                encodedStateMachineState,
-                reducedForkId,
-                genesisTimestamp,
-                outboundMessageBlock
-            );
-        } catch (error) {
-            const custom = tryDecodeCustomError(error);
-            this.logger.error("Error computing reduced snapshot data", {
-                custom,
-                error: error instanceof Error ? error.message : String(error)
-            });
-            throw error;
-        }
     }
 
     private buildForkSnapshotCalldata(
@@ -1000,10 +1049,10 @@ class StateManager<
     }
 
     public async tryMergeStoredBlockConfirmation(
-        block: Block,
-        strategy: AValidationStrategy,
-        senderAddress?: Address
+        entry: QueuedBlockEntry,
+        strategy: AValidationStrategy
     ): Promise<BlockValidationResult | undefined> {
+        const block = entry.block;
         const existingBlock = this.storage.blocks.getBlock(block.hash);
         if (!existingBlock) return undefined;
 
@@ -1041,17 +1090,44 @@ class StateManager<
         );
 
         if (!isSubset(newSignerAddresses, participants)) {
+            const unexpectedSigners = difference(
+                newSignerAddresses,
+                participants
+            );
+            const unexpectedSignatures = new Set(
+                Array.from(newSignatures).filter((signature) =>
+                    unexpectedSigners.has(
+                        getChecksumAddress(
+                            block.signatureToAddress(signature)
+                        ) as Address
+                    )
+                )
+            );
             this.logger.warn(
-                "maybeMergeStoredBlockConfirmation - not all new signers are participants",
+                "maybeMergeStoredBlockConfirmation - signers outside the participant union",
                 {
                     strategy: strategy.name,
-                    senderAddress,
                     block: LoggerUtils.getBlockMetadata(block, this.storage),
-                    newSignerAddresses: Array.from(newSignerAddresses),
+                    unexpectedSigners: Array.from(unexpectedSigners),
                     participants: Array.from(participants)
                 }
             );
-            return strategy.notAllSingersAreParticipants(block);
+            const validationResult =
+                await strategy.notAllSingersAreParticipants(
+                    entry,
+                    unexpectedSignatures
+                );
+            if (validationResult !== BlockValidationResult.SUCCESS) {
+                return validationResult;
+            }
+            // SUCCESS: the strategy stripped the stray signatures and cut
+            // their byzantine sender.
+            if (
+                difference(block.confirmationSignatures, existingSignatures)
+                    .size === 0
+            ) {
+                return strategy.noNewSignaturesOnExistingBlock(block);
+            }
         }
 
         this.storage.blocks.storeBlock(block);
@@ -1075,20 +1151,44 @@ class StateManager<
         return BlockValidationResult.DUPLICATE;
     }
 
-    // Passes the block confirmation through a verification pipeline
+    /**
+     * Struct adapter for callers that replay confirmations outside the queue
+     * (dispute stateProof replay, spectate sync): wraps into a sourceless
+     * entry — those pipelines don't punish by transport.
+     */
+    public async onBlockConfirmationStruct(
+        blockConfirmation: BlockConfirmationStruct,
+        options?: {
+            validationStrategy?: AValidationStrategy;
+        }
+    ): Promise<boolean> {
+        return this.onBlockConfirmation(
+            this.storage.queues.createEntry(
+                Block.fromBlockConfirmation(blockConfirmation)
+            ),
+            options
+        );
+    }
+
+    // Passes the block confirmation through a verification pipeline.
+    // The entry is the CRDT accumulation of the block up to scheduling; the
+    // run is atomic over it and its source attribution.
     // returns true if the block is valid and the state transition is successful
     // returns false -> the calling context should disconnect from the peer
     public async onBlockConfirmation(
-        blockConfirmation: BlockConfirmationStruct,
+        entry: QueuedBlockEntry,
         options?: {
-            onChainTimestamp?: Timestamp;
             validationStrategy?: AValidationStrategy;
-            senderAddress?: string;
         }
     ): Promise<boolean> {
         let strategy: AValidationStrategy | undefined;
         let block: Block | undefined;
         let keepConnection: boolean | undefined;
+        // The VM is advanced by applyTransaction below; every exit that doesn't
+        // reach success() must restore it, or later validations run against a
+        // state the channel never agreed on (e.g. a rotated-past turn index).
+        let stateBeforeTransitionValidation: Bytes | undefined;
+        let restoreReason = "aborted before success";
 
         try {
             await this.mutex.lock({ taskName: "onBlockConfirmation" });
@@ -1096,18 +1196,12 @@ class StateManager<
             strategy =
                 options?.validationStrategy ||
                 this.getStrategyByStatus(this.status);
-            block = Block.fromBlockConfirmation(
-                blockConfirmation,
-                options?.onChainTimestamp
-            );
+            block = entry.block;
 
             if (this.storage.blocks.getBlock(block.hash)) {
                 this.blockQueueManager.scheduleStoredBlockConfirmationMerge(
-                    block,
-                    strategy,
-                    options?.senderAddress
-                        ? [options.senderAddress as Address]
-                        : []
+                    entry,
+                    strategy
                 );
                 return true;
             }
@@ -1115,12 +1209,14 @@ class StateManager<
             let validationResult: BlockValidationResult =
                 BlockValidationResult.SUCCESS;
 
-            const isAuthentic =
-                await this.isBlockConfirmationAuthentic(blockConfirmation);
+            const isAuthentic = await this.isBlockConfirmationAuthentic(
+                block.blockConfirmationStruct
+            );
 
             if (!isAuthentic) {
-                validationResult =
-                    await strategy.authenticateBlockFailed(blockConfirmation);
+                validationResult = await strategy.authenticateBlockFailed(
+                    block.blockConfirmationStruct
+                );
 
                 this.logger.warn(
                     "onBlockConfirmation - authentication failed",
@@ -1141,9 +1237,8 @@ class StateManager<
 
             validationResult =
                 await this.validationService.validateBlockConfirmation(
-                    block,
-                    strategy,
-                    options?.senderAddress
+                    entry,
+                    strategy
                 );
 
             if (validationResult !== BlockValidationResult.SUCCESS) {
@@ -1222,7 +1317,7 @@ class StateManager<
                 return keepConnection;
             }
 
-            const stateBeforeTransitionValidation =
+            stateBeforeTransitionValidation =
                 await this.diamondStateMachine.getState();
 
             const {
@@ -1234,12 +1329,7 @@ class StateManager<
             } = await this.applyTransaction(block.tx);
 
             if (!success) {
-                await this.restoreStateAfterFailedValidation(
-                    stateBeforeTransitionValidation,
-                    "state transition failed",
-                    block
-                );
-
+                restoreReason = "state transition failed";
                 validationResult =
                     await strategy.invalidStateTransitionDetected(block);
                 this.logger.warn(
@@ -1283,12 +1373,7 @@ class StateManager<
                 );
 
             if (stateSnapshot.hash !== block.stateSnapshotHash) {
-                await this.restoreStateAfterFailedValidation(
-                    stateBeforeTransitionValidation,
-                    "state snapshot hash mismatch",
-                    block
-                );
-
+                restoreReason = "state snapshot hash mismatch";
                 validationResult =
                     await strategy.invalidStateTransitionDetected(block);
                 this.logger.warn(
@@ -1328,14 +1413,13 @@ class StateManager<
                         )
                     )
                 );
-                this.blockQueueManager.disconnectPeersForSignatures(
-                    block.hash,
+                restoreReason = "signers not in participant union";
+                validationResult = await strategy.notAllSingersAreParticipants(
+                    entry,
                     unexpectedSignatures
                 );
-                validationResult =
-                    await strategy.notAllSingersAreParticipants(block);
                 this.logger.warn(
-                    "onBlockConfirmation - signer not in previous/resulting participant union",
+                    "onBlockConfirmation - signers outside the participant union",
                     {
                         strategy: strategy.name,
                         validationResult:
@@ -1344,15 +1428,20 @@ class StateManager<
                             block,
                             this.storage
                         ),
+                        author: block.signerAddress,
                         unexpectedSigners: Array.from(unexpectedSigners),
                         allowedSigners: Array.from(allowedSigners)
                     }
                 );
-                keepConnection =
-                    await strategy.interpretFinalValidationResult(
-                        validationResult
-                    );
-                return keepConnection;
+                if (validationResult !== BlockValidationResult.SUCCESS) {
+                    keepConnection =
+                        await strategy.interpretFinalValidationResult(
+                            validationResult
+                        );
+                    return keepConnection;
+                }
+                // SUCCESS: the strategy stripped the stray signatures and cut
+                // their byzantine senders — continue with the valid ones.
             }
 
             // TODO - apply strategy here too
@@ -1377,6 +1466,8 @@ class StateManager<
                 }
             );
             keepConnection = true;
+            // The VM keeps the advanced state from here on.
+            stateBeforeTransitionValidation = undefined;
             return keepConnection;
         } catch (error) {
             this.logger.error("onBlockConfirmation - error", {
@@ -1388,6 +1479,16 @@ class StateManager<
             });
             throw error;
         } finally {
+            // Any exit that advanced the VM without reaching success() —
+            // validation aborts and thrown errors alike — must revert it before
+            // the mutex frees the next task to run against the dirty state.
+            if (stateBeforeTransitionValidation !== undefined) {
+                await this.restoreStateAfterFailedValidation(
+                    stateBeforeTransitionValidation,
+                    restoreReason,
+                    block
+                );
+            }
             this.mutex.unlock({ scheduleNextAsMacroTask: true });
             // try signaling blocks in the queue (in case this block enabled them to be validated)
             this.timeoutManager.scheduleTask(
@@ -1687,7 +1788,10 @@ class StateManager<
         forkId: ForkId
     ): Promise<StateSnapshot | undefined> {
         const forkData = await this.prepareUpdateStateSnapshotFork();
-        const sameForkData = await this.prepareUpdateSnapshotSameFork(forkId);
+        const sameForkData = await this.prepareUpdateSnapshotSameFork(
+            forkId,
+            forkData?.expectedSnapshot
+        );
 
         const expectedSnapshot =
             sameForkData?.expectedSnapshot ??
@@ -1804,7 +1908,10 @@ class StateManager<
     /**
      * Prepares data for updating the state snapshot when the fork is the same
      */
-    public async prepareUpdateSnapshotSameFork(forkId: ForkId): Promise<
+    public async prepareUpdateSnapshotSameFork(
+        forkId: ForkId,
+        baseSnapshot?: StateSnapshot
+    ): Promise<
         | {
               callData: string[];
               expectedSnapshot: StateSnapshot;
@@ -1815,11 +1922,17 @@ class StateManager<
         | undefined
     > {
         try {
-            const currentOnChainSnapshot = StateSnapshot.from(
-                await this.diamondStateMachine.localDiamondContract.getStateSnapshot(
-                    this.channelId
-                )
-            );
+            // `baseSnapshot` is the snapshot that will be on-chain when this
+            // calldata executes - in a multicall the fork update lands first,
+            // so the same-fork update chains onto its expected result rather
+            // than the raw current on-chain snapshot.
+            const currentOnChainSnapshot =
+                baseSnapshot ??
+                StateSnapshot.from(
+                    await this.diamondStateMachine.localDiamondContract.getStateSnapshot(
+                        this.channelId
+                    )
+                );
 
             if (!currentOnChainSnapshot) {
                 return undefined;
@@ -1877,11 +1990,19 @@ class StateManager<
                 return undefined;
             }
 
-            // Verify that both snapshots belong to the same fork
+            // A same-fork update only applies within one fork. Local state
+            // being on a newer fork than the chain is the normal design (the
+            // local reduction always lands before its on-chain commit) - not
+            // applicable now, retried once the chain catches up.
             if (currentOnChainSnapshot.forkID !== latestSnapshot.forkID) {
-                throw new Error(
-                    `Fork mismatch: current fork ${currentOnChainSnapshot.forkID}, new fork ${latestSnapshot.forkID}`
+                this.logger.debug(
+                    "prepareUpdateSnapshotSameFork - base and latest snapshot on different forks, skipping",
+                    {
+                        baseForkId: currentOnChainSnapshot.forkID,
+                        latestForkId: latestSnapshot.forkID
+                    }
                 );
+                return undefined;
             }
 
             const currentOnChainExitBlockHash =
@@ -2970,7 +3091,15 @@ class StateManager<
                 await this.maybeInitiateForceJoinDispute(block, participants);
             }
         }
-        // step 1 - add my signature if appropriate
+        // step 1 - persist the state snapshot + state machine state first:
+        // shouldSignBlock reads the resulting participants from storage
+        this.storage.stateSnapshots.storeStateSnapshot(stateSnapshot);
+        this.storage.stateMachineStates.storeStateMachineState(
+            encodedStateMachineState,
+            { hash: stateSnapshot.stateMachineStateHash }
+        );
+
+        // step 2 - add my signature if appropriate
         if (
             (await this.shouldSignBlock(block)) &&
             !(options?.strategy instanceof DisputeValidationStrategy)
@@ -2983,7 +3112,7 @@ class StateManager<
             block.expandSignatures([signature]);
         }
 
-        // step 2 - persist the block // TODO - quick hack - cleaner code later
+        // step 3 - persist the block // TODO - quick hack - cleaner code later
         this.storage.blocks.storeBlock(block, {
             justPersist: options?.strategy instanceof DisputeValidationStrategy
         });
@@ -2993,15 +3122,6 @@ class StateManager<
             p2pEventHooks: this.p2pEventHooks,
             logger: this.logger
         });
-
-        // step 3 - persist the state snapshot
-        this.storage.stateSnapshots.storeStateSnapshot(stateSnapshot);
-
-        // step 4 - persist state machine state
-        this.storage.stateMachineStates.storeStateMachineState(
-            encodedStateMachineState,
-            { hash: stateSnapshot.stateMachineStateHash }
-        );
 
         // step 5 - persist the outbound message blocks if any
         if (options?.outboundMessageBlock) {
@@ -3087,6 +3207,18 @@ class StateManager<
     public async shouldSignBlock(block: Block): Promise<boolean> {
         if (this.p2pManager.isBlacklisted(block.author)) return false;
         if (this.status !== Status.PARTICIPATING) return false;
+        // Sign only blocks whose previous/resulting participant union contains
+        // us (e.g. never after leaving the channel). The resulting snapshot is
+        // persisted before signing, so a missing union means "don't sign".
+        const signerUnion = new Set<Address>(
+            this.storage.getParticipantsUnion(
+                block.coordinates,
+                block.stateSnapshotHash
+            )
+        );
+        if (!signerUnion.has(this.signerAddress)) {
+            return false;
+        }
         // Check if the block is posted on-chain and I am the next to write
         if (block.onChainTimestamp !== undefined) {
             const nextToWrite = await this.diamondStateMachine.getNextToWrite();

--- a/src/stateManager/ValidationService.ts
+++ b/src/stateManager/ValidationService.ts
@@ -4,6 +4,7 @@ import { ZeroHash } from "ethers";
 import ADiamondStateMachine from "@/ADiamondStateMachine";
 import Clock from "@/Clock";
 import Storage from "@/storage";
+import type { QueuedBlockEntry } from "@/storage/QueueStorage";
 import { Block, StateSnapshot } from "@/models";
 import { Logger } from "@/utils";
 import { BlockValidationResult, OnChainBlockStatus, TimeConfig } from "@/types";
@@ -44,10 +45,10 @@ export default class ValidationService {
     }
 
     async validateBlockConfirmation(
-        block: Block,
-        strategy: AValidationStrategy,
-        senderAddress?: string
+        entry: QueuedBlockEntry,
+        strategy: AValidationStrategy
     ): Promise<BlockValidationResult> {
+        const block = entry.block;
         // Check is correct channel
         if (
             !this.stateManager.channelId ||
@@ -69,7 +70,7 @@ export default class ValidationService {
                 stateManagerForkId: String(this.stateManager.forkId),
                 block: LoggerUtils.getBlockMetadata(block, this.storage)
             });
-            return await strategy.channelNotOpened(block);
+            return await strategy.channelNotOpened(entry);
         }
 
         //  Get participants
@@ -112,7 +113,7 @@ export default class ValidationService {
                 strategy: strategy.name,
                 block: LoggerUtils.getBlockMetadata(block, this.storage)
             });
-            return await strategy.blockForkIsDisputed(block, senderAddress);
+            return await strategy.blockForkIsDisputed(entry);
         }
 
         // isNext
@@ -132,10 +133,7 @@ export default class ValidationService {
                     block: LoggerUtils.getBlockMetadata(block, this.storage)
                 }
             );
-            return await strategy.blockIsNotNextAndIsInTheFuture(
-                block,
-                senderAddress
-            );
+            return await strategy.blockIsNotNextAndIsInTheFuture(entry);
         }
 
         // Is linked

--- a/src/stateManager/validationStrategy/AValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/AValidationStrategy.ts
@@ -1,9 +1,10 @@
 import { Block } from "@/models";
-import { BlockValidationResult } from "@/types";
+import { BlockValidationResult, Signature } from "@/types";
 import {
     BlockConfirmationStruct,
     MessageBlockStruct
 } from "@typechain-types/contracts/V1/types/DataTypes";
+import type { QueuedBlockEntry } from "@/storage/QueueStorage";
 
 export default abstract class AValidationStrategy {
     public get name(): string {
@@ -21,11 +22,21 @@ export default abstract class AValidationStrategy {
     public abstract wrongChannel(block: Block): Promise<BlockValidationResult>;
 
     public abstract channelNotOpened(
-        block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult>;
 
+    /**
+     * Signatures on the block recover to addresses outside the block's
+     * previous/resulting participant union. The strategy owns the side effects
+     * (filtering, disconnecting the byzantine senders, fraud proofs); SUCCESS
+     * means the block should continue through the pipeline with the stray
+     * signatures removed. The suppliers of the stray signatures resolve from
+     * the entry's signature -> source map. Signers are derivable O(1) via
+     * `entry.block.signatureToAddress` (cached).
+     */
     public abstract notAllSingersAreParticipants(
-        block: Block
+        entry: QueuedBlockEntry,
+        unexpectedSignatures: Set<Signature>
     ): Promise<BlockValidationResult>;
 
     public abstract noNewSignaturesOnExistingBlock(
@@ -63,13 +74,11 @@ export default abstract class AValidationStrategy {
     ): Promise<BlockValidationResult>;
 
     public abstract blockForkIsDisputed(
-        block: Block,
-        senderAddress?: string
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult>;
 
     public abstract blockIsNotNextAndIsInTheFuture(
-        block: Block,
-        senderAddress?: string
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult>;
 
     public abstract blockIsNotLinkedAndIsNotFirstBlock(

--- a/src/stateManager/validationStrategy/BlockValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/BlockValidationStrategy.ts
@@ -1,13 +1,15 @@
 import { Block } from "@/models";
-import { BlockValidationResult } from "@/types";
+import { BlockValidationResult, Signature } from "@/types";
 import {
     BlockConfirmationStruct,
     MessageBlockStruct
 } from "@typechain-types/contracts/V1/types/DataTypes";
 import AValidationStrategy from "./AValidationStrategy";
+import type { QueuedBlockEntry } from "@/storage/QueueStorage";
 import FraudProofService from "../utils/FraudProofService";
 import Storage from "@/storage";
 import type P2PManager from "@/P2PManager";
+import type BlockQueueManager from "../BlockQueueManager";
 import DisputeManager from "@/disputeManager";
 import { Logger } from "@/utils";
 
@@ -18,6 +20,7 @@ export default class BlockValidationStrategy extends AValidationStrategy {
         private readonly storage: Storage,
         private readonly p2pManager: P2PManager,
         private readonly disputeManager: DisputeManager,
+        private readonly blockQueueManager: BlockQueueManager,
         logger: Logger
     ) {
         super();
@@ -63,16 +66,39 @@ export default class BlockValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.DISCONNECT;
     }
     public async channelNotOpened(
-        block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         // not ready
-        this.storage.queues.queueBlock(block);
+        this.storage.queues.restoreEntry(entry);
         return BlockValidationResult.NOT_READY;
     }
     public async notAllSingersAreParticipants(
-        _block: Block
+        entry: QueuedBlockEntry,
+        unexpectedSignatures: Set<Signature>
     ): Promise<BlockValidationResult> {
-        return BlockValidationResult.DISCONNECT;
+        const block = entry.block;
+        // Punish the offenders: the transports that supplied the stray
+        // signatures (byzantine — honest peers strip strays before
+        // re-gossiping), resolved from the entry's signature -> source map.
+        this.blockQueueManager.disconnectPeersForSignatures(
+            entry,
+            unexpectedSignatures
+        );
+        if (unexpectedSignatures.has(block.originalSignature)) {
+            // An author outside the union is not a channel member, so there is
+            // nobody to slash — no fraud proof/dispute. Blacklist the signers
+            // of the garbage block and discard it.
+            for (const signature of unexpectedSignatures) {
+                this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(
+                    block.signatureToAddress(signature)
+                );
+            }
+            return BlockValidationResult.DISCONNECT;
+        }
+        // The block itself validated; stray confirmation signatures must not
+        // delay or invalidate it.
+        block.removeConfirmationSignatures(unexpectedSignatures);
+        return BlockValidationResult.SUCCESS;
     }
     public async noNewSignaturesOnExistingBlock(
         _block: Block
@@ -149,41 +175,49 @@ export default class BlockValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.DISCONNECT;
     }
     public async blockForkIsDisputed(
-        block: Block,
-        senderAddress?: string
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
-        // If we know who sent this, and they already acknowledged the dispute,
-        // disconnect/blacklist them for building on a disputed fork.
+        const block = entry.block;
+        // Suppliers that already acknowledged the dispute knowingly built on
+        // a dead fork - disconnect/blacklist them.
+        let acknowledgedCount = 0;
+        for (const peer of entry.sourcePeers) {
+            if (
+                this.p2pManager.localRpc.isForkDisputedService.didPeerAcknowledgeDisputedFork(
+                    peer as string,
+                    block.forkId
+                )
+            ) {
+                acknowledgedCount++;
+                this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(peer);
+            }
+        }
         if (
-            senderAddress &&
-            this.p2pManager.localRpc.isForkDisputedService.didPeerAcknowledgeDisputedFork(
-                senderAddress,
-                block.forkId
-            )
+            entry.sourcePeers.size > 0 &&
+            acknowledgedCount === entry.sourcePeers.size
         ) {
-            this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(
-                senderAddress
-            );
+            // Every supplier was byzantine - nothing honest to wait for.
             return BlockValidationResult.DISCONNECT;
         }
 
         // Queue the block - will process normally
-        this.storage.queues.queueBlock(block);
+        this.storage.queues.restoreEntry(entry);
         return BlockValidationResult.NOT_READY;
     }
     public async blockIsNotNextAndIsInTheFuture(
-        block: Block,
-        senderAddress?: string
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
-        // not ready
-        if (senderAddress)
+        const block = entry.block;
+        // not ready - ask the peers that supplied this block to sync us up
+        for (const peer of entry.sourcePeers) {
             this.p2pManager.localRpc.spectateService.sync(
-                senderAddress,
+                peer as string,
                 block.channelId,
                 block.forkId,
                 block.height
             );
-        this.storage.queues.queueBlock(block);
+        }
+        this.storage.queues.restoreEntry(entry);
         return BlockValidationResult.NOT_READY;
     }
     public async blockIsNotLinkedAndIsNotFirstBlock(

--- a/src/stateManager/validationStrategy/CalldataCommittedStrategy.ts
+++ b/src/stateManager/validationStrategy/CalldataCommittedStrategy.ts
@@ -1,10 +1,11 @@
 import { Block } from "@/models";
-import { BlockValidationResult } from "@/types";
+import { BlockValidationResult, Signature } from "@/types";
 import {
     BlockConfirmationStruct,
     MessageBlockStruct
 } from "@typechain-types/contracts/V1/types/DataTypes";
 import AValidationStrategy from "./AValidationStrategy";
+import type { QueuedBlockEntry } from "@/storage/QueueStorage";
 import DisputeManager from "@/disputeManager";
 import BlockValidationStrategy from "./BlockValidationStrategy";
 
@@ -36,14 +37,17 @@ export default class CalldataCommittedStrategy extends AValidationStrategy {
         );
     }
     public async channelNotOpened(
-        block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         // not ready
-        return this.blockValidationStrategy.channelNotOpened(block);
+        return this.blockValidationStrategy.channelNotOpened(entry);
     }
     public async notAllSingersAreParticipants(
-        _block: Block
+        _entry: QueuedBlockEntry,
+        _unexpectedSignatures: Set<Signature>
     ): Promise<BlockValidationResult> {
+        // Calldata confirmations carry only the author's signature, and the
+        // author was already authenticated against the chain event.
         throw new Error(
             "CalldataCommittedStrategy - notAllSingersAreParticipants should not be relevant/called"
         );
@@ -108,21 +112,15 @@ export default class CalldataCommittedStrategy extends AValidationStrategy {
         );
     }
     public async blockForkIsDisputed(
-        block: Block,
-        senderAddress?: string
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
-        return this.blockValidationStrategy.blockForkIsDisputed(
-            block,
-            senderAddress
-        );
+        return this.blockValidationStrategy.blockForkIsDisputed(entry);
     }
     public async blockIsNotNextAndIsInTheFuture(
-        block: Block,
-        senderAddress?: string
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         return this.blockValidationStrategy.blockIsNotNextAndIsInTheFuture(
-            block,
-            senderAddress
+            entry
         );
     }
     public async blockIsNotLinkedAndIsNotFirstBlock(

--- a/src/stateManager/validationStrategy/DisputeValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/DisputeValidationStrategy.ts
@@ -1,8 +1,9 @@
 import { Block } from "@/models";
-import { BlockValidationResult, Hash } from "@/types";
+import { BlockValidationResult, Hash, Signature } from "@/types";
 import { DisputeStruct } from "@typechain-types/contracts/V1/types/DisputeTypes";
 
 import AValidationStrategy from "./AValidationStrategy";
+import type { QueuedBlockEntry } from "@/storage/QueueStorage";
 import FraudProofService from "../utils/FraudProofService";
 import Storage from "@/storage";
 import DisputeFraudProofService from "../utils/DisputeFraudProofService";
@@ -85,17 +86,24 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.DISCONNECT;
     }
     public async channelNotOpened(
-        _block: Block
+        _entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         return BlockValidationResult.DISCONNECT;
     }
     public async notAllSingersAreParticipants(
-        _block: Block
+        entry: QueuedBlockEntry,
+        unexpectedSignatures: Set<Signature>
     ): Promise<BlockValidationResult> {
-        /**
-         * StateProof milestones check and require that signers are participants so this should never fail there.
-         * This can be called only if stateProof.signedBlocks are not from participants, in which case we'll let this pipeline continue and fail on the STF since only a participant can autor a block
-         */
+        const block = entry.block;
+        if (unexpectedSignatures.has(block.originalSignature)) {
+            // The outsider author can't be slashed, but the dispute submitter
+            // (a union member) packaged this block into the stateProof — kill
+            // the dispute with evidence against the submitter. No transport
+            // punishment: these blocks are replayed from a proof, not gossiped.
+            return this.invalidStateTransitionDetected(block);
+        }
+        // Stray confirmation signatures don't invalidate the replayed block.
+        block.removeConfirmationSignatures(unexpectedSignatures);
         return BlockValidationResult.SUCCESS;
     }
     public async noNewSignaturesOnExistingBlock(
@@ -164,15 +172,13 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
         return this.blockIsNotLinkedAndIsNotFirstBlock(block);
     }
     public async blockForkIsDisputed(
-        _block: Block,
-        _senderAddress?: string
+        _entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         // continue syncing
         return BlockValidationResult.SUCCESS;
     }
     public async blockIsNotNextAndIsInTheFuture(
-        _block: Block,
-        _senderAddress?: string
+        _entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         return BlockValidationResult.DISCONNECT;
     }

--- a/src/stateManager/validationStrategy/SpectatingValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/SpectatingValidationStrategy.ts
@@ -1,13 +1,15 @@
 import { Block } from "@/models";
-import { BlockValidationResult } from "@/types";
+import { BlockValidationResult, Signature } from "@/types";
 import {
     BlockConfirmationStruct,
     MessageBlockStruct
 } from "@typechain-types/contracts/V1/types/DataTypes";
 import AValidationStrategy from "./AValidationStrategy";
+import type { QueuedBlockEntry } from "@/storage/QueueStorage";
 import FraudProofService from "../utils/FraudProofService";
 import Storage from "@/storage";
 import type P2PManager from "@/P2PManager";
+import type BlockQueueManager from "../BlockQueueManager";
 import { Logger } from "@/utils";
 
 export default class SpectatingValidationStrategy extends AValidationStrategy {
@@ -16,6 +18,7 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
     constructor(
         private readonly storage: Storage,
         private readonly p2pManager: P2PManager,
+        private readonly blockQueueManager: BlockQueueManager,
         logger: Logger
     ) {
         super();
@@ -63,17 +66,31 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.DISCONNECT;
     }
     public async channelNotOpened(
-        block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         // not ready
-        this.storage.queues.queueBlock(block);
+        this.storage.queues.restoreEntry(entry);
         return BlockValidationResult.NOT_READY;
     }
     public async notAllSingersAreParticipants(
-        _block: Block
+        entry: QueuedBlockEntry,
+        unexpectedSignatures: Set<Signature>
     ): Promise<BlockValidationResult> {
-        this.disconnect();
-        return BlockValidationResult.DISCONNECT;
+        const block = entry.block;
+        // The peers that supplied stray signatures are byzantine — cut them,
+        // resolved from the entry's signature -> source map.
+        this.blockQueueManager.disconnectPeersForSignatures(
+            entry,
+            unexpectedSignatures
+        );
+        if (unexpectedSignatures.has(block.originalSignature)) {
+            // Garbage author — stop spectating this feed.
+            this.disconnect();
+            return BlockValidationResult.DISCONNECT;
+        }
+        // Stray confirmation signatures don't invalidate an otherwise valid block.
+        block.removeConfirmationSignatures(unexpectedSignatures);
+        return BlockValidationResult.SUCCESS;
     }
     public async noNewSignaturesOnExistingBlock(
         _block: Block
@@ -129,25 +146,26 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.DISCONNECT;
     }
     public async blockForkIsDisputed(
-        block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         // not ready
-        this.storage.queues.queueBlock(block);
+        this.storage.queues.restoreEntry(entry);
         return BlockValidationResult.NOT_READY;
     }
     public async blockIsNotNextAndIsInTheFuture(
-        block: Block,
-        senderAddress?: string
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
-        // not ready
-        if (senderAddress)
+        const block = entry.block;
+        // not ready - ask the peers that supplied this block to sync us up
+        for (const peer of entry.sourcePeers) {
             this.p2pManager.localRpc.spectateService.sync(
-                senderAddress,
+                peer as string,
                 block.channelId,
                 block.forkId,
                 block.height
             );
-        this.storage.queues.queueBlock(block);
+        }
+        this.storage.queues.restoreEntry(entry);
         return BlockValidationResult.NOT_READY;
     }
     public async blockIsNotLinkedAndIsNotFirstBlock(

--- a/src/storage/QueueStorage.ts
+++ b/src/storage/QueueStorage.ts
@@ -19,28 +19,41 @@ export class QueueStorage {
     // Secondary index for efficient queries by coordinates
     private blocksByCoordinates: Map<string, Set<Hash>> = new Map();
 
+    /**
+     * Build a standalone entry for a block copy — the unit of work the
+     * pipeline consumes. Same construction the queue uses, without queueing.
+     */
+    createEntry(block: Block, options?: QueueBlockOptions): QueuedBlockEntry {
+        const entry: QueuedBlockEntry = {
+            block,
+            firstSeenAt: Clock.getTimeInSeconds(),
+            sourcePeers: new Set(),
+            signatureSources: new Map()
+        };
+        this.trackSource(entry, block.allSignatures, options?.senderAddress);
+        return entry;
+    }
+
     /** Queue a block for future processing */
     queueBlock(block: Block, options?: QueueBlockOptions): Hash {
-        const now = Clock.getTimeInSeconds();
-
         // Check if block already exists in queue
         const existingEntry = this.queuedBlocks.get(block.hash);
 
         if (existingEntry) {
+            // Attribute only the signatures this copy carried to its sender,
+            // never signatures pooled from earlier copies.
+            this.trackSource(
+                existingEntry,
+                block.allSignatures,
+                options?.senderAddress
+            );
             existingEntry.block.expandSignatures(block.confirmationSignatures);
             this.mergeOnChainTimestamp(existingEntry.block, block);
-            this.trackSource(existingEntry, block, options?.senderAddress);
             this.queuedBlocks.set(block.hash, existingEntry);
             return block.hash;
         }
 
-        const entry: QueuedBlockEntry = {
-            block,
-            firstSeenAt: now,
-            sourcePeers: new Set(),
-            signatureSources: new Map()
-        };
-        this.trackSource(entry, block, options?.senderAddress);
+        const entry = this.createEntry(block, options);
 
         // Store the new block confirmation
         this.queuedBlocks.set(block.hash, entry);
@@ -107,13 +120,35 @@ export class QueueStorage {
         return this.queuedBlocks.get(blockHash);
     }
 
-    getSignatureSources(
-        blockHash: Hash,
-        signature: Signature
-    ): Set<Address> | undefined {
-        return this.queuedBlocks
-            .get(blockHash)
-            ?.signatureSources.get(signature);
+    /**
+     * Re-insert a previously dequeued entry, merging its signatures and
+     * source attribution into any entry queued for the same block meanwhile.
+     */
+    restoreEntry(entry: QueuedBlockEntry): void {
+        const existing = this.queuedBlocks.get(entry.block.hash);
+        if (!existing) {
+            this.queuedBlocks.set(entry.block.hash, entry);
+            this.addHashToCoordinateIndex(
+                entry.block.hash,
+                entry.block.forkId,
+                entry.block.height
+            );
+            return;
+        }
+
+        existing.block.expandSignatures(entry.block.confirmationSignatures);
+        this.mergeOnChainTimestamp(existing.block, entry.block);
+        existing.firstSeenAt = Math.min(
+            existing.firstSeenAt,
+            entry.firstSeenAt
+        );
+        for (const peer of entry.sourcePeers) existing.sourcePeers.add(peer);
+        for (const [signature, peers] of entry.signatureSources) {
+            const merged =
+                existing.signatureSources.get(signature) ?? new Set();
+            for (const peer of peers) merged.add(peer);
+            existing.signatureSources.set(signature, merged);
+        }
     }
 
     removeBlock(blockHash: Hash): QueuedBlockEntry | undefined {
@@ -185,13 +220,13 @@ export class QueueStorage {
 
     private trackSource(
         entry: QueuedBlockEntry,
-        block: Block,
+        signatures: Iterable<Signature>,
         senderAddress?: Address
     ): void {
         if (!senderAddress) return;
 
         entry.sourcePeers.add(senderAddress);
-        for (const signature of block.allSignatures) {
+        for (const signature of signatures) {
             const peers = entry.signatureSources.get(signature) ?? new Set();
             peers.add(senderAddress);
             entry.signatureSources.set(signature, peers);

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -120,6 +120,25 @@ Don't add `as unknown as` at call sites to reach control services — route thro
 - Inline vs worker is `RUN_SDK_IN_THREAD`. Worker mode derives each peer's
   `signerSecret` from the hardhat mnemonic so the host thread can sign.
 
+## Unit tests
+
+- **Unit tests use the same harness framework — no mocks, no junk data.** The
+  framework isn't e2e-only: teleport a real session to the scenario you need
+  (spin up peers, advance/sync to the target state), then exercise the one
+  component under test host-side (`execOnHost` / a control service) with all
+  of its real collaborators wired. Same machinery as e2e, unit-test scope.
+- Components with collaborators (e.g. `BlockQueueManager` needs a live
+  `StateManager`) are tested exactly this way — never by stubbing the
+  collaborators.
+- **Fixtures trigger src code, they never reimplement it.** A side effect a
+  test asserts (disconnect, blacklist, fraud proof, …) must be produced by
+  the real source path — e.g. send over the real RPC so the receiver's entry
+  point runs — not mirrored inside a harness endpoint.
+- Pure data structures (`QueueStorage`, `Block`, codecs) can skip the session
+  and be exercised directly — but still with real domain objects built via
+  `test/factory.ts` and real identities via ethers wallets, never placeholder
+  data that couldn't decode/verify in production.
+
 ## Running tests
 
 - Typecheck: `yarn tsc --noEmit -p tsconfig.json` (the `TestPeer`/control surface

--- a/test/e2e/E2E-BlockQueueManager.test.ts
+++ b/test/e2e/E2E-BlockQueueManager.test.ts
@@ -1,0 +1,288 @@
+import { expect } from "chai";
+import { ethers } from "ethers";
+import { Codec, Type } from "@/utils";
+import { MathTestSession as TestSession } from "@test/harness";
+import { waitFor } from "@test/utils/waitFor";
+import * as factory from "@test/factory";
+import type { Address } from "@/types/types";
+
+/**
+ * Unit-scope harness tests for BlockQueueManager's ingest guards and the
+ * queue-timeout stored-merge branch. Real sessions, real blocks, real
+ * signatures — the component is poked host-side through the control RPC.
+ */
+
+describe("E2E: BlockQueueManager", function () {
+    it("ingest rejects a block confirmation with a forged author signature", async function () {
+        this.timeout(90000);
+
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(3, 1);
+
+        const forkId = h.activeForkId;
+        expect(forkId).to.not.be.undefined;
+
+        const observer = h.getPeer(0);
+        const bundle = await h
+            .control(observer)
+            .query.getLatestBlockBundle(forkId!)
+            .request();
+        expect(bundle).to.not.be.null;
+
+        // Same block bytes, but the author signature recovers to an outsider
+        // instead of header.participant — authentication must fail.
+        const signedBlock = Codec.decode(
+            bundle!.encodedSignedBlock,
+            Type.SignedBlock
+        );
+        const outsider = ethers.Wallet.createRandom();
+        const forgedSignature = await outsider.signMessage(
+            ethers.getBytes(bundle!.hash)
+        );
+
+        await h.transition.ingestBlockConfirmationWait({
+            peerIndex: observer.index,
+            blockConfirmation: {
+                signedBlock: {
+                    encodedBlock: signedBlock.encodedBlock,
+                    signature: forgedSignature
+                },
+                signatures: []
+            },
+            keepConnection: false
+        });
+    });
+
+    it("ingest drops a wrong-channel block and cuts the transport when the sender is known", async function () {
+        this.timeout(90000);
+
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(3, 0);
+
+        const observer = h.getPeer(0);
+
+        // An authentic block (author signature recovers to header.participant)
+        // for a channel this peer is not in.
+        const outsider = ethers.Wallet.createRandom();
+        const foreignBlock = factory.block({
+            transaction: factory.transaction({
+                header: factory.transactionHeader({
+                    channelId: ethers.hexlify(ethers.randomBytes(32)),
+                    participant: outsider.address as Address
+                })
+            })
+        });
+        const blockConfirmation = {
+            signedBlock: {
+                encodedBlock: foreignBlock.encode(),
+                signature: await outsider.signMessage(
+                    ethers.getBytes(foreignBlock.hash)
+                )
+            },
+            signatures: []
+        };
+
+        // Without a known sender the block is just ignored.
+        await h.transition.ingestBlockConfirmationWait({
+            peerIndex: observer.index,
+            blockConfirmation,
+            keepConnection: true,
+            waitForProcessed: false
+        });
+
+        // Sent over the real state-transition RPC, the observer rejects it
+        // and cuts + blacklists the sending transport.
+        const sender = h.getPeer(1);
+        expect(
+            await h
+                .control(observer)
+                .query.isBlacklisted(sender.address)
+                .request()
+        ).to.equal(false);
+        await h
+            .control(sender)
+            .byzantine.sendBlockConfirmation(
+                Codec.encode(
+                    blockConfirmation,
+                    Type.BlockConfirmation
+                ) as string,
+                observer.address
+            )
+            .request();
+
+        await waitFor(
+            async () =>
+                await h
+                    .control(observer)
+                    .query.isBlacklisted(sender.address)
+                    .request(),
+            5000
+        );
+        expect(
+            await h
+                .control(observer)
+                .query.getBlockByHash(foreignBlock.hash)
+                .request()
+        ).to.be.null;
+    });
+
+    it("future block is evicted at queue timeout without punishing the supplier", async function () {
+        this.timeout(90000);
+
+        const h = TestSession.getHarness();
+        const timeConfig = {
+            p2pTime: 3,
+            agreementTime: 2,
+            chainFallbackTime: 30,
+            evidenceTime: 8
+        };
+        await h.lifecycle.start(4, 0, { timeConfig });
+
+        const forkId = h.activeForkId;
+        expect(forkId).to.not.be.undefined;
+
+        const observerIndex = 3;
+        const observer = h.getPeer(observerIndex);
+        await h.network.disconnectPeer(observerIndex);
+
+        await h.transition.advanceState({
+            count: 2,
+            waitForPeers: [0, 1, 2],
+            waitForFinalization: false
+        });
+
+        const source = await h.peerWithHighestBlock(forkId!);
+        const block1 = await h
+            .control(source)
+            .query.getBlockByHeight(forkId!, 1)
+            .request();
+        expect(block1).to.not.be.null;
+
+        // Future block (height 1 > observer's nextHeight 0) queues.
+        await h.transition.ingestBlockConfirmationWait({
+            peerIndex: observerIndex,
+            blockConfirmation: Codec.decode(
+                block1!.encodedBlockConfirmation,
+                Type.BlockConfirmation
+            ),
+            ingestOptions: { senderAddress: h.getPeer(1).address },
+            keepConnection: true,
+            waitForProcessed: false
+        });
+        expect(
+            await h
+                .control(observer)
+                .query.isBlockQueued(block1!.hash)
+                .request()
+        ).to.equal(true);
+
+        // Once the agreement window lapses the entry is evicted - gossip is
+        // free to forge, so unexecutable blocks must not accumulate.
+        await waitFor(
+            async () =>
+                !(await h
+                    .control(observer)
+                    .query.isBlockQueued(block1!.hash)
+                    .request()),
+            (timeConfig.agreementTime + 5) * 1000
+        );
+        expect(
+            await h
+                .control(observer)
+                .query.getBlockByHash(block1!.hash)
+                .request()
+        ).to.be.null;
+        // Eviction is hygiene, not punishment.
+        expect(
+            await h
+                .control(observer)
+                .query.isBlacklisted(h.getPeer(1).address)
+                .request()
+        ).to.equal(false);
+    });
+
+    it("queued entry that becomes stored merges at queue timeout: strays stripped, supplier blacklisted", async function () {
+        this.timeout(90000);
+
+        const h = TestSession.getHarness();
+        const timeConfig = {
+            p2pTime: 3,
+            agreementTime: 2,
+            chainFallbackTime: 30,
+            evidenceTime: 8
+        };
+        await h.lifecycle.start(4, 0, { timeConfig });
+
+        const forkId = h.activeForkId;
+        expect(forkId).to.not.be.undefined;
+
+        // Keep the observer blind so the block stays queued as a future block.
+        const observerIndex = 3;
+        const observer = h.getPeer(observerIndex);
+        await h.network.disconnectPeer(observerIndex);
+
+        await h.transition.advanceState({
+            count: 2,
+            waitForPeers: [0, 1, 2],
+            waitForFinalization: false
+        });
+
+        const source = await h.peerWithHighestBlock(forkId!);
+        const block1 = await h
+            .control(source)
+            .query.getBlockByHeight(forkId!, 1)
+            .request();
+        expect(block1).to.not.be.null;
+
+        // Tainted copy of h1 queues (height 1 > observer's nextHeight 0) with
+        // the stray signature attributed to its supplier.
+        const outsider = ethers.Wallet.createRandom();
+        const badSignature = await outsider.signMessage(
+            ethers.getBytes(block1!.hash)
+        );
+        await h.transition.ingestBlockConfirmationWait({
+            peerIndex: observerIndex,
+            blockConfirmation: {
+                signedBlock: Codec.decode(
+                    block1!.encodedSignedBlock,
+                    Type.SignedBlock
+                ),
+                signatures: [...block1!.confirmationSignatures, badSignature]
+            },
+            ingestOptions: { senderAddress: h.getPeer(1).address },
+            keepConnection: true,
+            waitForProcessed: false
+        });
+        expect(
+            await h
+                .control(observer)
+                .query.getBlockByHash(block1!.hash)
+                .request()
+        ).to.be.null;
+
+        // The block becomes stored out-of-band (as state-proof persistence
+        // does) while the entry still sits in the queue — the queue timeout
+        // must merge it immediately with the entry's attribution intact.
+        await h
+            .control(observer)
+            .transition.storeBlock(block1!.encodedBlockConfirmation)
+            .request();
+
+        await waitFor(
+            async () =>
+                await h
+                    .control(observer)
+                    .query.isBlacklisted(h.getPeer(1).address)
+                    .request(),
+            (timeConfig.agreementTime + 5) * 1000
+        );
+        const storedBlock = await h
+            .control(observer)
+            .query.getBlockByHash(block1!.hash)
+            .request();
+        expect(storedBlock).to.not.be.null;
+        expect(
+            storedBlock!.confirmationSignatures.includes(badSignature)
+        ).to.equal(false);
+    });
+});

--- a/test/e2e/E2E-FraudProofsBlockConfirmation.test.ts
+++ b/test/e2e/E2E-FraudProofsBlockConfirmation.test.ts
@@ -85,7 +85,9 @@ describe("E2E: Block Fraud Proofs", function () {
         ).to.be.null;
 
         // Posts the block's calldata on-chain via the author's signer (the SCM
-        // contract + signer are client-side, so this needs no host round-trip).
+        // contract + signer are client-side, so this needs no host round-trip)
+        // and returns the mined block's timestamp — what an event (re)read
+        // would deliver as onChainTimestamp.
         const postBlockCalldata = async (block: BlockBundle) => {
             const author = h.peers.find(
                 (peer) =>
@@ -99,11 +101,15 @@ describe("E2E: Block Fraud Proofs", function () {
                     Codec.decode(block.encodedSignedBlock, Type.SignedBlock),
                     Clock.getTimeInSeconds() + 1000
                 );
-            await tx.wait();
+            const receipt = await tx.wait();
+            const minedBlock = await author!.signer.provider!.getBlock(
+                receipt!.blockNumber
+            );
+            return Number(minedBlock!.timestamp);
         };
 
         h.event.resetEventSpies(observerIndex);
-        await postBlockCalldata(block2!);
+        const block2OnChainTimestamp = await postBlockCalldata(block2!);
         await h.event.waitUntilEventOccurs("onBlockCalldataPosted", 5000, [
             observerIndex
         ]);
@@ -116,6 +122,15 @@ describe("E2E: Block Fraud Proofs", function () {
 
         await sleep((timeConfig.agreementTime + 1) * 1000);
 
+        // The future calldata copy was evicted at the queue timeout — the
+        // chain still holds it, so nothing is lost.
+        expect(
+            await h
+                .control(observer)
+                .query.isBlockQueued(block2!.hash)
+                .request()
+        ).to.equal(false);
+
         // maybePostBlockOnChain is stubbed ()=>{} + after AgreementTime the subjective check each peer does would fail, so if the block is accepted -> calldata path
         await postBlockCalldata(block1!);
 
@@ -124,7 +139,24 @@ describe("E2E: Block Fraud Proofs", function () {
                 (await h
                     .control(observer)
                     .query.getBlockByHash(block1!.hash)
-                    .request()) !== null &&
+                    .request()) !== null,
+            5000
+        );
+
+        // Re-deliver block2 from the chain (as an event re-read would) — it
+        // is next now and applies through the calldata path.
+        await h.transition.ingestBlockConfirmationWait({
+            peerIndex: observerIndex,
+            blockConfirmation: Codec.decode(
+                block2!.encodedBlockConfirmation,
+                Type.BlockConfirmation
+            ),
+            ingestOptions: { onChainTimestamp: block2OnChainTimestamp },
+            keepConnection: true,
+            waitForProcessed: false
+        });
+        await waitFor(
+            async () =>
                 (await h
                     .control(observer)
                     .query.getBlockByHash(block2!.hash)
@@ -246,7 +278,7 @@ describe("E2E: Block Fraud Proofs", function () {
         ).to.equal(expectedTimestamp);
     });
 
-    it("stored duplicate rejects a new signature from a non-participant", async function () {
+    it("stored duplicate drops a new signature from a non-participant without dropping the block", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(3, 1);
 
@@ -275,15 +307,20 @@ describe("E2E: Block Fraud Proofs", function () {
             },
             ingestOptions: { senderAddress: h.getPeer(1).address },
             keepConnection: true,
-            processedKeepConnection: false
+            // The merge is a scheduled task and setup echoes of this block
+            // fire matching processed events, so waiting on the event races —
+            // poll for the strategy's outcome (sender blacklisted) instead.
+            waitForProcessed: false
         });
 
-        expect(
-            await h
-                .control(observer)
-                .query.isBlacklisted(h.getPeer(1).address)
-                .request()
-        ).to.equal(true);
+        await waitFor(
+            async () =>
+                await h
+                    .control(observer)
+                    .query.isBlacklisted(h.getPeer(1).address)
+                    .request(),
+            5000
+        );
         const storedBlock = await h
             .control(observer)
             .query.getBlockByHash(block!.hash)
@@ -291,6 +328,74 @@ describe("E2E: Block Fraud Proofs", function () {
         expect(
             storedBlock?.confirmationSignatures.includes(badSignature)
         ).to.equal(false);
+    });
+
+    it("fresh block with a non-participant signature applies after dropping it", async function () {
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(4, 0);
+
+        const forkId = h.activeForkId;
+        expect(forkId).to.not.be.undefined;
+
+        // Keep the observer blind to the next block so it can be hand-fed a
+        // tainted copy of it.
+        const observerIndex = 3;
+        const observer = h.getPeer(observerIndex);
+        await h.network.disconnectPeer(observerIndex);
+        const observerInitialSum = await observer.contractInstance.getSum();
+
+        await h.transition.advanceState({
+            count: 1,
+            waitForPeers: [0, 1, 2],
+            waitForFinalization: false
+        });
+
+        const source = await h.peerWithHighestBlock(forkId!);
+        const block = await h
+            .control(source)
+            .query.getBlockByHeight(forkId!, 0)
+            .request();
+        expect(block).to.not.be.null;
+
+        const outsider = ethers.Wallet.createRandom();
+        const badSignature = await outsider.signMessage(
+            ethers.getBytes(block!.hash)
+        );
+        await h.transition.ingestBlockConfirmationWait({
+            peerIndex: observerIndex,
+            blockConfirmation: {
+                signedBlock: Codec.decode(
+                    block!.encodedSignedBlock,
+                    Type.SignedBlock
+                ),
+                signatures: [...block!.confirmationSignatures, badSignature]
+            },
+            ingestOptions: { senderAddress: h.getPeer(1).address },
+            keepConnection: true,
+            // The block applies; the byzantine signature suppliers are
+            // disconnected+blacklisted by the strategy directly.
+            processedKeepConnection: true
+        });
+
+        // The block applied normally — stray signature dropped, not the block.
+        const storedBlock = await h
+            .control(observer)
+            .query.getBlockByHash(block!.hash)
+            .request();
+        expect(storedBlock).to.not.be.null;
+        expect(
+            storedBlock!.confirmationSignatures.includes(badSignature)
+        ).to.equal(false);
+        expect(await observer.contractInstance.getSum()).to.equal(
+            observerInitialSum + 1n
+        );
+        // The peer that supplied the stray signature is cut.
+        expect(
+            await h
+                .control(observer)
+                .query.isBlacklisted(h.getPeer(1).address)
+                .request()
+        ).to.equal(true);
     });
 
     it("double sign → BlockDoubleSign", async function () {
@@ -432,6 +537,12 @@ describe("E2E: Block Fraud Proofs", function () {
         // Peer 2 submits a block with a valid transaction but a wrong
         // stateSnapshotHash (ZeroHash).
         const maliciousPeerIndex = 2;
+        const honestPeers = h.peers.filter(
+            (p) => p.index !== maliciousPeerIndex
+        );
+        const honestSumsBefore = await Promise.all(
+            honestPeers.map((p) => p.contractInstance.getSum())
+        );
         await h.byzantine.submitInvalidStateTransitionBlock(maliciousPeerIndex);
 
         await h.assert.dispute.initiatedAndCommitedWait();
@@ -439,6 +550,15 @@ describe("E2E: Block Fraud Proofs", function () {
             fraudProofType: FraudProofType.BlockInvalidStateTransition,
             maliciousPeerIndex
         });
+
+        // The block's add() executed on honest VMs before the snapshot-hash
+        // check failed; the abort must have rolled the state back.
+        for (let i = 0; i < honestPeers.length; i++) {
+            expect(
+                await honestPeers[i].contractInstance.getSum(),
+                `Peer ${honestPeers[i].index} VM state not restored after rejected block`
+            ).to.equal(honestSumsBefore[i]);
+        }
 
         await h.assert.storage.storedDisputeConfirmationsWait();
 

--- a/test/e2e/E2E-ParticipantLifecycle.test.ts
+++ b/test/e2e/E2E-ParticipantLifecycle.test.ts
@@ -1,6 +1,9 @@
 import { MathTestSession as TestSession } from "@test/harness";
 import { expect } from "chai";
 import { Status } from "@/types";
+import { Block } from "@/models";
+import { Codec, Type } from "@/utils";
+import type { Address } from "@/types/types";
 
 /**
  * E2E Tests for Participant Lifecycle (Exit + Join)
@@ -36,6 +39,59 @@ describe("E2E: Participant Lifecycle", function () {
                     Status.PARTICIPATING,
                     `Peer ${p.index} should remain PARTICIPATING`
                 );
+            }
+        });
+
+        it("exiting participant does not sign blocks authored after its leave", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(4, 1);
+
+            // Detached: the leaver's process stays alive and connected while
+            // its exit completes, which is exactly when it must not keep
+            // signing (its signature is no longer in the participant union).
+            const leaverIndex = await h.transition.participantLeaveDetached();
+            const remaining = h.peers
+                .map((p) => p.index)
+                .filter((i) => i !== leaverIndex);
+
+            await h.transition.advanceState({
+                count: 1,
+                waitForPeers: remaining,
+                waitForFinalization: true
+            });
+
+            const forkId = h.activeForkId!;
+            const bundle = await h
+                .control(h.getPeer(remaining[0]))
+                .query.getLatestBlockBundle(forkId)
+                .request();
+            expect(bundle).to.not.be.null;
+
+            const block = Block.fromBlockConfirmation({
+                signedBlock: Codec.decode(
+                    bundle!.encodedSignedBlock,
+                    Type.SignedBlock
+                ),
+                signatures: bundle!.confirmationSignatures
+            });
+            const leaverAddress = h.getPeer(leaverIndex).address as Address;
+            expect(
+                block.allSignerAddresses.has(leaverAddress),
+                "leaver signed a post-leave block"
+            ).to.equal(false);
+
+            // And nobody got blacklisted over stray signatures in the process.
+            for (const i of remaining) {
+                for (const j of remaining) {
+                    if (i === j) continue;
+                    expect(
+                        await h
+                            .control(h.getPeer(i))
+                            .query.isBlacklisted(h.getPeer(j).address)
+                            .request(),
+                        `peer ${i} blacklisted honest peer ${j}`
+                    ).to.equal(false);
+                }
             }
         });
     });

--- a/test/e2e/E2E-Spectate.test.ts
+++ b/test/e2e/E2E-Spectate.test.ts
@@ -208,11 +208,10 @@ describe("E2E: Spectate Service", function () {
                     let didValidateQueuedBlock = false;
                     let didValidateQueuedBlockAgainstCorruptedState = false;
                     validation.validateBlockConfirmation = async (
-                        block,
-                        strategy,
-                        senderAddress
+                        entry,
+                        strategy
                     ) => {
-                        if (String(block.hash) === args.blockHash) {
+                        if (String(entry.block.hash) === args.blockHash) {
                             didValidateQueuedBlock = true;
                             const nextBlockHeight =
                                 sm.storage.blocks.getNextBlockHeight(
@@ -225,11 +224,11 @@ describe("E2E: Spectate Service", function () {
                                 String(nextToWrite) !==
                                     String(args.blockAuthor);
                         }
-                        return original(block, strategy, senderAddress);
+                        return original(entry, strategy);
                     };
                     try {
                         await sm.mutex.lock();
-                        const queuedBlockPromise = sm.onBlockConfirmation(
+                        const queuedBlockPromise = sm.onBlockConfirmationStruct(
                             args.blockConfirmation
                         );
                         const decoded =

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -1,4 +1,8 @@
-import { ethers } from "hardhat";
+// Plain ethers, not hardhat's: the SDK worker thread imports helpers from this
+// file (via HarnessControlRpc → DisputeService), and requiring "hardhat" there
+// boots the whole Hardhat runtime — incl. hardhat-foundry's sync `forge config`
+// exec — blocking the worker's event loop for ~800ms.
+import { ethers } from "ethers";
 import {
     BlockStruct,
     TransactionStruct,
@@ -28,7 +32,7 @@ import {
     Hash,
     Timestamp
 } from "@/types/types";
-import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 
 export const hash = (): `0x${string}` =>
     ethers.hexlify(ethers.randomBytes(32)) as `0x${string}`;

--- a/test/fixtures/customRpc/harnessControl/services/byzantine/ByzantineRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/byzantine/ByzantineRpcMethods.ts
@@ -45,6 +45,23 @@ export class ByzantineRpcMethods extends ARpcMethods {
     }
 
     /**
+     * Send a harness-crafted block confirmation as-is over the real
+     * state-transition RPC. The receiver runs the actual src path, including
+     * its transport-level side effects (disconnect/blacklist on rejection).
+     */
+    public async sendBlockConfirmation(
+        encodedBlockConfirmation: string,
+        targetEvmAddress: string
+    ): Promise<boolean> {
+        this.p2pManager.remoteRpc.stateTransitionService
+            .onBlockConfirmation(
+                Codec.decode(encodedBlockConfirmation, Type.BlockConfirmation)
+            )
+            .sendOne(targetEvmAddress);
+        return true;
+    }
+
+    /**
      * Apply a transaction against the live state machine and return the
      * resulting state-snapshot hash, for building a block whose body is invalid
      * but whose declared snapshot hash is a real (valid) state.

--- a/test/fixtures/customRpc/harnessControl/services/handshake/HandshakeRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/handshake/HandshakeRpcMethods.ts
@@ -146,8 +146,9 @@ export class HandshakeRpcMethods extends ARpcMethods {
 
     /**
      * Replay block-fork-dispute validation for a block built by `buildingAddress`
-     * (its latest block confirmation, fetched from the building peer). Mirrors
-     * the old `blockValidationStrategy.blockForkIsDisputed(block, address)`.
+     * (its latest block confirmation, fetched from the building peer). The
+     * strategy resolves suppliers from the entry's source attribution, so
+     * build the entry with the building peer as the sender of this copy.
      */
     public async simulateBlockForkIsDisputed(
         encodedBlockConfirmation: string,
@@ -156,9 +157,11 @@ export class HandshakeRpcMethods extends ARpcMethods {
         const block = Block.fromBlockConfirmation(
             Codec.decode(encodedBlockConfirmation, Type.BlockConfirmation)
         );
+        const entry = this.service.sm.storage.queues.createEntry(block, {
+            senderAddress: String(buildingAddress)
+        });
         await this.service.sm.blockValidationStrategy.blockForkIsDisputed(
-            block,
-            String(buildingAddress)
+            entry
         );
         return true;
     }

--- a/test/fixtures/customRpc/harnessControl/services/query/QueryRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/query/QueryRpcMethods.ts
@@ -190,6 +190,13 @@ export class QueryRpcMethods extends ARpcMethods {
         return this.p2pManager.isBlacklisted(evmAddress);
     }
 
+    /** Whether the block confirmation queue holds an entry for `blockHash`. */
+    public isBlockQueued(blockHash: Hash): boolean {
+        return (
+            this.service.storage.queues.getQueuedEntry(blockHash) !== undefined
+        );
+    }
+
     /**
      * Decode the top block of a dispute state proof on-chain: whether it has a
      * block and that block's height (`transactionCnt`).

--- a/test/fixtures/customRpc/harnessControl/services/transition/TransitionRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/transition/TransitionRpcMethods.ts
@@ -2,6 +2,7 @@ import ARpcMethods from "@/rpc/ARpcMethods";
 import type ATransport from "@/transport/ATransport";
 import type { ForkId } from "@/types/types";
 import type { IngestBlockConfirmationOptions } from "@/stateManager/BlockQueueManager";
+import { Block } from "@/models";
 import { Codec, Type } from "@/utils";
 import type { TransitionService } from "./TransitionService";
 
@@ -72,6 +73,21 @@ export class TransitionRpcMethods extends ARpcMethods {
             Codec.decode(encodedBlockConfirmation, Type.BlockConfirmation),
             options
         );
+    }
+
+    /**
+     * Persist a block straight into storage — bypassing the confirmation
+     * pipeline — the way spectate/state-proof persistence does.
+     */
+    public async storeBlock(
+        encodedBlockConfirmation: string
+    ): Promise<boolean> {
+        this.service.sm.storage.blocks.storeBlock(
+            Block.fromBlockConfirmation(
+                Codec.decode(encodedBlockConfirmation, Type.BlockConfirmation)
+            )
+        );
+        return true;
     }
 }
 

--- a/test/models/Block.test.ts
+++ b/test/models/Block.test.ts
@@ -289,6 +289,70 @@ describe("Block Model", () => {
 
             expect(block.confirmationSignatures.size).to.equal(countAfterFirst);
         });
+
+        it("should remove confirmation signatures", async () => {
+            const signer2 = signers[1];
+            const signer3 = signers[2];
+            const signature2 = await signer2.signMessage(
+                ethers.getBytes(block.hash)
+            );
+            const signature3 = await signer3.signMessage(
+                ethers.getBytes(block.hash)
+            );
+            block.expandSignatures([signature2, signature3]);
+
+            block.removeConfirmationSignatures(new Set([signature2]));
+
+            expect(block.confirmationSignatures.has(signature2)).to.be.false;
+            expect(block.confirmationSignatures.has(signature3)).to.be.true;
+        });
+
+        it("should shrink cached signer addresses when removing signatures", async () => {
+            const signer2 = signers[1];
+            const signature2 = await signer2.signMessage(
+                ethers.getBytes(block.hash)
+            );
+            block.expandSignatures([signature2]);
+            // Warm the address cache before removing.
+            expect(block.didSign(signer2.address)).to.equal(true);
+
+            block.removeConfirmationSignatures(new Set([signature2]));
+
+            expect(block.didSign(signer2.address)).to.equal(false);
+        });
+
+        it("should keep the author's original signature when removing", async () => {
+            const testBlock = blockFactory();
+            const signedBlockStruct = await testBlock.signBlock(signer);
+            const realSignedBlock = Block.fromSignedBlock(signedBlockStruct);
+
+            realSignedBlock.removeConfirmationSignatures(
+                new Set([realSignedBlock.originalSignature])
+            );
+
+            expect(
+                realSignedBlock.allSignatures.has(
+                    realSignedBlock.originalSignature
+                )
+            ).to.be.true;
+            expect(
+                realSignedBlock.allSignerAddresses.has(
+                    realSignedBlock.signerAddress
+                )
+            ).to.be.true;
+        });
+
+        it("should ignore removing unknown signatures", async () => {
+            const signer2 = signers[1];
+            const unknownSignature = await signer2.signMessage(
+                ethers.getBytes(block.hash)
+            );
+            const countBefore = block.confirmationSignatures.size;
+
+            block.removeConfirmationSignatures(new Set([unknownSignature]));
+
+            expect(block.confirmationSignatures.size).to.equal(countBefore);
+        });
     });
 
     describe("Block confirmation struct", () => {

--- a/test/storage/QueueStorage.test.ts
+++ b/test/storage/QueueStorage.test.ts
@@ -303,6 +303,44 @@ describe("QueueStorage", () => {
             ).to.equal(true);
         });
 
+        it("should attribute only the signatures each sender's copy carried", () => {
+            const senderA = ethers.Wallet.createRandom().address;
+            const senderB = ethers.Wallet.createRandom().address;
+            const straySig = sig();
+            const honestSig = sig();
+
+            storage.queueBlock(
+                Block.fromBlockConfirmation({
+                    ...mockBlockConfirmation,
+                    signatures: [straySig]
+                }),
+                { senderAddress: senderA }
+            );
+            // B's copy pools into A's entry but carries only the honest sig —
+            // B must not inherit A's stray signature.
+            storage.queueBlock(
+                Block.fromBlockConfirmation({
+                    ...mockBlockConfirmation,
+                    signatures: [honestSig]
+                }),
+                { senderAddress: senderB }
+            );
+
+            const entry = storage.getQueuedEntry(mockBlock.hash)!;
+            expect(entry.block.confirmationSignatures).to.deep.equal(
+                new Set([straySig, honestSig])
+            );
+            expect(entry.sourcePeers).to.deep.equal(
+                new Set([senderA, senderB])
+            );
+            expect(entry.signatureSources.get(straySig)).to.deep.equal(
+                new Set([senderA])
+            );
+            expect(entry.signatureSources.get(honestSig)).to.deep.equal(
+                new Set([senderB])
+            );
+        });
+
         it("should return empty on subsequent dequeues", () => {
             storage.queueBlock(mockBlock);
             expect(
@@ -311,6 +349,77 @@ describe("QueueStorage", () => {
             expect(storage.tryDequeueAt(mockForkId, mockHeight)).to.deep.equal(
                 []
             );
+        });
+    });
+
+    describe("Restore Entry", () => {
+        it("should restore a dequeued entry with its attribution intact", () => {
+            const senderAddress = ethers.Wallet.createRandom().address;
+            const confirmationSignature = sig();
+            const block = Block.fromBlockConfirmation({
+                ...mockBlockConfirmation,
+                signatures: [confirmationSignature]
+            });
+
+            storage.queueBlock(block, { senderAddress });
+            const [entry] = storage.tryDequeueAt(mockForkId, mockHeight);
+            expect(storage.isBlockQueued(block)).to.be.false;
+
+            storage.restoreEntry(entry);
+
+            expect(storage.isBlockQueued(block)).to.be.true;
+            const restored = storage.getQueuedEntry(block.hash)!;
+            expect(restored.sourcePeers.has(senderAddress)).to.equal(true);
+            expect(
+                restored.signatureSources
+                    .get(confirmationSignature)
+                    ?.has(senderAddress)
+            ).to.equal(true);
+            // Back in the coordinate index too - dequeueable again
+            expect(
+                storage.tryDequeueAt(mockForkId, mockHeight)
+            ).to.have.lengthOf(1);
+        });
+
+        it("should merge a restored entry with a copy queued meanwhile", () => {
+            const senderA = ethers.Wallet.createRandom().address;
+            const senderB = ethers.Wallet.createRandom().address;
+            const sigA = sig();
+            const sigB = sig();
+
+            storage.queueBlock(
+                Block.fromBlockConfirmation({
+                    ...mockBlockConfirmation,
+                    signatures: [sigA]
+                }),
+                { senderAddress: senderA }
+            );
+            const [entry] = storage.tryDequeueAt(mockForkId, mockHeight);
+            entry.firstSeenAt -= 100;
+
+            storage.queueBlock(
+                Block.fromBlockConfirmation({
+                    ...mockBlockConfirmation,
+                    signatures: [sigB]
+                }),
+                { senderAddress: senderB }
+            );
+            storage.restoreEntry(entry);
+
+            const merged = storage.getQueuedEntry(mockBlock.hash)!;
+            expect(merged.block.confirmationSignatures).to.deep.equal(
+                new Set([sigA, sigB])
+            );
+            expect(merged.sourcePeers).to.deep.equal(
+                new Set([senderA, senderB])
+            );
+            expect(merged.signatureSources.get(sigA)).to.deep.equal(
+                new Set([senderA])
+            );
+            expect(merged.signatureSources.get(sigB)).to.deep.equal(
+                new Set([senderB])
+            );
+            expect(merged.firstSeenAt).to.equal(entry.firstSeenAt);
         });
     });
 


### PR DESCRIPTION
# Byzantine-signature filtering, CRDT block queue, convergent fork reduction

## Summary

Three connected changes to the block-confirmation and dispute pipeline, driven by fixing the failing e2e suite (24 baseline failures → chronic-only):

1. **Byzantine signature handling** — a stray signature on a valid block no longer delays or invalidates the block; it punishes exactly its supplier.
2. **`QueuedBlockEntry` as the pipeline's unit of work** — entries are CRDTs: copies merge while queued, the dequeued entry executes atomically, and stored-path copies converge through storage.
3. **Convergent fork reduction** — one single-flight local reduction shared by every entry point, replacing a class of fatal event-ordering races.

## Protocol / security

- **Peers only sign blocks whose previous∪resulting participant union contains them** (`shouldSignBlock`); the resulting snapshot is persisted before signing so the check reads storage. Leavers no longer sign post-leave blocks.
- **Stray (non-union) signatures are stripped, and their suppliers disconnected + blacklisted** — never an honest relayer: attribution is per-copy via the queue's signature → source map. An author outside the union means nobody to slash: the block is discarded and its signers cut. All of this lives in the polymorphic validation strategies (`notAllSingersAreParticipants`), with per-pipeline side effects (live gossip punishes transports; dispute replay produces fraud-proof evidence against the submitter; spectating drops the feed).
- **VM state is restored on every non-success exit of `onBlockConfirmation`** (`finally`), not only on failed `applyTransaction` — an aborted validation previously leaked advanced VM state and produced false "unexpected next leader" disputes.

## Block queue: entry-based pipeline

- `onBlockConfirmation(entry)` / `validateBlockConfirmation(entry)` / `tryMergeStoredBlockConfirmation(entry)`: the entry carries block + source attribution through the whole pipeline. `processingEntries` side-registry deleted; strategies read `entry.sourcePeers` / `entry.signatureSources` directly and re-queue via `restoreEntry` so attribution survives not-ready cycles. Struct-only callers (dispute replay, spectate sync) enter via `onBlockConfirmationStruct` (sourceless — those paths don't punish by transport).
- Revived two previously-dead paths using entry sources: `blockForkIsDisputed` cuts suppliers that already acknowledged the disputed fork; `blockIsNotNextAndIsInTheFuture` requests spectate-sync from the suppliers.
- **`queueTimeout` dequeues first, then acts** — the timeout owns the entry it sees (no ownership races): stored → merge, next → execute through the pipeline, still-future → requestSync and the dequeue is the eviction (junk future blocks are free to forge and must not accumulate; calldata-posted blocks can always be re-read from the chain).

## Fork reduction: single-flight local convergence

- `StateManager.reduceLocally(forkId)`: computes the reduction and sets the reduced genesis — single-flight per fork, no on-chain submission; resolved ⇒ reduced locally and fork switched. The kill timestamp is always read on-chain so every peer derives the identical reduced genesis hash.
- Entry points share the one promise: `tryReduce` (awaits the core, then submits `reduceAndFinalize` — winner path), `onDisputeReducedResultCommitted` (implements the old "reduce on the spot" TODO; aborts participation if the finalized on-chain reduction can't be derived locally), and `onStateSnapshotUpdated`'s unknown-snapshot branch (reduce on the spot → re-check once → fatal only on genuine desync).
- This fixes the roving `unknown snapshot while status=4` fatal: chain events have no cross-event ordering per peer, so whoever lost the reduction race processed `StateSnapshotUpdated` before its local reduction landed and died. Losers now converge deterministically.
- **Local-ahead-of-chain is the design** (the local reduction always precedes its on-chain commit): `prepareUpdateSnapshotSameFork` accounts for it — takes the multicall's expected post-fork-update snapshot as its base and skips (instead of throwing `Fork mismatch`) across forks.

## Tests

- New `E2E-BlockQueueManager.test.ts` (harness-style unit scope): forged author signature rejected; wrong-channel block from a known sender cut over the **real** state-transition RPC (side effects produced by src, not fixtures); future-block eviction at queue timeout (no supplier punishment); stored-at-timeout merge with attribution intact.
- New byzantine e2e tests: stored duplicate / fresh block with a non-participant signature → block applies, signature dropped, supplier blacklisted; exiting participant doesn't sign post-leave blocks.
- Unit tests: `QueueStorage` per-copy attribution (honest relayer never inherits a pooled stray) + `restoreEntry` merging; `Block.removeConfirmationSignatures`.
- Harness: `transition.storeBlock`, `query.isBlockQueued`, `byzantine.sendBlockConfirmation` endpoints; calldata test updated to the eviction semantics (evict → re-deliver from chain).
- Conventions recorded in `AGENTS.md` / `test/AGENTS.md`: deviations go through strategies; the entry is the pipeline's unit of work; unit tests use the harness (no mocks, no junk data); fixtures trigger src code, never reimplement it; no `Awaited<ReturnType<...>>` wrappers.

## Suite status

24 baseline failures → chronic-only (tracked in `TEST_FAILURES.md`, temporary): the fixed set includes the whole dispute-validation case1 family, the roving unknown-snapshot cluster, and the SDK-worker starvation cluster. Known remaining: the chronic dozen (pre-existing), the StateSnapshots multicall test (same-fork prepare now needs the fork-update to bridge multi-hop forks — next iteration), and the `validateDisputeReductionAndChallenge` branch racing mid-reduction events (next iteration).
