### PR TITLE
fix(p2p): stop permanently exhausting the holepunch relayer pool on repeated failures

### DIFF
--- a/src/HolepunchRelay.ts
+++ b/src/HolepunchRelay.ts
@@ -5,11 +5,26 @@ import DHT from "@hyperswarm/dht-relay";
 //@ts-ignore
 import Stream from "@hyperswarm/dht-relay/ws";
 import { Logger } from "@/utils";
+// Base/cap for exponential backoff applied when a full round of relayers
+// has just been exhausted (all configured relayers failed since the last
+// success), so a fully-down network doesn't tight-loop hammering reconnects.
+const BACKOFF_BASE_MS = 1000;
+const BACKOFF_CAP_MS = 30000;
+
 class HolepunchRelay {
     relayerUrls: string[];
     updateCallback: Function;
     swarm: any;
     logger: Logger;
+
+    // Relayers that failed since the last successful connection. Never
+    // mutates relayerUrls - this is purely an exclusion filter that gets
+    // reset once every configured relayer has failed (retry the pool) or
+    // once a connection succeeds.
+    private excludedRelayers: Set<string> = new Set();
+    // Number of consecutive full-round exhaustions (every relayer excluded)
+    // since the last successful connection. Drives the backoff delay.
+    private backoffAttempt = 0;
 
     private static instance: HolepunchRelay;
 
@@ -35,6 +50,16 @@ class HolepunchRelay {
     }
 
     private connectToRelayer(): void {
+        if (this.relayerUrls.length === 0) {
+            this.logger.warn("No holepunch relayers configured");
+            return;
+        }
+
+        if (this.isRelayerPoolExhausted()) {
+            this.scheduleRetryAfterExhaustion();
+            return;
+        }
+
         const relayerUrl = this.pickRandomRelayer();
         this.logger.info("Connecting to holepunch relayer", {
             relayerUrl
@@ -50,19 +75,21 @@ class HolepunchRelay {
                 this.logger.info("Holepunch relayer connected", {
                     relayerUrl
                 });
+                this.excludedRelayers.clear();
+                this.backoffAttempt = 0;
             };
             ws.onclose = () => {
                 this.logger.warn("Holepunch relayer disconnected", {
                     relayerUrl
                 });
-                this.removeAndConnectToRelayer(relayerUrl);
+                this.excludeAndConnectToRelayer(relayerUrl);
             };
             ws.onerror = (error) => {
                 this.logger.warn("Holepunch relayer error", {
                     relayerUrl,
                     error
                 });
-                this.removeAndConnectToRelayer(relayerUrl);
+                this.excludeAndConnectToRelayer(relayerUrl);
             };
 
             this.updateCallback();
@@ -71,7 +98,7 @@ class HolepunchRelay {
                 relayerUrl,
                 error: e
             });
-            this.removeAndConnectToRelayer(relayerUrl);
+            this.excludeAndConnectToRelayer(relayerUrl);
         }
     }
 
@@ -86,25 +113,45 @@ class HolepunchRelay {
     }
 
     private pickRandomRelayer(): string | undefined {
-        if (this.relayerUrls.length === 0) return undefined;
-        const index = Math.floor(Math.random() * this.relayerUrls.length);
-        return this.relayerUrls[index];
+        const available = this.relayerUrls.filter(
+            (url) => !this.excludedRelayers.has(url)
+        );
+        if (available.length === 0) return undefined;
+        const index = Math.floor(Math.random() * available.length);
+        return available[index];
     }
 
-    private removeRelayer(relayerUrl: string): boolean {
-        const index = this.relayerUrls.indexOf(relayerUrl);
-        if (index === -1) return false;
-        const deletedRelayer = this.relayerUrls.splice(index, 1);
-        this.logger.debug("Removed holepunch relayer", {
-            removed: deletedRelayer,
-            remaining: this.relayerUrls
+    // True once every configured relayer has failed since the last success
+    // (or since the last reset). Never true when relayerUrls is empty.
+    private isRelayerPoolExhausted(): boolean {
+        return (
+            this.relayerUrls.length > 0 &&
+            this.relayerUrls.every((url) => this.excludedRelayers.has(url))
+        );
+    }
+
+    private scheduleRetryAfterExhaustion(): void {
+        const delayMs = Math.min(
+            BACKOFF_BASE_MS * 2 ** this.backoffAttempt,
+            BACKOFF_CAP_MS
+        );
+        this.backoffAttempt++;
+        this.logger.warn(
+            "All holepunch relayers failed, retrying pool after backoff",
+            { delayMs, relayerUrls: this.relayerUrls }
+        );
+        this.excludedRelayers.clear();
+        setTimeout(() => this.connectToRelayer(), delayMs);
+    }
+
+    private excludeAndConnectToRelayer(relayerUrl: string): void {
+        this.excludedRelayers.add(relayerUrl);
+        this.logger.debug("Excluded holepunch relayer after failure", {
+            excluded: relayerUrl,
+            excludedCount: this.excludedRelayers.size,
+            total: this.relayerUrls.length
         });
-        return true;
-    }
-
-    private removeAndConnectToRelayer(relayerUrl: string): void {
-        const success = this.removeRelayer(relayerUrl);
-        success && this.connectToRelayer();
+        this.connectToRelayer();
     }
 }
 

--- a/test/utils/HolepunchRelay.test.ts
+++ b/test/utils/HolepunchRelay.test.ts
@@ -1,0 +1,202 @@
+import { expect } from "chai";
+import sinon from "sinon";
+
+// hyperswarm / @hyperswarm/dht-relay / @hyperswarm/dht-relay/ws all set up
+// real DHT/network machinery (including their own internal timers) on
+// construction. Stub them out via the require cache, before HolepunchRelay
+// is loaded, so tests exercise only the relayer-pool/backoff logic in
+// HolepunchRelay.ts against a controlled fake WebSocket - not real DHT
+// wiring or unrelated timers that would fight sinon's fake clock.
+class FakeHyperswarm {
+    constructor(_opts?: any) {}
+}
+class FakeDhtNode {
+    constructor(_stream?: any) {}
+}
+class FakeDhtStream {
+    constructor(_isInitiator?: boolean, _socket?: any) {}
+}
+
+function stubModule(specifier: string, fakeExports: any) {
+    const resolved = require.resolve(specifier);
+    require.cache[resolved] = {
+        id: resolved,
+        filename: resolved,
+        loaded: true,
+        exports: fakeExports
+    } as any;
+}
+
+stubModule("hyperswarm", FakeHyperswarm);
+stubModule("@hyperswarm/dht-relay", FakeDhtNode);
+stubModule("@hyperswarm/dht-relay/ws", FakeDhtStream);
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const HolepunchRelay = require("@/HolepunchRelay").default;
+
+// Minimal fake WebSocket the test drives manually via emitOpen/emitClose/emitError.
+class FakeWebSocket {
+    static instances: FakeWebSocket[] = [];
+
+    url: string;
+    readyState = 0; // CONNECTING
+    binaryType = "arraybuffer";
+
+    onopen: (() => void) | null = null;
+    onclose: (() => void) | null = null;
+    onerror: ((error: any) => void) | null = null;
+    onmessage: ((event: any) => void) | null = null;
+
+    constructor(url: string) {
+        this.url = url;
+        FakeWebSocket.instances.push(this);
+    }
+
+    addEventListener() {}
+    removeEventListener() {}
+    send(_data: any) {}
+    close() {
+        this.readyState = 3; // CLOSED
+    }
+
+    emitOpen() {
+        this.readyState = 1; // OPEN
+        this.onopen?.();
+    }
+
+    emitClose() {
+        this.onclose?.();
+    }
+
+    emitError(error: any = new Error("fake ws error")) {
+        this.onerror?.(error);
+    }
+}
+
+function createLogger() {
+    const logger: any = {
+        child: () => logger,
+        debug: () => undefined,
+        verbose: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+        info: () => undefined
+    };
+    return logger;
+}
+
+// Reaches into the singleton to reset it between tests, since
+// HolepunchRelay.init() always assigns HolepunchRelay.instance.
+function resetSingleton() {
+    (HolepunchRelay as any).instance = undefined;
+}
+
+describe("HolepunchRelay", function () {
+    let originalWebSocket: any;
+    let clock: sinon.SinonFakeTimers;
+
+    beforeEach(() => {
+        originalWebSocket = (global as any).WebSocket;
+        (global as any).WebSocket = FakeWebSocket;
+        FakeWebSocket.instances = [];
+        clock = sinon.useFakeTimers();
+        resetSingleton();
+    });
+
+    afterEach(() => {
+        (global as any).WebSocket = originalWebSocket;
+        clock.restore();
+        resetSingleton();
+    });
+
+    it("does not permanently exhaust the relayer pool after more failures than configured relayers", () => {
+        const relayerUrls = ["wss://relay-a.example", "wss://relay-b.example"];
+        let updateCallbackCount = 0;
+
+        HolepunchRelay.init(
+            relayerUrls,
+            () => {
+                updateCallbackCount++;
+            },
+            createLogger()
+        );
+
+        // Simulate more consecutive failures than there are configured relayers.
+        for (let i = 0; i < 5; i++) {
+            const ws =
+                FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+            ws.emitClose();
+            // A full-round exhaustion schedules a backoff retry; advance
+            // through the pending timer so the pool keeps retrying.
+            clock.tick(30000);
+        }
+
+        // Pre-fix, after relayerUrls.length (2) failures the pool would be
+        // permanently empty and connectToRelayer() would silently no-op -
+        // updateCallback would stop firing forever. Assert it keeps firing.
+        expect(updateCallbackCount).to.be.greaterThan(relayerUrls.length);
+        expect(FakeWebSocket.instances.length).to.be.greaterThan(
+            relayerUrls.length
+        );
+    });
+
+    it("keeps retrying a single configured relayer without locking out", () => {
+        const relayerUrls = ["wss://only-relay.example"];
+        let updateCallbackCount = 0;
+
+        HolepunchRelay.init(
+            relayerUrls,
+            () => {
+                updateCallbackCount++;
+            },
+            createLogger()
+        );
+
+        for (let i = 0; i < 4; i++) {
+            const ws =
+                FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+            ws.emitError();
+            clock.tick(30000);
+        }
+
+        // Every attempt should target the only configured relayer, and the
+        // pool should never go permanently dark - 1 initial connect + 4 retries.
+        expect(updateCallbackCount).to.equal(5);
+        for (const ws of FakeWebSocket.instances) {
+            expect(ws.url).to.equal(relayerUrls[0]);
+        }
+    });
+
+    it("resets exclusion/backoff state on a successful connection", () => {
+        const relayerUrls = ["wss://relay-a.example", "wss://relay-b.example"];
+        let updateCallbackCount = 0;
+
+        HolepunchRelay.init(
+            relayerUrls,
+            () => {
+                updateCallbackCount++;
+            },
+            createLogger()
+        );
+
+        // Fail both relayers once (exhausts the round, schedules backoff).
+        FakeWebSocket.instances[0].emitClose();
+        FakeWebSocket.instances[1].emitClose();
+
+        // The first exhaustion backoff is base * 2^0 = 1s; advance past it
+        // so the pool retries and produces a fresh connection to succeed on.
+        clock.tick(1000);
+        const successWs =
+            FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+        successWs.emitOpen();
+
+        // After success, a subsequent single failure must not be treated as
+        // a full-round exhaustion (no backoff delay) - a new connection
+        // attempt should happen synchronously via connectToRelayer(), not
+        // require a timer tick.
+        const countBeforeFailure = updateCallbackCount;
+        successWs.emitClose();
+
+        expect(updateCallbackCount).to.equal(countBeforeFailure + 1);
+    });
+});


### PR DESCRIPTION
## What was broken

`HolepunchRelay` connects to a random relayer from a small configured list (2 in production). Any close/error permanently deleted that relayer from the list before retrying. Two connectivity failures over a tab's lifetime — a WiFi/cellular handoff, a VPN toggle, or a mobile browser backgrounding — permanently killed reconnection, silently, for the rest of the session.

Found while scoping a mobile background/reconnect initiative; blocks it outright.

## What changed

`src/HolepunchRelay.ts`: replaced destructive removal with a non-destructive exclusion set. A failed relayer is excluded, not deleted. Once every relayer has failed, the set resets and the pool retries with capped exponential backoff (1s → 30s). A successful connection clears exclusion + backoff. Single-relayer configs now retry with backoff instead of locking out after one failure. Public API and callers unchanged.

## Test plan

- New `test/utils/HolepunchRelay.test.ts` (3 tests): pool survives more failures than configured relayers, single-relayer retries via backoff, success resets state.
- `yarn tsc --noEmit` clean for both configs (one unrelated pre-existing error in `DisputeValidationService.ts`, confirmed present before this change — stale generated types, not touched here).
- `yarn hardhat test` on `test/utils/*.test.ts` — 40/40 passing, no regressions.