### PR TITLE
(test infra) ignore errors thrown from byzntine peers

### DIFF
--- a/src/evm/EvmDiamondStateMachine.ts
+++ b/src/evm/EvmDiamondStateMachine.ts
@@ -38,6 +38,7 @@ import {
 } from "@platform/p2pRuntimeChannel";
 import { createP2pRuntimeWorker } from "@platform/p2pRuntimeWorkerRuntime";
 import { startP2pRuntimeHost } from "./p2pRuntime/P2pRuntimeHost";
+import type { HostHandlerExecutionContext } from "./p2pRuntime/HostHandlerExecutionContext";
 import P2pRuntimeClient from "./p2pRuntime/P2pRuntimeClient";
 import DeploymentBridgeSigner from "./signer/DeploymentBridgeSigner";
 import type {
@@ -456,6 +457,12 @@ class EvmDiamondStateMachine extends ADiamondStateMachine {
              * signer inside the worker. Required when `RUN_SDK_IN_THREAD`.
              */
             signerSecret?: string;
+            /**
+             * Context every inline-host handler runs inside (see
+             * {@link HostHandlerExecutionContext}). Ignored in threaded mode —
+             * a worker thread runs exactly one peer's host.
+             */
+            handlerExecutionContext?: HostHandlerExecutionContext;
         }
     ): Promise<P2pInstance<T, TCustomRpc>> {
         // Initialize SDK config for this runtime (intended to be called once).
@@ -521,7 +528,8 @@ class EvmDiamondStateMachine extends ADiamondStateMachine {
             const channel = createRuntimeChannel();
             clientPort = channel.port1;
             void startP2pRuntimeHost(channel.port2, payload, {
-                signer
+                signer,
+                handlerExecutionContext: options?.handlerExecutionContext
             }).catch((error) => {
                 logger.error("Inline runtime host failed", { error });
             });

--- a/src/evm/p2pRuntime/HostHandlerExecutionContext.ts
+++ b/src/evm/p2pRuntime/HostHandlerExecutionContext.ts
@@ -1,0 +1,3 @@
+export interface HostHandlerExecutionContext {
+    runHandler<T>(handlerBody: () => T): T;
+}

--- a/src/evm/p2pRuntime/P2pRuntimeClient.ts
+++ b/src/evm/p2pRuntime/P2pRuntimeClient.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 
+import { maybeStampErrorWithPeerAddress } from "@/utils/errorPeerAddress";
 import type { Address } from "@/types/types";
 import ClientP2pSigner from "../signer/ClientP2pSigner";
 import RuntimeEventEmitter, {
@@ -29,6 +30,9 @@ function deserializeError(serialized: SerializedError): Error {
     if (serialized.data !== undefined) {
         (error as Error & { data?: string }).data = serialized.data;
     }
+    // Restore the originating-peer stamp (the non-enumerable in-process
+    // property doesn't survive the structured-clone hop across the port).
+    maybeStampErrorWithPeerAddress(error, serialized.peerAddress);
     return error;
 }
 
@@ -70,6 +74,7 @@ class P2pRuntimeClient<T = ethers.Contract> {
     webRTCBridgePort?: MessagePort;
 
     private readonly port: RuntimePort;
+    private readonly signerAddress: Address;
     private readonly pending = new Map<number, PendingRequest>();
     private nextRequestId = 1;
     private readonly events = new RuntimeEventEmitter();
@@ -80,6 +85,7 @@ class P2pRuntimeClient<T = ethers.Contract> {
 
     constructor(port: RuntimePort, options: P2pRuntimeClientOptions) {
         this.port = port;
+        this.signerAddress = options.signerAddress;
         this.onClose = options.onClose;
         this.ready = new Promise<void>((resolve) => {
             this.resolveReady = resolve;
@@ -231,6 +237,10 @@ class P2pRuntimeClient<T = ethers.Contract> {
 
     private dispatchHostError(message: RuntimeHostErrorMessage): void {
         const error = deserializeError(message.error);
+        // deserializeError only restores a stamp the wire carried - hostError
+        // comes from a worker, which never stamps -> attribute it here (the
+        // whole worker is this one peer)
+        maybeStampErrorWithPeerAddress(error, String(this.signerAddress));
 
         if (this.hostErrorListeners.size === 0) {
             // No orchestrator hook: surface as a main-thread unhandled rejection

--- a/src/evm/p2pRuntime/P2pRuntimeHost.ts
+++ b/src/evm/p2pRuntime/P2pRuntimeHost.ts
@@ -10,7 +10,12 @@ import EvmDiamondStateMachine from "@/evm/EvmDiamondStateMachine";
 import Clock from "@/Clock";
 import Storage from "@/storage";
 import { TimeConfig } from "@/types";
-import { createLogger, DebugProxy, DetachedPromises } from "@/utils";
+import {
+    createLogger,
+    DebugProxy,
+    DetachedPromises,
+    getErrorPeerAddress
+} from "@/utils";
 import { config } from "@/utils/config";
 import { LoggerUtils } from "@/utils/LoggerUtils";
 import MainRpcService from "@/rpc/MainRpcService";
@@ -25,6 +30,7 @@ import {
     forwardEventHandlerInvocations
 } from "./host/EventForwarding";
 
+import type { HostHandlerExecutionContext } from "./HostHandlerExecutionContext";
 import type {
     HostRpcRequest,
     RuntimeClientRequest,
@@ -46,6 +52,12 @@ export interface HostContext {
      * inline (main-thread) host — the harness's main logger covers that.
      */
     threadLabel?: string;
+    /**
+     * Optional context this host's handlers run inside (see
+     * {@link HostHandlerExecutionContext}). Unused in threaded mode — a worker
+     * thread runs exactly one peer's host, so no disambiguation is needed.
+     */
+    handlerExecutionContext?: HostHandlerExecutionContext;
 }
 
 /** Live runtime graph while the host is running. */
@@ -87,10 +99,15 @@ export function serializeError(error: unknown): SerializedError {
             message: error.message,
             name: error.name,
             stack: error.stack,
-            data: extractRevertData(error)
+            data: extractRevertData(error),
+            peerAddress: getErrorPeerAddress(error)
         };
     }
-    return { message: String(error), data: extractRevertData(error) };
+    return {
+        message: String(error),
+        data: extractRevertData(error),
+        peerAddress: getErrorPeerAddress(error)
+    };
 }
 
 /**
@@ -127,7 +144,7 @@ export async function startP2pRuntimeHost<
     TCustomRpc extends MainRpcService = MainRpcService,
     TCustomRpcOptions = unknown
 >(port: RuntimePort, payload: SetupPayload, ctx: HostContext): Promise<void> {
-    const { signer, threadLabel } = ctx;
+    const { signer, threadLabel, handlerExecutionContext } = ctx;
     const signerAddress = await signer.getAddress();
     const logger = createLogger(
         { peerId: payload.peerId, peerAddress: signerAddress },
@@ -264,7 +281,20 @@ export async function startP2pRuntimeHost<
             port.post({ type: "contractEvent", name, args })
         );
 
-        forwardEventHandlerInvocations(stateManager.eventHandler, port);
+        forwardEventHandlerInvocations(
+            stateManager.eventHandler,
+            port,
+            handlerExecutionContext
+        );
+
+        if (handlerExecutionContext) {
+            const p2pManager = stateManager.p2pManager;
+            const onRpc = p2pManager.onRpc.bind(p2pManager);
+            p2pManager.onRpc = (serializedRpc, transport) =>
+                handlerExecutionContext.runHandler(() =>
+                    onRpc(serializedRpc, transport)
+                );
+        }
 
         runtimeHandle = { stateManager, evmDiamondStateMachine };
         // A bridge-setup failure must not deadlock `ready`; WebRTC is optional.
@@ -413,9 +443,15 @@ export async function startP2pRuntimeHost<
         }
     };
 
-    port.onMessage((raw) => {
+    const onPortMessage = (raw: unknown): void => {
         void handleRequest(raw as RuntimeClientRequest);
-    });
+    };
+    port.onMessage(
+        handlerExecutionContext
+            ? (raw) =>
+                  handlerExecutionContext.runHandler(() => onPortMessage(raw))
+            : onPortMessage
+    );
     // Client went away without a clean `dispose` (thread died / port closed).
     port.onClose(() => {
         void disposeRuntime().catch((error) => {

--- a/src/evm/p2pRuntime/host/EventForwarding.ts
+++ b/src/evm/p2pRuntime/host/EventForwarding.ts
@@ -1,6 +1,7 @@
 import type { EventHandler } from "@/eventHandlers/EventHandler";
 import type P2pEventHooks from "@/P2pEventHooks";
 import { EVENT_HANDLER_HOOK_NAMES } from "@/eventHandlers/EventHandlerHooks";
+import type { HostHandlerExecutionContext } from "../HostHandlerExecutionContext";
 import type { RuntimePort } from "../types";
 
 /** Best-effort structured-clone of handler args; `[]` if not cloneable. */
@@ -37,14 +38,15 @@ export function createForwardingHooks(port: RuntimePort): P2pEventHooks {
  */
 export function forwardEventHandlerInvocations(
     eventHandler: EventHandler,
-    port: RuntimePort
+    port: RuntimePort,
+    handlerExecutionContext?: HostHandlerExecutionContext
 ): void {
     const handler = eventHandler as unknown as Record<string, unknown>;
     for (const name of EVENT_HANDLER_HOOK_NAMES) {
         const original = handler[name];
         if (typeof original !== "function") continue;
         const originalFn = original as (...args: unknown[]) => unknown;
-        handler[name] = async function (...args: unknown[]) {
+        const forwardingMethod = async function (...args: unknown[]) {
             const result = await originalFn.apply(handler, args);
             port.post({
                 type: "eventHandlerInvoked",
@@ -53,5 +55,11 @@ export function forwardEventHandlerInvocations(
             });
             return result;
         };
+        handler[name] = handlerExecutionContext
+            ? (...args: unknown[]) =>
+                  handlerExecutionContext.runHandler(() =>
+                      forwardingMethod(...args)
+                  )
+            : forwardingMethod;
     }
 }

--- a/src/evm/p2pRuntime/types.ts
+++ b/src/evm/p2pRuntime/types.ts
@@ -88,6 +88,12 @@ export interface SerializedError {
     name?: string;
     stack?: string;
     data?: string;
+    /**
+     * EVM address of the peer host the error originated on, when stamped (see
+     * `errorPeerAddress`). Carried explicitly because the in-process stamp
+     * doesn't survive the structured-clone hop across the port.
+     */
+    peerAddress?: string;
 }
 
 /** Minimal surface needed to issue requests to the host. */

--- a/src/utils/errorPeerAddress.ts
+++ b/src/utils/errorPeerAddress.ts
@@ -1,0 +1,28 @@
+const ERROR_PEER_ADDRESS_KEY = Symbol.for("peer3.errorOriginPeerAddress");
+
+/** Read the originating peer address previously stamped onto an error. */
+export function getErrorPeerAddress(error: unknown): string | undefined {
+    if (typeof error !== "object" || error === null) return undefined;
+    const value = (error as Record<symbol, unknown>)[ERROR_PEER_ADDRESS_KEY];
+    return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Stamp `error` with the originating peer address. No-op when the address is
+ * missing, the error isn't an object, or a stamp already exists — an existing
+ * stamp is never overwritten, so the true origin wins over a later fallback.
+ */
+export function maybeStampErrorWithPeerAddress(
+    error: unknown,
+    peerAddress: string | undefined
+): void {
+    if (!peerAddress) return;
+    if (typeof error !== "object" || error === null) return;
+    if (getErrorPeerAddress(error) !== undefined) return;
+    Object.defineProperty(error, ERROR_PEER_ADDRESS_KEY, {
+        value: peerAddress,
+        enumerable: false,
+        configurable: true,
+        writable: true
+    });
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,6 +16,7 @@ export * from "./config";
 export * from "./hash";
 export * from "./evmErrorHandler";
 export * from "./DetachedPromises";
+export * from "./errorPeerAddress";
 export * from "./logging";
 export * from "./EthersResultProxy";
 export * from "./address";

--- a/test/e2e/E2E-ByzantineErrorAttribution.test.ts
+++ b/test/e2e/E2E-ByzantineErrorAttribution.test.ts
@@ -1,0 +1,39 @@
+import { expect } from "chai";
+
+import { MathTestSession as TestSession } from "@test/harness";
+
+describe("E2E: Byzantine error attribution", function () {
+    it("suppresses a stray detached error originating on a malicious peer", async function () {
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(3, 2);
+
+        h.contextApi.markMaliciousPeer({ maliciousPeerIndex: 1 });
+
+        await h.execOnHost(h.getPeer(1), () => {
+            void Promise.reject(new Error("byzantine peer stray error"));
+        });
+
+        // the error carries peer 1's address -> ignored, nothing recorded
+        const err = await TestSession.consumeFirstDetachedError(1500);
+        expect(
+            err,
+            `expected the byzantine peer's error to be suppressed, got: ${err?.message}`
+        ).to.equal(undefined);
+    });
+
+    it("does not suppress the same error when it comes from an honest peer", async function () {
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(3, 2);
+
+        await h.execOnHost(h.getPeer(1), () => {
+            void Promise.reject(new Error("honest peer stray error"));
+        });
+
+        // honest-peer errors must still be recorded
+
+        await TestSession.expectFirstDetachedError({
+            includes: "honest peer stray error",
+            timeoutMs: 5000
+        });
+    });
+});

--- a/test/fixtures/PeerTestHarness.ts
+++ b/test/fixtures/PeerTestHarness.ts
@@ -1027,7 +1027,6 @@ export class PeerTestHarness<
         return new Set(
             [
                 ...this.context.maliciousPeerIndices,
-                ...this.context.leftChannelPeerIndices
             ].map((i) => this.getPeer(i).address)
         );
     }

--- a/test/fixtures/PeerTestHarness.ts
+++ b/test/fixtures/PeerTestHarness.ts
@@ -27,8 +27,11 @@ import {
     LocalDiscoveryServer,
     Logger,
     EventBarrier,
-    createEthersResultProxy
+    createEthersResultProxy,
+    getErrorPeerAddress,
+    maybeStampErrorWithPeerAddress
 } from "@/utils";
+import { PeerIdentityExecutionContext } from "@test/harness/core/peerErrorAttribution";
 import { DisputeStruct } from "@typechain-types/contracts/V1/types/DisputeTypes";
 import { createConfig, Config, config } from "@/utils/config";
 import testConfig from "../peer3.test.config";
@@ -740,7 +743,10 @@ export class PeerTestHarness<
                 customPrecompiles: this.options.customPrecompiles!,
                 customRpcManifest: this.resolveHarnessRpcManifest(),
                 signerSecret,
-                config: this.harnessConfig
+                config: this.harnessConfig,
+                handlerExecutionContext: useWorker
+                    ? undefined
+                    : new PeerIdentityExecutionContext(address)
             }
         );
 
@@ -986,18 +992,50 @@ export class PeerTestHarness<
     }
 
     async quiesceHosts(): Promise<Error[]> {
+        // In worker mode each drained worker thread runs exactly one peer, so
+        // an unstamped rejection is attributable to the peer whose host
+        // returned it. Inline hosts share one process (any peer's quiesce can
+        // drain another's work) - there only collect-time stamps are
+        // trustworthy.
+        const stampPerHostThread = !!this.harnessConfig.RUN_SDK_IN_THREAD;
         const perPeer = await Promise.all(
-            this.peers.map((peer) =>
-                peer.p2pInstance
+            this.peers.map(async (peer) => {
+                const errors = await peer.p2pInstance
                     .quiesce()
                     .catch((error: unknown) => [
                         error instanceof Error
                             ? error
                             : new Error(String(error))
-                    ])
-            )
+                    ]);
+                if (stampPerHostThread) {
+                    for (const error of errors) {
+                        maybeStampErrorWithPeerAddress(error, peer.address);
+                    }
+                }
+                return errors;
+            })
         );
         return perPeer.flat();
+    }
+
+    /**
+     * EVM addresses of peers a scenario marked byzantine/malicious or
+     * left-channel. Errors originating on these peers are expected and
+     * suppressed.
+     */
+    private byzantinePeerAddresses(): Set<string> {
+        return new Set(
+            [
+                ...this.context.maliciousPeerIndices,
+                ...this.context.leftChannelPeerIndices
+            ].map((i) => this.getPeer(i).address)
+        );
+    }
+
+    isExpectedByzantineError(error: unknown): boolean {
+        const address = getErrorPeerAddress(error);
+        if (!address) return false;
+        return this.byzantinePeerAddresses().has(address);
     }
 
     async ensurePeerSignersRegistered(

--- a/test/harness/core/peerErrorAttribution.ts
+++ b/test/harness/core/peerErrorAttribution.ts
@@ -1,0 +1,77 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import { DetachedPromises, maybeStampErrorWithPeerAddress } from "@/utils";
+import type { HostHandlerExecutionContext } from "@/evm/p2pRuntime/HostHandlerExecutionContext";
+
+/**
+ * Tags all of one inline peer's work with its EVM address.
+ *
+ * Inline peers share one process, so an escaping error can't be traced back
+ * to a peer on its own. The harness passes one instance per peer into
+ * `p2pSetup` (`handlerExecutionContext`); it runs every host handler inside an
+ * AsyncLocalStorage scope holding the peer's address, and escaping errors get
+ * stamped with it. `TestSession.setFirstDetachedError` uses the stamp to
+ * ignore errors from byzantine/left-channel peers.
+ *
+ * Worker peers don't need this: one worker thread = one peer, so the
+ * `P2pRuntimeClient` / `quiesceHosts` boundaries attribute errors directly.
+ */
+export class PeerIdentityExecutionContext
+    implements HostHandlerExecutionContext
+{
+    // one store shared by all inline peers
+    private static readonly currentPeerIdentityStorage = new AsyncLocalStorage<{
+        peerAddress: string;
+    }>();
+
+    private static detachedRejectionStampingInstalled = false;
+
+    constructor(private readonly peerAddress: string) {}
+
+    /** Run one host handler invocation under this peer's identity. */
+    runHandler<T>(handlerBody: () => T): T {
+        return PeerIdentityExecutionContext.currentPeerIdentityStorage.run(
+            { peerAddress: this.peerAddress },
+            handlerBody
+        );
+    }
+
+    /**
+     * Address of the peer whose handler the caller is running under, if any.
+     *
+     * Covers floating rejections (`void somePromise`) that never went through
+     * `DetachedPromises.collect`: Node runs `unhandledRejection` listeners in
+     * the rejected promise's async context, so the unhandledRejection listener
+     * can still read the peer here and stamp the error.
+     */
+    static getPeerAddressOfCurrentAsyncContext(): string | undefined {
+        return PeerIdentityExecutionContext.currentPeerIdentityStorage.getStore()
+            ?.peerAddress;
+    }
+
+    /**
+     * Patch `DetachedPromises.collect` (once): a promise collected while a
+     * peer's handler runs gets its eventual rejection stamped with that peer's
+     * address.
+     */
+    static installDetachedPromiseRejectionStamping(): void {
+        if (PeerIdentityExecutionContext.detachedRejectionStampingInstalled) {
+            return;
+        }
+        PeerIdentityExecutionContext.detachedRejectionStampingInstalled = true;
+
+        const originalCollect = DetachedPromises.collect.bind(DetachedPromises);
+        DetachedPromises.collect = (promise: Promise<unknown>): void => {
+            const peerAddress =
+                PeerIdentityExecutionContext.getPeerAddressOfCurrentAsyncContext();
+            originalCollect(
+                peerAddress
+                    ? promise.catch((error: unknown) => {
+                          maybeStampErrorWithPeerAddress(error, peerAddress);
+                          throw error;
+                      })
+                    : promise
+            );
+        };
+    }
+}

--- a/test/harness/session/TestSession.ts
+++ b/test/harness/session/TestSession.ts
@@ -42,6 +42,9 @@ export class TestSession {
     }
 
     static setFirstDetachedError(error: Error): void {
+        if (this.harness?.isExpectedByzantineError(error)) {
+            return;
+        }
         // drop errors a test has already claimed (multi-peer same-throw case)
         if (
             this.detachedErrorAllowlist.some((s) => error.message.includes(s))
@@ -90,12 +93,10 @@ export class TestSession {
         timeoutMs?: number;
         required?: boolean;
     }): Promise<void> {
-        // Allowlist pattern so duplicate peer throws are ignored.
-        this.detachedErrorAllowlist.push(options.includes);
-
         const err = await this.consumeFirstDetachedError(
             options.timeoutMs ?? 0
         );
+        this.detachedErrorAllowlist.push(options.includes);
         if (!err) {
             if (options.required ?? true) {
                 throw new Error(

--- a/test/harness/session/registerTestSessionHooks.ts
+++ b/test/harness/session/registerTestSessionHooks.ts
@@ -1,5 +1,6 @@
-import { DetachedPromises } from "@/utils";
+import { DetachedPromises, maybeStampErrorWithPeerAddress } from "@/utils";
 
+import { PeerIdentityExecutionContext } from "../core/peerErrorAttribution";
 import { TestSession } from "./TestSession";
 
 type TestSessionClass = typeof TestSession;
@@ -30,10 +31,17 @@ export function registerTestSessionHooks(testSession: TestSessionClass): void {
     ) {
         globalThis.__peer3UnhandledRejectionHookRegistered__ = true;
 
+        // Stamp detached rejections with the inline peer they originated on.
+        PeerIdentityExecutionContext.installDetachedPromiseRejectionStamping();
+
         process.prependListener("unhandledRejection", (reason) => {
-            testSession.setFirstDetachedError(
-                reason instanceof Error ? reason : new Error(String(reason))
+            const error =
+                reason instanceof Error ? reason : new Error(String(reason));
+            maybeStampErrorWithPeerAddress(
+                error,
+                PeerIdentityExecutionContext.getPeerAddressOfCurrentAsyncContext()
             );
+            testSession.setFirstDetachedError(error);
         });
     }
 


### PR DESCRIPTION
### what

a peer we deliberately make misbehave throws expected errors in its detached
work, and those were failing the tests. now each error carries the address of
the peer it came from, and the harness ignores errors from peers the test
marked byzantine. honest-peer errors still fail the test.

https://trello.com/c/K6byL6EU

### how

each inline peer's handlers run inside an `AsyncLocalStorage` scope holding its
EVM address. when a detached promise is collected, we read the address back
from that scope and stamp it onto the eventual rejection error.
`TestSession.setFirstDetachedError` reads the stamp and skips errors from
marked peers. Worker peers skip the tracing:
one thread = one peer, so the client stamps its own address.

### also fixes

`expectFirstDetachedError` registered its ignore pattern before waiting ->
late-arriving errors were dropped by their own pattern. now waits first.

### tests

new `E2E-ByzantineErrorAttribution` (ignored byzantine error + recorded honest
error), passing inline and in worker mode.