### PR TITLE
feat(storage): add an async persistence port behind BlockStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,42 @@ The SDK abstracts away most of the complexities of the system and is designed to
 
 ## Configuration
 
+### Persistence
+
+`p2pSetup` enables persistence by default. Browser runtimes store channel
+partitions in IndexedDB; Node runtimes use embedded LevelDB in the operating
+system's application-data directory unless `persistence.location` is set.
+Pass the channel ID during setup to restore the channel signer and cached state
+before connecting:
+
+```ts
+await EvmStateMachine.p2pSetup(scm, stateMachine, deployStateMachine, {
+    channelId,
+    persistence: { location: "/path/to/app-data" }
+});
+```
+
+Each channel partition permits one live writer. Local demos or tests running
+multiple peers for the same channel must use separate locations or
+`persistence: false`.
+
+Storage writes update the in-memory cache immediately and are buffered to the
+platform database in short atomic batches. Protocol actions that expose signed
+state or submit transactions flush the required state internally first, and a
+graceful SDK shutdown flushes the remaining buffered writes. A forced process
+or worker termination can lose the unflushed, non-externalized tail.
+
+Persistence recovery fails closed when stored data is corrupt or incomplete
+and reports the resolved database location. Passing
+`persistence: { location, reset: true }` explicitly deletes that channel
+partition and starts fresh; it does not attempt to repair or preserve its data.
+
+Signer secrets are currently stored as plaintext local metadata. Node limits
+the default root to the current OS user; browsers rely on the origin boundary.
+Caller-supplied encryption and automatic partition destruction after a channel
+settles are not implemented yet. Proof-aware pruning is also pending, so
+partitions grow until the application removes them.
+
 Create a `peer3.config.json` file in the root of your project (next to `package.json`) with the following structure and set the values per your configuration:
 
 ```json

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "hardhat-gas-reporter": "^1.0.8",
     "husky": "^8.0.3",
     "lint-staged": "^14.0.1",
+    "memory-level": "^3",
     "nyc": "^15.1.0",
     "playwright": "^1.55.0",
     "prettier": "^3.2.5",
@@ -66,7 +67,9 @@
     "@nomiclabs/hardhat-ethers": "2.2.3",
     "@nomiclabs/hardhat-waffle": "2.0.6",
     "@openzeppelin/contracts": "^5.0.2",
+    "abstract-level": "^3",
     "axios": "^1.6.8",
+    "browser-level": "^3",
     "buffer": "^6.0.3",
     "ethereum-waffle": "4.0.10",
     "fflate": "^0.8.2",
@@ -89,6 +92,7 @@
     "get-logs": "ts-node scripts/logging/fetch-logs.ts",
     "test": "yarn hardhat test --no-compile $(find test -name '*.test.ts' -not -path 'test/e2e/*')",
     "test:browser:worker": "yarn build:browser && node test/browser/run-worker-contract-executor.mjs",
+    "test:browser:persistence": "yarn build:browser && node test/browser/run-persistence-restart.mjs",
     "test:browser:webrtc": "node test/browser/run-p2p-webrtc-e2e.mjs",
     "test:debug": "yarn hardhat test --no-compile $(find test -name '*.test.ts')",
     "test:all": "yarn hardhat test $(find test -name '*.test.ts')",
@@ -158,5 +162,8 @@
     "example": "examples",
     "test": "test"
   },
-  "author": ""
+  "author": "",
+  "optionalDependencies": {
+    "classic-level": "^3"
+  }
 }

--- a/scripts/benchmarks/persistence-write-behind.ts
+++ b/scripts/benchmarks/persistence-write-behind.ts
@@ -1,0 +1,334 @@
+import { monitorEventLoopDelay, performance } from "node:perf_hooks";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { ClassicLevel } from "classic-level";
+import { MemoryLevel } from "memory-level";
+
+import {
+    PersistenceController,
+    PersistentCollection,
+    type PersistenceBatchOperation,
+    type PersistenceDatabase,
+    type PersistenceDatabaseHandle
+} from "../../src/storage/persistence";
+import { createStorageRecordCodec } from "../../src/storage/persistence/storageCodecs";
+
+const WARMUPS = 5;
+const MEASURED_RUNS = 30;
+const WORKLOAD_SIZES = [10, 100, 1_000] as const;
+const OUTPUT_DIRECTORY = path.resolve(
+    "temp/plan-implementations/16-write-behind-persistence"
+);
+
+type Backend = "MemoryLevel" | "ClassicLevel";
+type Mode = "database-first" | "write-behind";
+type Workload = "distinct" | "repeated" | "canonical-transition";
+type Sample = {
+    backend: Backend;
+    mode: Mode;
+    workload: Workload;
+    writes: number;
+    mutationCallMs: number;
+    totalMs: number;
+    flushMs: number;
+    batchCalls: number;
+    submittedOperations: number;
+    mutationP50Ms: number;
+    mutationP95Ms: number;
+    eventLoopDelayP95Ms: number;
+};
+
+function percentile(values: number[], quantile: number): number {
+    const sorted = [...values].sort((left, right) => left - right);
+    return sorted[
+        Math.min(sorted.length - 1, Math.floor(sorted.length * quantile))
+    ];
+}
+
+function round(value: number): number {
+    return Number(value.toFixed(4));
+}
+
+function instrumentDatabase(database: PersistenceDatabase): {
+    getBatchCalls: () => number;
+    getSubmittedOperations: () => number;
+} {
+    const originalBatch = database.batch.bind(database);
+    let batchCalls = 0;
+    let submittedOperations = 0;
+    database.batch = ((
+        operations: PersistenceBatchOperation[]
+    ): Promise<void> => {
+        batchCalls += 1;
+        submittedOperations += operations.length;
+        return originalBatch(operations);
+    }) as PersistenceDatabase["batch"];
+    return {
+        getBatchCalls: () => batchCalls,
+        getSubmittedOperations: () => submittedOperations
+    };
+}
+
+async function createDatabase(
+    backend: Backend,
+    runId: string
+): Promise<{
+    handle: PersistenceDatabaseHandle;
+    cleanup: () => Promise<void>;
+}> {
+    if (backend === "MemoryLevel") {
+        const database = new MemoryLevel<string, string>({
+            keyEncoding: "utf8",
+            valueEncoding: "utf8"
+        });
+        let closed = false;
+        return {
+            handle: {
+                database,
+                location: `memory:${runId}`,
+                close: async () => {
+                    if (closed) return;
+                    closed = true;
+                    await database.close();
+                },
+                destroy: () => database.clear()
+            },
+            cleanup: async () => undefined
+        };
+    }
+
+    const root = await mkdtemp(
+        path.join(tmpdir(), "state-channels-plus-persistence-benchmark-")
+    );
+    const location = path.join(root, runId);
+    const database = new ClassicLevel<string, string>(location, {
+        keyEncoding: "utf8",
+        valueEncoding: "utf8"
+    });
+    let closed = false;
+    return {
+        handle: {
+            database,
+            location,
+            close: async () => {
+                if (closed) return;
+                closed = true;
+                await database.close();
+            },
+            destroy: async () => {
+                if (!closed) {
+                    closed = true;
+                    await database.close();
+                }
+                await ClassicLevel.destroy(location);
+            }
+        },
+        cleanup: () => rm(root, { recursive: true, force: true })
+    };
+}
+
+async function runSample(
+    backend: Backend,
+    mode: Mode,
+    workload: Workload,
+    writes: number,
+    run: number
+): Promise<Sample> {
+    const { handle, cleanup } = await createDatabase(
+        backend,
+        `${mode}-${workload}-${writes}-${run}`
+    );
+    const database = handle.database;
+    const instrumentation = instrumentDatabase(database);
+    const eventLoopDelay = monitorEventLoopDelay({ resolution: 1 });
+    const mutationLatencies: number[] = [];
+    let mutationCallMs = 0;
+    let flushMs = 0;
+    const startedAt = performance.now();
+    eventLoopDelay.enable();
+
+    try {
+        await database.open();
+        if (mode === "database-first") {
+            const cache = new Map<string, number>();
+            for (let index = 0; index < writes; index++) {
+                const key =
+                    workload === "repeated" ? "value" : `value-${index}`;
+                const mutationStartedAt = performance.now();
+                await database.batch([
+                    {
+                        type: "put",
+                        key: `records!v1!forceJoin!${key}`,
+                        value: `0x${index.toString(16).padStart(64, "0")}`
+                    }
+                ]);
+                cache.set(key, index);
+                const mutationMs = performance.now() - mutationStartedAt;
+                mutationLatencies.push(mutationMs);
+                mutationCallMs += mutationMs;
+            }
+        } else {
+            const controller = new PersistenceController(
+                createStorageRecordCodec(),
+                {
+                    databaseHandle: handle,
+                    flushIntervalMs: 60_000,
+                    maxBatchOperations: Number.MAX_SAFE_INTEGER
+                }
+            );
+            const values = new PersistentCollection<string, number>(
+                "forceJoin",
+                controller
+            );
+            await controller.bind();
+            for (let index = 0; index < writes; index++) {
+                const key =
+                    workload === "repeated" ? "value" : `value-${index}`;
+                const mutationStartedAt = performance.now();
+                values.set(key, index);
+                const mutationMs = performance.now() - mutationStartedAt;
+                mutationLatencies.push(mutationMs);
+                mutationCallMs += mutationMs;
+            }
+            const flushStartedAt = performance.now();
+            await controller.flush();
+            flushMs = performance.now() - flushStartedAt;
+            await controller.close();
+        }
+    } finally {
+        eventLoopDelay.disable();
+        await handle.close();
+        await cleanup();
+    }
+
+    return {
+        backend,
+        mode,
+        workload,
+        writes,
+        mutationCallMs: round(mutationCallMs),
+        totalMs: round(performance.now() - startedAt),
+        flushMs: round(flushMs),
+        batchCalls: instrumentation.getBatchCalls(),
+        submittedOperations: instrumentation.getSubmittedOperations(),
+        mutationP50Ms: round(percentile(mutationLatencies, 0.5)),
+        mutationP95Ms: round(percentile(mutationLatencies, 0.95)),
+        eventLoopDelayP95Ms: round(eventLoopDelay.percentile(95) / 1_000_000)
+    };
+}
+
+function summarize(samples: Sample[]) {
+    const groups = new Map<string, Sample[]>();
+    for (const sample of samples) {
+        const key = [
+            sample.backend,
+            sample.mode,
+            sample.workload,
+            sample.writes
+        ].join(":");
+        const values = groups.get(key) ?? [];
+        values.push(sample);
+        groups.set(key, values);
+    }
+    return [...groups.values()].map((values) => {
+        const first = values[0];
+        const median = (field: keyof Sample) =>
+            round(
+                percentile(
+                    values.map((sample) => Number(sample[field])),
+                    0.5
+                )
+            );
+        return {
+            backend: first.backend,
+            mode: first.mode,
+            workload: first.workload,
+            writes: first.writes,
+            mutationCallMs: median("mutationCallMs"),
+            totalMs: median("totalMs"),
+            flushMs: median("flushMs"),
+            batchCalls: median("batchCalls"),
+            submittedOperations: median("submittedOperations"),
+            mutationP50Ms: median("mutationP50Ms"),
+            mutationP95Ms: median("mutationP95Ms"),
+            eventLoopDelayP95Ms: median("eventLoopDelayP95Ms")
+        };
+    });
+}
+
+function renderReport(
+    summary: ReturnType<typeof summarize>,
+    nodeVersion: string
+): string {
+    const lines = [
+        "# Persistence write-behind benchmark",
+        "",
+        `Node ${nodeVersion}; ${WARMUPS} warmups and ${MEASURED_RUNS} measured runs per workload.`,
+        "",
+        "| Backend | Mode | Workload | Writes | Mutation calls ms | Total ms | Flush ms | Batches | Submitted ops | Mutation p50 ms | Mutation p95 ms | Event-loop p95 ms |",
+        "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+    ];
+    for (const row of summary) {
+        lines.push(
+            `| ${row.backend} | ${row.mode} | ${row.workload} | ${row.writes} | ${row.mutationCallMs} | ${row.totalMs} | ${row.flushMs} | ${row.batchCalls} | ${row.submittedOperations} | ${row.mutationP50Ms} | ${row.mutationP95Ms} | ${row.eventLoopDelayP95Ms} |`
+        );
+    }
+    return `${lines.join("\n")}\n`;
+}
+
+async function main(): Promise<void> {
+    const samples: Sample[] = [];
+    const workloads = [
+        ...(["distinct", "repeated"] as const).flatMap((workload) =>
+            WORKLOAD_SIZES.map((writes) => ({ workload, writes }))
+        ),
+        // Snapshot, state, block, metadata, outbound message, participant
+        // change, and force-join removal before the externalization gate.
+        { workload: "canonical-transition" as const, writes: 7 }
+    ];
+    for (const backend of ["MemoryLevel", "ClassicLevel"] as const) {
+        for (const mode of ["database-first", "write-behind"] as const) {
+            for (const { workload, writes } of workloads) {
+                for (let run = -WARMUPS; run < MEASURED_RUNS; run++) {
+                    const sample = await runSample(
+                        backend,
+                        mode,
+                        workload,
+                        writes,
+                        run
+                    );
+                    if (run >= 0) samples.push(sample);
+                }
+            }
+        }
+    }
+
+    const summary = summarize(samples);
+    const raw = {
+        environment: {
+            node: process.version,
+            platform: process.platform,
+            architecture: process.arch,
+            warmups: WARMUPS,
+            measuredRuns: MEASURED_RUNS
+        },
+        samples,
+        summary
+    };
+    await mkdir(OUTPUT_DIRECTORY, { recursive: true });
+    await Promise.all([
+        writeFile(
+            path.join(OUTPUT_DIRECTORY, "benchmark-node.json"),
+            `${JSON.stringify(raw, null, 2)}\n`
+        ),
+        writeFile(
+            path.join(OUTPUT_DIRECTORY, "benchmark-node.md"),
+            renderReport(summary, process.version)
+        )
+    ]);
+    console.log(JSON.stringify(summary, null, 2));
+}
+
+void main();

--- a/src/disputeManager/DisputeManager.ts
+++ b/src/disputeManager/DisputeManager.ts
@@ -110,6 +110,8 @@ class DisputeManager {
                 fraudProofsToApply
             );
 
+            await this.storage.flush();
+
             // check if multicall is needed
             if (fraudProofsToApply.length > 0) {
                 // 1) apply fraud proofs

--- a/src/eventHandlers/EventHandler.ts
+++ b/src/eventHandlers/EventHandler.ts
@@ -230,6 +230,8 @@ export class EventHandler {
     private async handleChannelClose(channelId: ChannelId): Promise<void> {
         this.logger.info("Handling channel close", { channelId });
 
+        // TODO(persistence): destroy the settled channel partition after
+        // signer-key lifecycle ownership is defined.
         this.stateManager.setStatus(Status.NOT_OPENED);
 
         // Disconnect from all peers in this channel
@@ -254,8 +256,8 @@ export class EventHandler {
                 Block.fromSignedBlock(signedBlock)
             )
         });
-        // Recovery schedules this handler without awaiting validation; keep
-        // this store before the first await so its immediate re-read is valid.
+        // Recovery schedules this handler without awaiting validation; finish
+        // this store before its immediate re-read.
         this.storage.blockCalldata.storeBlockCalldata({
             signedBlock,
             onChainTimestamp: timestamp
@@ -358,7 +360,7 @@ export class EventHandler {
             return;
         }
 
-        this.stateManager.blockQueueManager.clearFork(forkId);
+        await this.stateManager.blockQueueManager.clearFork(forkId);
 
         const isFirstOccurrence =
             this.stateManager.p2pManager.localRpc.isForkDisputedService.requestDisputeAcknowledgment(
@@ -504,7 +506,7 @@ export class EventHandler {
                     );
                 }
             }
-            this.stateManager.disputeValidationService.persistDisputeDataWithoutAudit(
+            await this.stateManager.disputeValidationService.persistDisputeDataWithoutAudit(
                 dispute,
                 persistableAuditingData,
                 { includeUnfinalizedBlocks: true }

--- a/src/evm/EvmDiamondStateMachine.ts
+++ b/src/evm/EvmDiamondStateMachine.ts
@@ -17,7 +17,11 @@ import {
     type AContractExecutor,
     type ContractExecutionLog
 } from "./contractExecutor";
-import { Address, Bytes } from "@/types/types";
+import { Address, Bytes, ChannelId } from "@/types/types";
+import {
+    openPersistencePartition,
+    type PersistenceOptions
+} from "@/storage/persistence";
 import {
     BalanceStruct,
     MessageStruct
@@ -461,6 +465,18 @@ class EvmDiamondStateMachine extends ADiamondStateMachine {
              */
             signerSecret?: string;
             /**
+             * Durable storage is enabled by default. Browsers use IndexedDB and
+             * Node uses an embedded LevelDB. One live runtime owns a channel
+             * partition, so local multi-peer setups must use distinct locations
+             * or pass `false`.
+             */
+            persistence?: boolean | PersistenceOptions;
+            /**
+             * Known channel identity used to recover the persisted signer and
+             * channel state before the runtime graph is constructed.
+             */
+            channelId?: ChannelId;
+            /**
              * Context every inline-host handler runs inside (see
              * {@link HostHandlerExecutionContext}). Ignored in threaded mode —
              * a worker thread runs exactly one peer's host.
@@ -471,22 +487,8 @@ class EvmDiamondStateMachine extends ADiamondStateMachine {
         // Initialize SDK config for this runtime (intended to be called once).
         const activeConfig = createConfig(options?.config);
 
-        const runtimeSignerSecret =
+        let runtimeSignerSecret =
             options?.signerSecret ?? ethers.Wallet.createRandom().privateKey;
-        const trimmedSignerSecret = runtimeSignerSecret.trim();
-        const resolvedSignerAddress = /^0x[0-9a-fA-F]{64}$/.test(
-            trimmedSignerSecret
-        )
-            ? new ethers.Wallet(trimmedSignerSecret).address
-            : ethers.Wallet.fromPhrase(trimmedSignerSecret).address;
-
-        const logger =
-            options?.peerLogger ||
-            createLogger(
-                { peerId: options?.peerId, peerAddress: resolvedSignerAddress },
-                { component: "ClientApp" },
-                { attachErrorListener: true }
-            );
 
         // Main-thread description of the app contract (rebuilt by the client).
         const stateMachine: SerializedContract = {
@@ -509,12 +511,65 @@ class EvmDiamondStateMachine extends ADiamondStateMachine {
                 "p2pSetup requires the state channel manager to have a provider"
             );
         }
+        const persistence =
+            options?.persistence === false
+                ? undefined
+                : options?.persistence === true ||
+                    options?.persistence === undefined
+                  ? {}
+                  : options.persistence;
+        const persistenceIdentity = persistence
+            ? {
+                  chainId: (
+                      await clientProvider.getNetwork()
+                  ).chainId.toString(),
+                  stateChannelManagerAddress: scm.address,
+                  stateMachineAddress: stateMachine.address
+              }
+            : undefined;
+        const channelId = options?.channelId
+            ? ethers.hexlify(options.channelId)
+            : undefined;
+
+        if (persistence && persistenceIdentity && channelId) {
+            const preparedPartition = await openPersistencePartition({
+                identity: { ...persistenceIdentity, channelId },
+                persistence,
+                signerSecret: runtimeSignerSecret,
+                existingPartition: "allow"
+            });
+            runtimeSignerSecret = preparedPartition.signerSecret;
+            await preparedPartition.databaseHandle.close();
+        }
+
+        const trimmedSignerSecret = runtimeSignerSecret.trim();
+        const resolvedSignerAddress = /^0x[0-9a-fA-F]{64}$/.test(
+            trimmedSignerSecret
+        )
+            ? new ethers.Wallet(trimmedSignerSecret).address
+            : ethers.Wallet.fromPhrase(trimmedSignerSecret).address;
+
+        const logger =
+            options?.peerLogger ||
+            createLogger(
+                { peerId: options?.peerId, peerAddress: resolvedSignerAddress },
+                { component: "ClientApp" },
+                { attachErrorListener: true }
+            );
 
         const payload: SetupPayload = {
             config: activeConfig,
             scm,
             stateMachine,
             signerSecret: runtimeSignerSecret,
+            persistence:
+                persistence && persistenceIdentity
+                    ? {
+                          options: persistence,
+                          identity: persistenceIdentity,
+                          channelId
+                      }
+                    : undefined,
             peerId: options?.peerId,
             customRpcManifest: options?.customRpcManifest,
             customPrecompiles: options?.customPrecompiles

--- a/src/evm/index.ts
+++ b/src/evm/index.ts
@@ -23,6 +23,7 @@ import type {
     EvmNativeCustomPrecompile
 } from "./EvmFactory";
 import type { LocalStateMachineDeployer } from "../../scripts/V1/deploy";
+import type { PersistenceOptions } from "@/storage/persistence";
 
 export {
     AContractExecutor,
@@ -47,5 +48,6 @@ export type {
     EvmCustomPrecompileManifest,
     EvmFactoryOptions,
     EvmNativeCustomPrecompile,
-    LocalStateMachineDeployer
+    LocalStateMachineDeployer,
+    PersistenceOptions
 };

--- a/src/evm/p2pRuntime/P2pRuntimeHost.ts
+++ b/src/evm/p2pRuntime/P2pRuntimeHost.ts
@@ -12,6 +12,10 @@ import Storage from "@/storage";
 import { TimeConfig } from "@/types";
 import type { ForkId, Hash } from "@/types/types";
 import {
+    openPersistencePartition,
+    type PersistenceDatabaseHandle
+} from "@/storage/persistence";
+import {
     createLogger,
     Codec,
     DebugProxy,
@@ -78,6 +82,7 @@ export interface HostContext {
 interface RuntimeHostState {
     stateManager: StateManager;
     evmDiamondStateMachine: EvmDiamondStateMachine;
+    storage: Storage;
 }
 
 /**
@@ -207,16 +212,33 @@ export async function startP2pRuntimeHost<
 >(port: RuntimePort, payload: SetupPayload, ctx: HostContext): Promise<void> {
     const { threadLabel, handlerExecutionContext } = ctx;
     let chainContext: RuntimeChainContext;
+    let persistenceDatabaseHandle: PersistenceDatabaseHandle | undefined;
+    let runtimeSignerSecret = payload.signerSecret;
+    let boundChannelId = payload.persistence?.channelId;
     try {
+        if (payload.persistence?.channelId) {
+            const partition = await openPersistencePartition({
+                identity: {
+                    ...payload.persistence.identity,
+                    channelId: payload.persistence.channelId
+                },
+                persistence: payload.persistence.options,
+                signerSecret: payload.signerSecret,
+                existingPartition: "allow"
+            });
+            persistenceDatabaseHandle = partition.databaseHandle;
+            runtimeSignerSecret = partition.signerSecret;
+        }
         chainContext = await createRuntimeChainContext(
             payload.config,
-            payload.signerSecret
+            runtimeSignerSecret
         );
     } catch (error) {
         // Provider creation happens before the rest of the runtime graph exists,
         // but its failure must still settle the paired client's `ready` promise.
         port.post({ type: "hostError", error: serializeError(error) });
         port.close();
+        await persistenceDatabaseHandle?.close();
         throw error;
     }
     const { provider, signer } = chainContext;
@@ -238,6 +260,7 @@ export async function startP2pRuntimeHost<
             if (runtimeHandle) {
                 await runtimeHandle.stateManager.dispose();
             } else {
+                await persistenceDatabaseHandle?.close();
                 await contractExecutor?.dispose();
                 logger?.stopPerformanceMonitoring();
             }
@@ -339,7 +362,11 @@ export async function startP2pRuntimeHost<
                     disputeExecutionGasLimit
                 );
 
-            const storage = new Storage();
+            const storage = new Storage(logger, payload.persistence?.options);
+            if (persistenceDatabaseHandle) {
+                await storage.bind(persistenceDatabaseHandle);
+                persistenceDatabaseHandle = undefined;
+            }
 
             const stateManager = new StateManager<
                 TCustomRpc,
@@ -359,6 +386,7 @@ export async function startP2pRuntimeHost<
                 customRpcResolved?.customRpc,
                 customRpcResolved?.customRpcOptions
             );
+            storage.setPersistenceFailureHandler(() => stateManager.abort());
 
             evmDiamondStateMachine.setStateManager(stateManager);
 
@@ -370,6 +398,10 @@ export async function startP2pRuntimeHost<
             evmDiamondStateMachine.setContractEventEmitter((name, args) =>
                 port.post({ type: "contractEvent", name, args })
             );
+
+            if (boundChannelId) {
+                await stateManager.setChannelId(boundChannelId);
+            }
 
             forwardEventHandlerInvocations(
                 stateManager.eventHandler,
@@ -386,7 +418,11 @@ export async function startP2pRuntimeHost<
                     );
             }
 
-            runtimeHandle = { stateManager, evmDiamondStateMachine };
+            runtimeHandle = {
+                stateManager,
+                evmDiamondStateMachine,
+                storage
+            };
             // A bridge-setup failure must not deadlock `ready`; WebRTC is optional.
             try {
                 bridgeWorkerPort = await bubbleWebRTCBridgePortIfNeeded(port);
@@ -491,6 +527,7 @@ export async function startP2pRuntimeHost<
                     case "connectToChannel":
                         if (!runtimeHandle)
                             throw new Error("Runtime is not ready");
+                        await bindPersistenceForChannel(request.channelId);
                         await runtimeHandle.stateManager.p2pManager.p2pSigner.connectToChannel(
                             request.channelId
                         );
@@ -542,6 +579,7 @@ export async function startP2pRuntimeHost<
                     case "setChannelId":
                         if (!runtimeHandle)
                             throw new Error("Runtime is not ready");
+                        await bindPersistenceForChannel(request.channelId);
                         await runtimeHandle.stateManager.p2pManager.p2pSigner.setChannelId(
                             request.channelId
                         );
@@ -618,6 +656,42 @@ export async function startP2pRuntimeHost<
                     error: serializeError(error)
                 });
             }
+        };
+
+        const bindPersistenceForChannel = async (
+            channelId: string
+        ): Promise<void> => {
+            if (!payload.persistence) return;
+            const normalizedChannelId = ethers.hexlify(channelId).toLowerCase();
+            if (boundChannelId) {
+                if (
+                    ethers.hexlify(boundChannelId).toLowerCase() !==
+                    normalizedChannelId
+                ) {
+                    throw new Error(
+                        "A persistent runtime cannot be rebound to another channel"
+                    );
+                }
+                return;
+            }
+            if (!runtimeHandle) throw new Error("Runtime is not ready");
+            const partition = await openPersistencePartition({
+                identity: {
+                    ...payload.persistence.identity,
+                    channelId: normalizedChannelId
+                },
+                persistence: payload.persistence.options,
+                signerSecret: runtimeSignerSecret,
+                existingPartition: "reject"
+            });
+            if (partition.signerSecret !== runtimeSignerSecret) {
+                await partition.databaseHandle.close();
+                throw new Error(
+                    "Late channel binding cannot replace the runtime signer"
+                );
+            }
+            await runtimeHandle.storage.bind(partition.databaseHandle);
+            boundChannelId = normalizedChannelId;
         };
 
         const onPortMessage = (raw: unknown): void => {

--- a/src/evm/p2pRuntime/types.ts
+++ b/src/evm/p2pRuntime/types.ts
@@ -2,6 +2,10 @@ import type { Config } from "@/utils/config";
 import type { EvmCustomPrecompileManifest } from "@/evm/EvmFactory";
 import type { CustomRpcManifest } from "@/rpc/registry";
 import type { RuntimeRequestInput } from "./worker/protocol";
+import type {
+    PersistenceOptions,
+    PersistencePartitionIdentity
+} from "@/storage/persistence";
 
 /**
  * Transport definitions for the p2p runtime channel.
@@ -54,6 +58,11 @@ export interface SetupPayload {
      * `ethers.Wallet` inside the host.
      */
     signerSecret: string;
+    persistence?: {
+        options: PersistenceOptions;
+        identity: Omit<PersistencePartitionIdentity, "channelId">;
+        channelId?: string;
+    };
     peerId?: number;
     /** Optional dynamic custom RPC manifest resolved on the host side. */
     customRpcManifest?: CustomRpcManifest;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export type {
     EvmNativeCustomPrecompile,
     LocalStateMachineDeployer
 } from "@/evm";
+export type { PersistenceOptions } from "@/storage/persistence";
 
 export {
     AContractExecutor,

--- a/src/rpc/services/spectate/SpectateService.ts
+++ b/src/rpc/services/spectate/SpectateService.ts
@@ -854,7 +854,7 @@ class SpectateService extends ARpcService<SpectateServiceRpcMethods> {
                             .stateMachineStateHash
                     }
                 );
-                this.persistFinalizedBlocks(finalizedBlocks);
+                await this.persistFinalizedBlocks(finalizedBlocks);
                 for (const snapshot of syncPayload.milestoneSnapshots)
                     storage.stateSnapshots.storeStateSnapshot(
                         StateSnapshot.from(snapshot)
@@ -903,7 +903,7 @@ class SpectateService extends ARpcService<SpectateServiceRpcMethods> {
         return blocks.some((block) => this.hasBlockConflict(block));
     }
 
-    private persistFinalizedBlocks(blocks: Block[]): void {
+    private async persistFinalizedBlocks(blocks: Block[]): Promise<void> {
         const storage = this.p2pManager.stateManager.storage;
         for (const block of blocks) storage.blocks.storeBlock(block);
     }

--- a/src/stateManager/BlockQueueManager.ts
+++ b/src/stateManager/BlockQueueManager.ts
@@ -30,6 +30,12 @@ export default class BlockQueueManager {
         new Map();
     private readonly logger: Logger;
 
+    // Blocks currently dequeued and executing. An entry leaves the queue before
+    // it runs, so a copy arriving meanwhile would otherwise look unknown and be
+    // scheduled a second time. Held from dequeue until `executeQueuedEntry`
+    // finishes (released in its `finally`, so a throw can't strand the hash).
+    private readonly executingHashes = new Set<Hash>();
+
     // Fork-recovery gate. A mismatched block may just mean we're late to reduce
     // our own disputed current fork. Reducing takes the StateManager mutex, so
     // it MUST run detached (ingest can be under that mutex via the dispute
@@ -88,6 +94,16 @@ export default class BlockQueueManager {
                 options?.onChainTimestamp
             );
 
+            // Executing right now: park the copy so its signatures/sources pool
+            // into a deferred entry (queued under the same block hash) without
+            // scheduling a second execution. `executeQueuedEntry` drains it.
+            if (this.executingHashes.has(block.hash)) {
+                this.stateManager.storage.queues.queueBlock(block, {
+                    senderAddress: options?.senderAddress
+                });
+                return true;
+            }
+
             if (this.isBlockStored(block)) {
                 this.scheduleStoredBlockConfirmationMerge(
                     this.stateManager.storage.queues.createEntry(block, {
@@ -117,7 +133,7 @@ export default class BlockQueueManager {
                     block.channelId
                 )
             ) {
-                this.clearFork(block.forkId);
+                await this.clearFork(block.forkId);
                 this.logger.verbose(
                     "ingestBlockConfirmation - ignoring unstored block on disputed fork",
                     {
@@ -160,6 +176,24 @@ export default class BlockQueueManager {
     public onForkTransition(): void {
         this.recoveryScheduledForFork.clear();
         this.recoverySuppressedUntil.clear();
+    }
+
+    /**
+     * Restart entry point: the queue is durable but timers are process-local,
+     * so hydrated entries come back with no timeout armed. Re-arm each one for
+     * the REMAINDER of its window (`scheduleQueueTimeout` reads the persisted
+     * `firstSeenAt`, so a restart never grants a fresh one) and drain the forks
+     * they belong to. Runs before listeners/transport attach.
+     */
+    public async resumePersistedQueue(): Promise<void> {
+        const forkIds = new Set<ForkId>();
+        for (const entry of this.stateManager.storage.queues.getEntries()) {
+            this.scheduleQueueTimeout(entry.block.hash);
+            forkIds.add(entry.block.forkId);
+        }
+        for (const forkId of forkIds) {
+            await this.tryExecuteFromQueue(forkId);
+        }
     }
 
     /**
@@ -262,7 +296,7 @@ export default class BlockQueueManager {
             for (const entry of entries) {
                 this.cancelQueueTimeout(entry.block.hash);
             }
-            this.clearFork(entries[0].block.forkId);
+            await this.clearFork(entries[0].block.forkId);
             this.logger.verbose(
                 "tryExecuteFromQueue - discarded queued blocks for disputed fork",
                 {
@@ -275,6 +309,7 @@ export default class BlockQueueManager {
 
         for (const entry of entries) {
             this.cancelQueueTimeout(entry.block.hash);
+            this.executingHashes.add(entry.block.hash);
             this.scheduleQueuedEntryExecution(entry);
         }
     }
@@ -293,7 +328,7 @@ export default class BlockQueueManager {
                 entry.block.channelId
             )
         ) {
-            this.clearFork(entry.block.forkId);
+            await this.clearFork(entry.block.forkId);
             return;
         }
 
@@ -355,7 +390,7 @@ export default class BlockQueueManager {
         this.requestSync(entry);
     }
 
-    public clearFork(forkId: ForkId): void {
+    public async clearFork(forkId: ForkId): Promise<void> {
         const removedHashes =
             this.stateManager.storage.queues.clearFork(forkId);
         for (const hash of removedHashes) {
@@ -451,10 +486,10 @@ export default class BlockQueueManager {
      * - Otherwise restore + (re)arm the remaining-window timeout; if the window
      *   already elapsed, run the timeout logic as an immediate task.
      */
-    public restoreQueuedEntry(
+    public async restoreQueuedEntry(
         entry: QueuedBlockEntry,
         strategy?: AValidationStrategy
-    ): void {
+    ): Promise<void> {
         if (this.isBlockStored(entry.block)) {
             this.scheduleStoredBlockConfirmationMerge(
                 entry,
@@ -517,33 +552,72 @@ export default class BlockQueueManager {
         });
     }
 
+    /**
+     * Executes a dequeued entry and then drains its deferred copy - the single
+     * entry (the queue is keyed by block hash) that pooled every copy ingest
+     * parked while this hash was in `executingHashes`. That copy carries
+     * signatures/attribution `entry` never saw, and ingest scheduled neither a
+     * timeout nor an execution for it, so nothing else would pick it up - and
+     * the queue is durable now, so it would linger past restart.
+     */
     private async executeQueuedEntry(entry: QueuedBlockEntry): Promise<void> {
-        if (this.isBlockStored(entry.block)) {
-            await this.handleStoredBlockConfirmationMerge(
-                entry,
-                this.stateManager.getActiveValidationStrategy()
-            );
-            return;
-        }
-
-        // The pipeline handles a fork that moved out from under this entry (as a
-        // side effect: it restores the entry for a timeout sync, or drops it if
-        // we've moved past it) - see `onBlockConfirmation`. A `false` here is a
-        // genuine validation failure on the current fork.
-        const shouldKeepConnection =
-            await this.stateManager.onBlockConfirmation(entry);
-
-        if (!shouldKeepConnection) {
-            this.logger.warn(
-                "tryExecuteFromQueue - queued block failed canonical validation",
-                {
-                    block: LoggerUtils.getBlockMetadata(
-                        entry.block,
-                        this.stateManager.storage
-                    ),
-                    sourcePeers: Array.from(entry.sourcePeers)
+        try {
+            if (this.isBlockStored(entry.block)) {
+                await this.handleStoredBlockConfirmationMerge(
+                    entry,
+                    this.stateManager.getActiveValidationStrategy()
+                );
+                // Merged separately: `entry` was dequeued before the copies
+                // arrived, so the two hold different signature sets.
+                const deferred = this.stateManager.storage.queues.removeBlock(
+                    entry.block.hash
+                );
+                if (deferred) {
+                    await this.handleStoredBlockConfirmationMerge(
+                        deferred,
+                        this.stateManager.getActiveValidationStrategy()
+                    );
                 }
-            );
+                return;
+            }
+
+            // The pipeline handles a fork that moved out from under this entry (as a
+            // side effect: it restores the entry for a timeout sync, or drops it if
+            // we've moved past it) - see `onBlockConfirmation`. A `false` here is a
+            // genuine validation failure on the current fork.
+            const shouldKeepConnection =
+                await this.stateManager.onBlockConfirmation(entry);
+
+            if (!shouldKeepConnection) {
+                this.logger.warn(
+                    "tryExecuteFromQueue - queued block failed canonical validation",
+                    {
+                        block: LoggerUtils.getBlockMetadata(
+                            entry.block,
+                            this.stateManager.storage
+                        ),
+                        sourcePeers: Array.from(entry.sourcePeers)
+                    }
+                );
+            }
+
+            // Only drain once the block actually stored. On a failure or a
+            // not-ready result `restoreQueuedEntry` has already merged `entry`
+            // INTO the deferred copy and armed its timeout - removing it here
+            // would drop the entry the queue now owns.
+            if (this.isBlockStored(entry.block)) {
+                const deferred = this.stateManager.storage.queues.removeBlock(
+                    entry.block.hash
+                );
+                if (deferred) {
+                    await this.handleStoredBlockConfirmationMerge(
+                        deferred,
+                        this.stateManager.getActiveValidationStrategy()
+                    );
+                }
+            }
+        } finally {
+            this.executingHashes.delete(entry.block.hash);
         }
     }
 

--- a/src/stateManager/DisputeValidationService.ts
+++ b/src/stateManager/DisputeValidationService.ts
@@ -54,7 +54,7 @@ export default class DisputeValidationService {
             this.logger.warn("Dispute inbound hash not in chain", {
                 dispute: LoggerUtils.getDisputeMetadata(dispute)
             });
-            this.disputeFraudProofService.createDisputeInboundHashNotInChain(
+            await this.disputeFraudProofService.createDisputeInboundHashNotInChain(
                 dispute
             );
             return false;
@@ -77,7 +77,7 @@ export default class DisputeValidationService {
                     "Dispute posted with auditing data, but auditing data missing"
                 );
             }
-            this.disputeFraudProofService.createDisputeInvalidStateProof(
+            await this.disputeFraudProofService.createDisputeInvalidStateProof(
                 dispute,
                 onChainDisputeAuditingData
             );
@@ -95,7 +95,7 @@ export default class DisputeValidationService {
                     dispute: LoggerUtils.getDisputeMetadata(dispute)
                 }
             );
-            this.disputeFraudProofService.createDisputeStateProofHeaderMismatch(
+            await this.disputeFraudProofService.createDisputeStateProofHeaderMismatch(
                 dispute
             );
             return false;
@@ -110,7 +110,7 @@ export default class DisputeValidationService {
                 dispute: LoggerUtils.getDisputeMetadata(dispute),
                 blockIndex: invalidStructureResult.blockIndex
             });
-            this.disputeFraudProofService.createDisputeInvalidBlockStructure(
+            await this.disputeFraudProofService.createDisputeInvalidBlockStructure(
                 dispute,
                 Number(invalidStructureResult.blockIndex)
             );
@@ -133,14 +133,14 @@ export default class DisputeValidationService {
                 this.logger.warn("Auditing: Invalid state proof", {
                     dispute: LoggerUtils.getDisputeMetadata(dispute)
                 });
-                this.disputeFraudProofService.createDisputeInvalidStateProof(
+                await this.disputeFraudProofService.createDisputeInvalidStateProof(
                     dispute,
                     onChainDisputeAuditingData
                 );
                 return false;
             }
 
-            this.persistDisputeDataWithoutAudit(
+            await this.persistDisputeDataWithoutAudit(
                 dispute,
                 onChainDisputeAuditingData,
                 { includeUnfinalizedBlocks: false }
@@ -151,7 +151,7 @@ export default class DisputeValidationService {
                     dispute
                 );
             if (!milestoneFinalityResult) {
-                this.disputeFraudProofService.createDisputeLastMilestoneNotFinalAndNoAuditingData(
+                await this.disputeFraudProofService.createDisputeLastMilestoneNotFinalAndNoAuditingData(
                     dispute
                 );
                 return false;
@@ -273,7 +273,7 @@ export default class DisputeValidationService {
                             LoggerUtils.getAuditingMetadata(disputeAuditingData)
                     }
                 );
-                this.disputeFraudProofService.createDisputeInvalidStateProof(
+                await this.disputeFraudProofService.createDisputeInvalidStateProof(
                     dispute,
                     disputeAuditingData
                 );
@@ -305,7 +305,7 @@ export default class DisputeValidationService {
                 this.logger.debug(
                     `dispute slashes ${[...disputeOnChainSlashes].map((a) => a.toString())} not subset of on-chain slashes ${[...onChainSlashes].map((a) => a.toString())}`
                 );
-                this.disputeFraudProofService.createDisputeOnChainSlashesNotSubset(
+                await this.disputeFraudProofService.createDisputeOnChainSlashesNotSubset(
                     dispute
                 );
                 return false;
@@ -328,7 +328,7 @@ export default class DisputeValidationService {
                 }
             );
 
-            this.disputeFraudProofService.createDisputeInvalidBalanceInvariant(
+            await this.disputeFraudProofService.createDisputeInvalidBalanceInvariant(
                 dispute,
                 disputeAuditingData.latestStateSnapshot,
                 latestStateMachineState
@@ -353,7 +353,7 @@ export default class DisputeValidationService {
                 this.logger.debug("Dispute not latest state", {
                     dispute: LoggerUtils.getDisputeMetadata(dispute)
                 });
-                this.disputeFraudProofService.createDisputeNotLatestState(
+                await this.disputeFraudProofService.createDisputeNotLatestState(
                     dispute,
                     result.block.encode(),
                     result.signature
@@ -391,7 +391,7 @@ export default class DisputeValidationService {
                 expectedTimeoutHeight !==
                 Number(dispute.input.timeout.blockHeight)
             ) {
-                this.disputeFraudProofService.createTimeoutNotLinkedToLatestState(
+                await this.disputeFraudProofService.createTimeoutNotLinkedToLatestState(
                     dispute
                 );
                 return false;
@@ -402,7 +402,7 @@ export default class DisputeValidationService {
                 latestStateMachineState
             );
             if (nextToWrite !== dispute.input.timeout.participant) {
-                this.disputeFraudProofService.createTimeoutParticipantNotNext(
+                await this.disputeFraudProofService.createTimeoutParticipantNotNext(
                     dispute,
                     disputeAuditingData.latestStateSnapshot,
                     latestStateMachineState
@@ -460,7 +460,7 @@ export default class DisputeValidationService {
                         Number(dispute.input.timeout.blockHeight)
                     )
             ) {
-                this.disputeFraudProofService.createTimeoutTooEarly(
+                await this.disputeFraudProofService.createTimeoutTooEarly(
                     dispute,
                     disputeAuditingData.genesisStateSnapshotData,
                     previousBlockOrSnapshot?.block?.onChainTimestamp
@@ -470,7 +470,7 @@ export default class DisputeValidationService {
 
             // [check] N/N Threshold
             if (block && block.didEveryoneSign(participants)) {
-                this.disputeFraudProofService.createTimeoutThreshold(
+                await this.disputeFraudProofService.createTimeoutThreshold(
                     dispute,
                     block.blockConfirmationStruct,
                     disputeAuditingData.latestStateSnapshot,
@@ -508,7 +508,7 @@ export default class DisputeValidationService {
                         dispute
                     );
                 if (isValid) {
-                    this.disputeFraudProofService.storeTimeoutCalldataPosted(
+                    await this.disputeFraudProofService.storeTimeoutCalldataPosted(
                         dispute,
                         proof
                     );
@@ -537,7 +537,7 @@ export default class DisputeValidationService {
                     dispute: LoggerUtils.getDisputeMetadata(dispute)
                 }
             );
-            this.disputeFraudProofService.createInvalidDisputeReason(
+            await this.disputeFraudProofService.createInvalidDisputeReason(
                 dispute,
                 disputeAuditingData.latestStateSnapshot
             );
@@ -596,7 +596,7 @@ export default class DisputeValidationService {
 
         if (!isCorrectDisputeOutput) {
             // invalid dispute output
-            this.disputeFraudProofService.createDisputeInvalidOutputState(
+            await this.disputeFraudProofService.createDisputeInvalidOutputState(
                 dispute,
                 disputeAuditingData.latestStateSnapshot,
                 latestStateMachineState,
@@ -852,11 +852,11 @@ export default class DisputeValidationService {
         }
     }
 
-    public persistDisputeDataWithoutAudit(
+    public async persistDisputeDataWithoutAudit(
         dispute: DisputeStruct,
         disputeAuditingData: DisputeAuditingDataStruct | undefined,
         options: { includeUnfinalizedBlocks: boolean }
-    ): void {
+    ): Promise<void> {
         if (disputeAuditingData) {
             if (options.includeUnfinalizedBlocks) {
                 this.storage.stateSnapshots.storeStateSnapshot(

--- a/src/stateManager/EventSyncService.ts
+++ b/src/stateManager/EventSyncService.ts
@@ -137,10 +137,13 @@ export default class EventSyncService {
                 });
                 throw error;
             })
-            .finally(() => {
+            .finally(async () => {
                 state.pending -= 1;
                 state.complete = state.pending === 0 && !state.failed;
-                this.publishCompletedBlocks(scheduledChannelId, channelKey);
+                await this.publishCompletedBlocks(
+                    scheduledChannelId,
+                    channelKey
+                );
             });
         this.eventPromises.set(eventKey, promise);
         this.eventBlockNumbers.set(eventKey, log.blockNumber);
@@ -458,10 +461,10 @@ export default class EventSyncService {
         }
     }
 
-    private publishCompletedBlocks(
+    private async publishCompletedBlocks(
         channelId: ChannelId,
         channelKey: ChannelKey
-    ): void {
+    ): Promise<void> {
         const states = this.getBlockStates(channelKey);
         const ordered = [...states.keys()].sort((a, b) => a - b);
         let publishable: BlockNumber | undefined;

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -33,6 +33,7 @@ import { ReductionManager } from "./reduction";
 import { SnapshotUpdateService } from "./snapshotUpdate";
 import Storage from "@/storage";
 import type { QueuedBlockEntry } from "@/storage/QueueStorage";
+import { validatePersistedRuntimeState } from "@/storage/persistence/validatePersistedRuntimeState";
 import { EventHandler } from "@/eventHandlers/EventHandler";
 import {
     tryDecodeCustomError,
@@ -279,11 +280,10 @@ class StateManager<
             try {
                 await this.stateChannelEventListener.dispose();
             } finally {
-                await Promise.all([
-                    this.timeoutManager.dispose(),
-                    this.p2pManager.dispose(),
-                    this.diamondStateMachine.dispose()
-                ]);
+                await this.timeoutManager.dispose();
+                await this.p2pManager.dispose();
+                await this.storage.close();
+                await this.diamondStateMachine.dispose();
             }
         })().finally(() => {
             this.logger.dispose({
@@ -373,7 +373,37 @@ class StateManager<
         this.logger.updateSharedContext({ channelId: String(channelId) });
         this.disputeManager.setChannelId(channelId);
         this.eventSyncService.setChannelId(channelId);
+        await this.restorePersistedState();
         await this.stateChannelEventListener.setChannelId(channelId);
+    }
+
+    /**
+     * Restores what a restart CANNOT get from storage. Every storage collection
+     * (blocks, messages, snapshots, disputes, queues, ...) is already hydrated
+     * by `Storage.bind()`, which runs during host construction before this
+     * StateManager exists - so `validatePersistedRuntimeState` only cross-checks
+     * loaded caches, it never loads. What remains is the process-local state:
+     * the local diamond's VM state, the active fork field, the status (derived,
+     * deliberately never persisted), and the queue's timers.
+     */
+    public async restorePersistedState(): Promise<void> {
+        const persisted = validatePersistedRuntimeState(
+            this.storage,
+            this.channelId
+        );
+        if (!persisted) return;
+
+        // TODO(persistence): classify and recover legal forward crash prefixes
+        // from multi-record flows instead of failing every inconsistent prefix.
+        await this.diamondStateMachine.setState(persisted.encodedState);
+        this.forkId = persisted.metadata.activeForkId;
+        const participants = await this.diamondStateMachine.getParticipants();
+        this.setStatus(
+            participants.includes(this.signerAddress)
+                ? Status.PARTICIPATING
+                : Status.SYNCED
+        );
+        await this.blockQueueManager.resumePersistedQueue();
     }
     public getChannelId(): ChannelId {
         return this.channelId;
@@ -451,12 +481,15 @@ class StateManager<
         this.storage.forceJoin.setJoinSubmissionBlockHeight(
             joinSubmissionHeight
         );
+        // TODO(persistence): reconcile a crash after this durable marker but
+        // before the join transaction is accepted on-chain.
         this.logger.info(
             "joinChannel - recorded force join submission height",
             { joinSubmissionHeight }
         );
 
         try {
+            await this.storage.flush();
             const tx = await this.stateChannelManagerContract.joinChannel(
                 confirmation,
                 expectedSnapshotHash,
@@ -593,7 +626,16 @@ class StateManager<
         // Update the forkId to the new fork
         const forkId = stateSnapshot.forkId;
         this.forkId = forkId;
+        // TODO(persistence): recover legal prefixes if the process crashes
+        // between these individually durable records.
+        this.storage.setRuntimeMetadata({
+            activeForkId: forkId,
+            headHash: this.storage.blocks.getLatestBlock(forkId)?.hash,
+            snapshotHash: latestSnapshot.hash,
+            stateHash: latestSnapshot.stateMachineStateHash
+        });
 
+        await this.storage.flush();
         const participants = await this.diamondStateMachine.getParticipants();
         const isParticipant = participants.includes(this.signerAddress);
         if (isParticipant) {
@@ -825,7 +867,8 @@ class StateManager<
             }
         }
 
-        this.storage.blocks.storeBlock(block);
+        const validationResult =
+            await strategy.goodNewSignaturesOnExistingBlock(block);
         const persisted = this.storage.blocks.getBlock(block.hash);
         if (persisted) {
             P2pEventHooksUtils.maybeNotifyBlockFinalized({
@@ -836,14 +879,7 @@ class StateManager<
             });
         }
 
-        if (!(strategy instanceof DisputeValidationStrategy)) {
-            this.p2pManager.remoteRpc.stateTransitionService
-                .onBlockConfirmation(block.blockConfirmationStruct)
-                .broadcast();
-            return BlockValidationResult.BROADCAST;
-        }
-
-        return BlockValidationResult.DUPLICATE;
+        return validationResult;
     }
 
     /**
@@ -909,7 +945,10 @@ class StateManager<
                         { blockHash: block.hash, blockForkId: block.forkId }
                     );
                 } else {
-                    this.blockQueueManager.restoreQueuedEntry(entry, strategy);
+                    await this.blockQueueManager.restoreQueuedEntry(
+                        entry,
+                        strategy
+                    );
                 }
                 keepConnection = true; // not a peer fault
                 return keepConnection;
@@ -2267,21 +2306,6 @@ class StateManager<
             onBlockCommitted?: () => void;
         }
     ): Promise<void> {
-        // step 9 - potentially change status: SYNCED | PENDING_PARTICIPANT → PARTICIPATING
-        if (
-            this.status === Status.SYNCED ||
-            this.status === Status.PENDING_PARTICIPANT
-        ) {
-            const participants =
-                await this.diamondStateMachine.getParticipants();
-            const isParticipant = participants.includes(this.signerAddress);
-            if (isParticipant) {
-                this.setStatus(Status.PARTICIPATING);
-                this.storage.forceJoin.clear();
-            } else if (this.status === Status.PENDING_PARTICIPANT) {
-                await this.maybeInitiateForceJoinDispute(block, participants);
-            }
-        }
         // step 1 - persist the state snapshot + state machine state first:
         // shouldSignBlock reads the resulting participants from storage
         this.storage.stateSnapshots.storeStateSnapshot(stateSnapshot);
@@ -2289,10 +2313,18 @@ class StateManager<
             encodedStateMachineState,
             { hash: stateSnapshot.stateMachineStateHash }
         );
+        const mayPromoteStatus =
+            this.status === Status.SYNCED ||
+            this.status === Status.PENDING_PARTICIPANT;
+        const participants = mayPromoteStatus
+            ? await this.diamondStateMachine.getParticipants()
+            : [];
+        const shouldPromoteToParticipant =
+            mayPromoteStatus && participants.includes(this.signerAddress);
 
         // step 2 - add my signature if appropriate
         if (
-            (await this.shouldSignBlock(block)) &&
+            (await this.shouldSignBlock(block, shouldPromoteToParticipant)) &&
             !(options?.strategy instanceof DisputeValidationStrategy)
         ) {
             // Sign the block and add our signature to confirmation signatures
@@ -2307,6 +2339,42 @@ class StateManager<
         this.storage.blocks.storeBlock(block, {
             justPersist: options?.strategy instanceof DisputeValidationStrategy
         });
+        if (!(options?.strategy instanceof DisputeValidationStrategy)) {
+            // TODO(persistence): recover legal prefixes if the process crashes
+            // between snapshot, state, block, and metadata commits.
+            this.storage.setRuntimeMetadata({
+                activeForkId: block.forkId,
+                headHash: block.hash,
+                snapshotHash: stateSnapshot.hash,
+                stateHash: stateSnapshot.stateMachineStateHash
+            });
+        }
+        // step 5 - persist the outbound message blocks if any
+        if (options?.outboundMessageBlock) {
+            this.storage.outboundMessages.store(options.outboundMessageBlock);
+        }
+
+        // step 6 - persist participant change points
+        if (
+            !(options?.strategy instanceof DisputeValidationStrategy) &&
+            (participantChanges.left.size > 0 ||
+                participantChanges.joined.size > 0)
+        ) {
+            this.storage.participantSetChanges.storeChangePoint(
+                block.forkId,
+                block.height
+            );
+        }
+
+        // step 9 - potentially change status: SYNCED | PENDING_PARTICIPANT → PARTICIPATING
+        // Publish status only after all durable mutations for the transition
+        // have succeeded.
+        if (shouldPromoteToParticipant) {
+            this.storage.forceJoin.clear();
+        }
+
+        await this.storage.flush();
+
         // The block is canonical from here: a failure in the remaining side
         // effects must not roll the VM back behind stored state.
         options?.onBlockCommitted?.();
@@ -2317,23 +2385,16 @@ class StateManager<
             logger: this.logger
         });
 
-        // step 5 - persist the outbound message blocks if any
-        if (options?.outboundMessageBlock) {
-            this.storage.outboundMessages.store(options.outboundMessageBlock);
-        }
-
         // TODO - quick hack - cleaner code later
         if (options?.strategy instanceof DisputeValidationStrategy) return;
 
-        // step 6 - persist participant change points
-        if (
-            participantChanges.left.size > 0 ||
-            participantChanges.joined.size > 0
+        if (shouldPromoteToParticipant) {
+            this.setStatus(Status.PARTICIPATING);
+        } else if (
+            mayPromoteStatus &&
+            this.status === Status.PENDING_PARTICIPANT
         ) {
-            this.storage.participantSetChanges.storeChangePoint(
-                block.forkId,
-                block.height
-            );
+            await this.maybeInitiateForceJoinDispute(block, participants);
         }
 
         // step 7 - gossip after local persistence, so echoed confirmations are
@@ -2398,9 +2459,14 @@ class StateManager<
         // Universally scheduled on mutex release
     }
 
-    public async shouldSignBlock(block: Block): Promise<boolean> {
+    public async shouldSignBlock(
+        block: Block,
+        allowPendingPromotion = false
+    ): Promise<boolean> {
         if (this.p2pManager.isBlacklisted(block.author)) return false;
-        if (this.status !== Status.PARTICIPATING) return false;
+        if (this.status !== Status.PARTICIPATING && !allowPendingPromotion) {
+            return false;
+        }
         // Sign only blocks whose previous/resulting participant union contains
         // us (e.g. never after leaving the channel). The resulting snapshot is
         // persisted before signing, so a missing union means "don't sign".

--- a/src/stateManager/utils/FraudProofService.ts
+++ b/src/stateManager/utils/FraudProofService.ts
@@ -259,8 +259,6 @@ export default class FraudProofService {
             encodedProof: Codec.encode(proof.struct, proof.type)
         };
 
-        const proofHash = this.storage.fraudProofs.storeFraudProof(fraudProof);
-
-        return proofHash;
+        return this.storage.fraudProofs.storeFraudProof(fraudProof);
     }
 }

--- a/src/stateManager/validationStrategy/BlockValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/BlockValidationStrategy.ts
@@ -113,6 +113,14 @@ export default class BlockValidationStrategy extends AValidationStrategy {
     ): Promise<BlockValidationResult> {
         // Store new signatures and broadcast
         this.storage.blocks.storeBlock(block);
+        // Durability barrier: this runs outside any mutex as a detached
+        // macrotask (StateManager.tryMergeStoredBlockConfirmation's stored-merge
+        // re-gossip), so the flush must be awaited at THIS write-site before the
+        // signature is gossiped (slashing vector). On a poisoned controller the
+        // flush rejects: TimeoutManager's task catch swallows it, the broadcast
+        // simply never fires (withhold), and teardown comes from the
+        // persistence failure handler (stateManager.abort), not from here.
+        await this.storage.flush();
         this.p2pManager.remoteRpc.stateTransitionService
             .onBlockConfirmation(block.blockConfirmationStruct)
             .broadcast();

--- a/src/stateManager/validationStrategy/BlockValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/BlockValidationStrategy.ts
@@ -71,7 +71,7 @@ export default class BlockValidationStrategy extends AValidationStrategy {
         entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         // not ready
-        this.blockQueueManager.restoreQueuedEntry(entry, this);
+        await this.blockQueueManager.restoreQueuedEntry(entry, this);
         return BlockValidationResult.NOT_READY;
     }
     public async notAllSingersAreParticipants(
@@ -134,7 +134,10 @@ export default class BlockValidationStrategy extends AValidationStrategy {
             participant: block.signerAddress,
             blockHeight: block.height
         });
-        this.fraudProofService.createDoubleSignProof(conflictingBlock, block);
+        await this.fraudProofService.createDoubleSignProof(
+            conflictingBlock,
+            block
+        );
         await this.disputeManager.dispute(block.forkId);
         return BlockValidationResult.DISPUTE;
     }
@@ -145,7 +148,7 @@ export default class BlockValidationStrategy extends AValidationStrategy {
             blockAuthor: block.author,
             blockHeight: block.height
         });
-        this.fraudProofService.createInvalidStateTransitionProof(block);
+        await this.fraudProofService.createInvalidStateTransitionProof(block);
         await this.disputeManager.dispute(block.forkId);
         return BlockValidationResult.DISPUTE;
     }
@@ -185,7 +188,7 @@ export default class BlockValidationStrategy extends AValidationStrategy {
             blockAuthor: block.author,
             blockHeight: block.height
         });
-        this.fraudProofService.createWrongGenesisProof(block);
+        await this.fraudProofService.createWrongGenesisProof(block);
         await this.disputeManager.dispute(block.forkId);
         return BlockValidationResult.DISPUTE;
     }
@@ -197,7 +200,7 @@ export default class BlockValidationStrategy extends AValidationStrategy {
             blockAuthor: block.author,
             blockHeight: block.height
         });
-        this.fraudProofService.createForgedInboundMessageBlockProof(
+        await this.fraudProofService.createForgedInboundMessageBlockProof(
             block,
             messageBlock
         );
@@ -238,7 +241,7 @@ export default class BlockValidationStrategy extends AValidationStrategy {
         }
 
         // Queue the block - will process normally
-        this.blockQueueManager.restoreQueuedEntry(entry, this);
+        await this.blockQueueManager.restoreQueuedEntry(entry, this);
         return BlockValidationResult.NOT_READY;
     }
     public async blockIsNotNextAndIsInTheFuture(
@@ -247,7 +250,7 @@ export default class BlockValidationStrategy extends AValidationStrategy {
         // Not ready: put it back and let the queue timeout be the sole sync
         // probe (no arrival-time sync from strategy hooks - that punished honest
         // peers before the convergence window).
-        this.blockQueueManager.restoreQueuedEntry(entry, this);
+        await this.blockQueueManager.restoreQueuedEntry(entry, this);
         return BlockValidationResult.NOT_READY;
     }
     public async blockIsNotLinkedAndIsNotFirstBlock(
@@ -264,7 +267,7 @@ export default class BlockValidationStrategy extends AValidationStrategy {
             blockAuthor: block.author,
             blockHeight: block.height
         });
-        this.fraudProofService.createInvalidTimestampProof(block);
+        await this.fraudProofService.createInvalidTimestampProof(block);
         await this.disputeManager.dispute(block.forkId);
         return BlockValidationResult.DISPUTE;
     }

--- a/src/stateManager/validationStrategy/DisputeValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/DisputeValidationStrategy.ts
@@ -40,12 +40,12 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
         );
     }
 
-    private createDisputeInvalidBlockInStateProofApplyFraudProof(
+    private async createDisputeInvalidBlockInStateProofApplyFraudProof(
         fraudProofHash: Hash
-    ): void {
+    ): Promise<void> {
         const fraudProof =
             this.storage.fraudProofs.getFraudProofByHash(fraudProofHash)!;
-        this.disputeFraudProofService.createDisputeInvalidBlockInStateProofApplyFraudProof(
+        await this.disputeFraudProofService.createDisputeInvalidBlockInStateProofApplyFraudProof(
             this.dispute,
             fraudProof,
             this.blockIndexInUnfinalizedPartOfStateProof
@@ -68,7 +68,7 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
         // "continue replay", not "the dispute is valid". A later transition,
         // snapshot, or other authoritative check must make the final decision.
         if (!isInvalid) return BlockValidationResult.SUCCESS;
-        this.disputeFraudProofService.createDisputeInvalidBlockStructure(
+        await this.disputeFraudProofService.createDisputeInvalidBlockStructure(
             this.dispute,
             this.blockIndexInUnfinalizedPartOfStateProof
         );
@@ -143,7 +143,7 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
                 );
                 return BlockValidationResult.SUCCESS;
             }
-            this.disputeFraudProofService.createDisputeBlockAuthorNotParticipant(
+            await this.disputeFraudProofService.createDisputeBlockAuthorNotParticipant(
                 this.dispute,
                 block,
                 participantSnapshots.previous,
@@ -191,7 +191,7 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
             );
             return BlockValidationResult.SUCCESS;
         }
-        this.disputeFraudProofService.createDisputeBlockAuthorNotParticipant(
+        await this.disputeFraudProofService.createDisputeBlockAuthorNotParticipant(
             this.dispute,
             block,
             previousStateSnapshot,
@@ -205,7 +205,10 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
         block: Block
     ): Promise<BlockValidationResult> {
         // Create and apply normal fraud proof to slash the offender + DEFER creating a new dispute - this dispute may still be honest, so continute validation
-        this.fraudProofService.createDoubleSignProof(conflictingBlock, block);
+        await this.fraudProofService.createDoubleSignProof(
+            conflictingBlock,
+            block
+        );
         // TODO - apply the fraud proof without creating a new dispute
         // await this.disputeManager.dispute(block.forkId);
         return BlockValidationResult.SUCCESS; // so we continue 'syncing' and checking new blocks
@@ -215,8 +218,10 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
     ): Promise<BlockValidationResult> {
         // TODO - here we have to kill the dispute, since the dispute contains incorrect state
         const hash =
-            this.fraudProofService.createInvalidStateTransitionProof(block);
-        this.createDisputeInvalidBlockInStateProofApplyFraudProof(hash);
+            await this.fraudProofService.createInvalidStateTransitionProof(
+                block
+            );
+        await this.createDisputeInvalidBlockInStateProofApplyFraudProof(hash);
         // await this.disputeManager.dispute(block.forkId);
         return BlockValidationResult.DISPUTE;
     }
@@ -237,8 +242,9 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
             throw new Error("Unexpected genesisSnapshot missing");
         }
         // TODO - here we have to kill the dispute, since the dispute contains incorrect state
-        const hash = this.fraudProofService.createWrongGenesisProof(block);
-        this.createDisputeInvalidBlockInStateProofApplyFraudProof(hash);
+        const hash =
+            await this.fraudProofService.createWrongGenesisProof(block);
+        await this.createDisputeInvalidBlockInStateProofApplyFraudProof(hash);
         // await this.disputeManager.dispute(block.forkId);
         return BlockValidationResult.DISPUTE;
     }
@@ -247,11 +253,11 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
         messageBlock: MessageBlockStruct
     ): Promise<BlockValidationResult> {
         const hash =
-            this.fraudProofService.createForgedInboundMessageBlockProof(
+            await this.fraudProofService.createForgedInboundMessageBlockProof(
                 block,
                 messageBlock
             );
-        this.createDisputeInvalidBlockInStateProofApplyFraudProof(hash);
+        await this.createDisputeInvalidBlockInStateProofApplyFraudProof(hash);
         return BlockValidationResult.DISPUTE;
     }
     public async conflictingButNotLinkedBlockDetected(
@@ -283,8 +289,9 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
     ): Promise<BlockValidationResult> {
         // TODO - here we have to kill the dispute, since the dispute contains incorrect state
         // TODO - think about this - can this change over time? i.e. can onChainTimestamp or the presence of calldata change things
-        const hash = this.fraudProofService.createInvalidTimestampProof(block);
-        this.createDisputeInvalidBlockInStateProofApplyFraudProof(hash);
+        const hash =
+            await this.fraudProofService.createInvalidTimestampProof(block);
+        await this.createDisputeInvalidBlockInStateProofApplyFraudProof(hash);
         // await this.disputeManager.dispute(block.forkId);
         return BlockValidationResult.DISPUTE;
     }

--- a/src/stateManager/validationStrategy/SpectatingValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/SpectatingValidationStrategy.ts
@@ -73,7 +73,7 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
         entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         // not ready
-        this.blockQueueManager.restoreQueuedEntry(entry, this);
+        await this.blockQueueManager.restoreQueuedEntry(entry, this);
         return BlockValidationResult.NOT_READY;
     }
     public async notAllSingersAreParticipants(
@@ -181,7 +181,7 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
         entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         // not ready
-        this.blockQueueManager.restoreQueuedEntry(entry, this);
+        await this.blockQueueManager.restoreQueuedEntry(entry, this);
         return BlockValidationResult.NOT_READY;
     }
     public async blockIsNotNextAndIsInTheFuture(
@@ -189,7 +189,7 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
     ): Promise<BlockValidationResult> {
         // Not ready: put it back and let the queue timeout be the sole sync
         // probe (no arrival-time sync from strategy hooks).
-        this.blockQueueManager.restoreQueuedEntry(entry, this);
+        await this.blockQueueManager.restoreQueuedEntry(entry, this);
         return BlockValidationResult.NOT_READY;
     }
     public async blockIsNotLinkedAndIsNotFirstBlock(

--- a/src/storage/BlockCalldataStorage.ts
+++ b/src/storage/BlockCalldataStorage.ts
@@ -1,5 +1,15 @@
-import { ForkId, BlockHeight, BlockCalldata, Address } from "@/types/types";
 import { Block } from "@/models";
+import type {
+    Address,
+    BlockCalldata,
+    BlockHeight,
+    ForkId
+} from "@/types/types";
+
+import {
+    PersistentCollection,
+    type PersistenceController
+} from "./persistence";
 
 type CalldataCoordinateKey = string;
 
@@ -7,18 +17,23 @@ export class BlockCalldataStorage {
     // ====================================
     // STORAGE MAPS
     // ====================================
-    private coordinatesToBlockMap: Map<CalldataCoordinateKey, BlockCalldata>;
+    private readonly blocks: PersistentCollection<
+        CalldataCoordinateKey,
+        BlockCalldata
+    >;
 
-    constructor() {
-        this.coordinatesToBlockMap = new Map();
+    constructor(controller?: PersistenceController) {
+        this.blocks = new PersistentCollection("blockCalldata", controller);
     }
 
     // ====================================
     // CREATE
     // ====================================
 
-    storeBlockCalldata(blockCalldata: BlockCalldata): CalldataCoordinateKey {
-        const block: Block = Block.fromSignedBlock(
+    public storeBlockCalldata(
+        blockCalldata: BlockCalldata
+    ): CalldataCoordinateKey {
+        const block = Block.fromSignedBlock(
             blockCalldata.signedBlock,
             blockCalldata.onChainTimestamp
         );
@@ -27,7 +42,7 @@ export class BlockCalldataStorage {
             block.height,
             block.author
         );
-        this.coordinatesToBlockMap.set(coordinateKey, blockCalldata);
+        this.blocks.set(coordinateKey, blockCalldata);
         return coordinateKey;
     }
 
@@ -35,20 +50,17 @@ export class BlockCalldataStorage {
     // READ
     // ====================================
 
-    getBlockCalldata(
+    public getBlockCalldata(
         forkId: ForkId,
         height: BlockHeight,
         blockAuthor: Address
     ): BlockCalldata | undefined {
-        const coordinateKey = this.buildCoordinateKey(
-            forkId,
-            height,
-            blockAuthor
+        return this.blocks.get(
+            this.buildCoordinateKey(forkId, height, blockAuthor)
         );
-        return this.coordinatesToBlockMap.get(coordinateKey);
     }
 
-    getMatchingBlockCalldata(block: Block): BlockCalldata | undefined {
+    public getMatchingBlockCalldata(block: Block): BlockCalldata | undefined {
         const calldata = this.getBlockCalldata(
             block.forkId,
             block.height,

--- a/src/storage/BlockStorage.ts
+++ b/src/storage/BlockStorage.ts
@@ -1,5 +1,11 @@
-import { Hash, ForkId, BlockHeight, Signature, Timestamp } from "@/types/types";
 import { Block, BlockCoordinates } from "@/models";
+import { BlockHeight, ForkId, Hash, Signature, Timestamp } from "@/types/types";
+
+import {
+    PersistentCollection,
+    type PersistenceController
+} from "./persistence";
+import type { PersistedBlockRecord } from "./persistence/storageCodecs";
 
 type CoordinateKey = string;
 type StoreOptions = {
@@ -17,24 +23,70 @@ export class BlockStorage {
     // ====================================
     // STORAGE MAPS
     // ====================================
-    private hashToBlockMap: Map<Hash, Block>;
-    private coordinatesToBlockMap: Map<CoordinateKey, Block>;
+    private readonly records: PersistentCollection<Hash, PersistedBlockRecord>;
+    private readonly coordinateToHash = new Map<CoordinateKey, Hash>();
 
     // NEW: Track highest height for each forkId
-    private forkIdToMaxHeightMap: Map<ForkId, BlockHeight>;
+    private readonly forkIdToMaxHeightMap = new Map<ForkId, BlockHeight>();
 
-    constructor() {
-        this.hashToBlockMap = new Map();
-        this.coordinatesToBlockMap = new Map();
-        this.forkIdToMaxHeightMap = new Map();
+    constructor(controller?: PersistenceController) {
+        this.records = new PersistentCollection("blocks", controller, () =>
+            this.rebuildIndexes()
+        );
     }
 
     // ====================================
     // CREATE
     // ====================================
 
-    storeBlock(block: Block, options?: StoreOptions): Hash | undefined {
-        return this._storeBlockWithOptions(block, options);
+    public storeBlock(block: Block, options?: StoreOptions): Hash | undefined {
+        // Determine hash - use provided or compute
+        const blockHash = options?.hash ?? block.hash;
+
+        // Determine coordinates - use provided or compute
+        const coordinates = options?.coordinates ?? block.coordinates;
+
+        // Store the block entry
+        let compatible = true;
+        this.records.update(blockHash, (record) => {
+            const coordinateKey = this.coordinatesToKey(coordinates);
+            const storedCoordinateHash =
+                this.coordinateToHash.get(coordinateKey);
+            if (storedCoordinateHash && storedCoordinateHash !== blockHash) {
+                // Not equal => abort
+                compatible = false;
+                return record;
+            }
+
+            if (!record) {
+                // Store new block entry
+                return {
+                    block,
+                    coordinates,
+                    advancesTip: !options?.justPersist
+                };
+            }
+            if (
+                !block.equals(record.block) ||
+                this.coordinatesToKey(record.coordinates) !== coordinateKey
+            ) {
+                // Not equal => abort
+                compatible = false;
+                return record;
+            }
+
+            // They are equal => merge signatures
+            record.block.expandSignatures(block.confirmationSignatures);
+            if (block.onChainTimestamp !== undefined) {
+                record.block.onChainTimestamp = block.onChainTimestamp;
+            }
+            if (!options?.justPersist) record.advancesTip = true;
+            return record;
+        });
+        if (!compatible) return undefined;
+
+        // Update max height unless this is a persistence-only operation
+        return blockHash;
     }
 
     // ====================================
@@ -46,28 +98,30 @@ export class BlockStorage {
     ────────────────────────────────────────────────────────────────────────────*/
 
     /** [OVERLOAD 1] Get block entry by hash */
-    getBlock(blockHash: Hash): Block | undefined;
+    public getBlock(blockHash: Hash): Block | undefined;
 
     /** [OVERLOAD 2] Get block entry by coordinates */
-    getBlock(forkId: ForkId, height: BlockHeight): Block | undefined;
+    public getBlock(forkId: ForkId, height: BlockHeight): Block | undefined;
 
     /*────────────────────────────────────────────────────────────────────────────
       IMPLEMENTATION
     ────────────────────────────────────────────────────────────────────────────*/
-    getBlock(
+    public getBlock(
         hashOrForkId: Hash | ForkId,
         height?: BlockHeight
     ): Block | undefined {
         if (height === undefined) {
             // ┌─ ROUTES TO: [OVERLOAD 1] - by hash
-            return this.hashToBlockMap.get(hashOrForkId as Hash);
+            return this.records.get(hashOrForkId as Hash)?.block;
         }
         // ┌─ ROUTES TO: [OVERLOAD 2] - by coordinates
-        const coordinateKey = this.coordinatesToKey({
-            forkId: hashOrForkId as ForkId,
-            height
-        });
-        return this.coordinatesToBlockMap.get(coordinateKey);
+        const hash = this.coordinateToHash.get(
+            this.coordinatesToKey({
+                forkId: hashOrForkId as ForkId,
+                height
+            })
+        );
+        return hash ? this.records.get(hash)?.block : undefined;
     }
 
     // ====================================
@@ -79,10 +133,13 @@ export class BlockStorage {
     ────────────────────────────────────────────────────────────────────────────*/
 
     /** [OVERLOAD 1] Insert signature by hash */
-    insertSignature(signature: Signature, blockHash: Hash): Block | undefined;
+    public insertSignature(
+        signature: Signature,
+        blockHash: Hash
+    ): Block | undefined;
 
     /** [OVERLOAD 2] Insert signature by coordinates */
-    insertSignature(
+    public insertSignature(
         signature: Signature,
         forkId: ForkId,
         height: BlockHeight
@@ -91,22 +148,26 @@ export class BlockStorage {
     /*────────────────────────────────────────────────────────────────────────────
       IMPLEMENTATION
     ────────────────────────────────────────────────────────────────────────────*/
-    insertSignature(
+    public insertSignature(
         signature: Signature,
         hashOrForkId: Hash | ForkId,
         height?: BlockHeight
     ): Block | undefined {
-        const block =
+        const blockHash =
             height === undefined
-                ? this.hashToBlockMap.get(hashOrForkId as Hash)
-                : this.coordinatesToBlockMap.get(
+                ? (hashOrForkId as Hash)
+                : this.coordinateToHash.get(
                       this.coordinatesToKey({
                           forkId: hashOrForkId as ForkId,
                           height
                       })
                   );
-
-        return block?.expandSignatures([signature]);
+        if (!blockHash) return undefined;
+        const updated = this.records.update(blockHash, (record) => {
+            record?.block.expandSignatures([signature]);
+            return record;
+        });
+        return updated?.block;
     }
 
     // ====================================
@@ -118,10 +179,10 @@ export class BlockStorage {
     ────────────────────────────────────────────────────────────────────────────*/
 
     /** [OVERLOAD 1] Set on-chain timestamp by hash */
-    setOnChainTimestamp(blockHash: Hash, timestamp: Timestamp): boolean;
+    public setOnChainTimestamp(blockHash: Hash, timestamp: Timestamp): boolean;
 
     /** [OVERLOAD 2] Set on-chain timestamp by coordinates */
-    setOnChainTimestamp(
+    public setOnChainTimestamp(
         forkId: ForkId,
         height: BlockHeight,
         timestamp: Timestamp
@@ -130,33 +191,29 @@ export class BlockStorage {
     /*────────────────────────────────────────────────────────────────────────────
       IMPLEMENTATION
     ────────────────────────────────────────────────────────────────────────────*/
-    setOnChainTimestamp(
+    public setOnChainTimestamp(
         hashOrForkId: Hash | ForkId,
         timestampOrHeight: Timestamp | BlockHeight,
         timestamp?: Timestamp
     ): boolean {
-        let block: Block | undefined;
-
-        if (timestamp === undefined) {
-            // ┌─ ROUTES TO: [OVERLOAD 1] - by hash
-            block = this.hashToBlockMap.get(hashOrForkId as Hash);
-            if (block) {
-                block.onChainTimestamp = timestampOrHeight as Timestamp;
-                return true;
+        const blockHash =
+            timestamp === undefined
+                ? (hashOrForkId as Hash)
+                : this.coordinateToHash.get(
+                      this.coordinatesToKey({
+                          forkId: hashOrForkId as ForkId,
+                          height: timestampOrHeight as BlockHeight
+                      })
+                  );
+        if (!blockHash || !this.records.has(blockHash)) return false;
+        this.records.update(blockHash, (record) => {
+            if (record) {
+                record.block.onChainTimestamp =
+                    timestamp ?? (timestampOrHeight as Timestamp);
             }
-            return false;
-        }
-        // ┌─ ROUTES TO: [OVERLOAD 2] - by coordinates
-        const coordinateKey = this.coordinatesToKey({
-            forkId: hashOrForkId as ForkId,
-            height: timestampOrHeight as BlockHeight
+            return record;
         });
-        block = this.coordinatesToBlockMap.get(coordinateKey);
-        if (block) {
-            block.onChainTimestamp = timestamp;
-            return true;
-        }
-        return false;
+        return true;
     }
 
     // ====================================
@@ -168,70 +225,47 @@ export class BlockStorage {
     ────────────────────────────────────────────────────────────────────────────*/
 
     /** [OVERLOAD 1] Delete block entry by hash */
-    deleteBlock(blockHash: Hash): boolean;
+    public deleteBlock(blockHash: Hash): boolean;
 
     /** [OVERLOAD 2] Delete block entry by coordinates */
-    deleteBlock(forkId: ForkId, height: BlockHeight): boolean;
+    public deleteBlock(forkId: ForkId, height: BlockHeight): boolean;
 
     /*────────────────────────────────────────────────────────────────────────────
       IMPLEMENTATION
     ────────────────────────────────────────────────────────────────────────────*/
-    deleteBlock(hashOrForkId: Hash | ForkId, height?: BlockHeight): boolean {
+    public deleteBlock(
+        hashOrForkId: Hash | ForkId,
+        height?: BlockHeight
+    ): boolean {
         if (height === undefined) {
             // ┌─ ROUTES TO: [OVERLOAD 1] - delete by hash
-            const block = this.hashToBlockMap.get(hashOrForkId as Hash);
-            if (!block) return false;
-
             // Need to find and delete from coordinates map too
-            const coordinateKey = this.coordinatesToKey(block.coordinates);
-
-            this.hashToBlockMap.delete(hashOrForkId as Hash);
-            this.coordinatesToBlockMap.delete(coordinateKey);
-
-            const blockHeight = block.height;
-            if (blockHeight === this.forkIdToMaxHeightMap.get(block.forkId)) {
-                this.forkIdToMaxHeightMap.set(
-                    block.forkId,
-                    Math.max(0, blockHeight - 1)
-                );
-            }
-
-            return true;
+        } else {
+            // ┌─ ROUTES TO: [OVERLOAD 2] - delete by coordinates
+            // Need to find and delete from hash map too
         }
-
-        // ┌─ ROUTES TO: [OVERLOAD 2] - delete by coordinates
-        const forkId = hashOrForkId as ForkId;
-        const coordinateKey = this.coordinatesToKey({
-            forkId: forkId,
-            height
-        });
-        const block = this.coordinatesToBlockMap.get(coordinateKey);
-        if (!block) return false;
-
-        // Need to find and delete from hash map too
-        const blockHash = block.hash;
-
-        this.coordinatesToBlockMap.delete(coordinateKey);
-        this.hashToBlockMap.delete(blockHash);
-
-        if (height === this.forkIdToMaxHeightMap.get(forkId)) {
-            this.forkIdToMaxHeightMap.set(forkId, Math.max(0, height - 1));
-        }
-
-        return true;
+        const blockHash =
+            height === undefined
+                ? (hashOrForkId as Hash)
+                : this.coordinateToHash.get(
+                      this.coordinatesToKey({
+                          forkId: hashOrForkId as ForkId,
+                          height
+                      })
+                  );
+        if (!blockHash) return false;
+        return this.records.delete(blockHash);
     }
 
-    getNextBlockHeight(forkId: ForkId): BlockHeight {
-        if (this.forkIdToMaxHeightMap.has(forkId)) {
-            return this.forkIdToMaxHeightMap.get(forkId)! + 1;
-        }
-        return 0;
+    public getNextBlockHeight(forkId: ForkId): BlockHeight {
+        const maxHeight = this.forkIdToMaxHeightMap.get(forkId);
+        return maxHeight === undefined ? 0 : maxHeight + 1;
     }
 
     /*────────────────────────────────────────────────────────────────────────────
       GET ALL BLOCKS BY FORK ID - SEQUENTIAL ITERATOR
     ────────────────────────────────────────────────────────────────────────────*/
-    *getIterator(
+    public *getIterator(
         forkId: ForkId,
         sortOrder?: SortOrder,
         startHeight?: BlockHeight
@@ -242,93 +276,73 @@ export class BlockStorage {
 
         if (sortOrder === SortOrder.ASC) {
             // Start from startHeight or 0, go up to maxHeight
-            const start = startHeight !== undefined ? startHeight : 0;
+            const start = startHeight ?? 0;
             for (let height = start; height <= maxHeight; height++) {
-                const coordinateKey = this.coordinatesToKey({ forkId, height });
-                const block = this.coordinatesToBlockMap.get(coordinateKey);
-                if (block) {
-                    yield block;
-                }
+                const block = this.getBlock(forkId, height);
+                if (block) yield block;
             }
-        } else {
-            // Start from startHeight or maxHeight, go down to 0. Clamp to
-            // maxHeight so a caller passing an absurd startHeight (e.g. a
-            // remote-supplied sync target) can't loop over the empty range
-            // above the fork's tip and stall the event loop.
-            const start =
-                startHeight !== undefined
-                    ? Math.min(startHeight, maxHeight)
-                    : maxHeight;
-            for (let height = start; height >= 0; height--) {
-                const coordinateKey = this.coordinatesToKey({ forkId, height });
-                const block = this.coordinatesToBlockMap.get(coordinateKey);
-                if (block) {
-                    yield block;
-                }
-            }
+            return;
+        }
+
+        // Start from startHeight or maxHeight, go down to 0. Clamp to
+        // maxHeight so a caller passing an absurd startHeight (e.g. a
+        // remote-supplied sync target) can't loop over the empty range
+        // above the fork's tip and stall the event loop.
+        const start =
+            startHeight !== undefined
+                ? Math.min(startHeight, maxHeight)
+                : maxHeight;
+        for (let height = start; height >= 0; height--) {
+            const block = this.getBlock(forkId, height);
+            if (block) yield block;
         }
     }
 
-    getLatestBlock(forkId: ForkId): Block | undefined {
-        const blockIterator = this.getIterator(forkId, SortOrder.DESC);
-        const iteratorResult = blockIterator.next();
-        return iteratorResult.done ? undefined : iteratorResult.value;
+    public getLatestBlock(forkId: ForkId): Block | undefined {
+        const result = this.getIterator(forkId, SortOrder.DESC).next();
+        return result.done ? undefined : result.value;
     }
 
     // ====================================
     // PRIVATE HELPERS
     // ====================================
 
+    public rebuildIndexes(): void {
+        this.coordinateToHash.clear();
+        this.forkIdToMaxHeightMap.clear();
+        for (const [hash, record] of this.records.entries()) {
+            const coordinateKey = this.coordinatesToKey(record.coordinates);
+            const existingHash = this.coordinateToHash.get(coordinateKey);
+            if (existingHash && existingHash !== hash) {
+                throw new Error(
+                    `Conflicting persisted blocks at ${coordinateKey}`
+                );
+            }
+            this.indexRecord(hash, record);
+        }
+    }
+
     private coordinatesToKey(coordinates: BlockCoordinates): CoordinateKey {
         return `${coordinates.forkId}:${coordinates.height}`;
     }
 
-    private _storeBlockWithOptions(
-        block: Block,
-        options?: StoreOptions
-    ): Hash | undefined {
-        // Determine hash - use provided or compute
-        const blockHash = options?.hash ?? block.hash;
-
-        // Determine coordinates - use provided or compute
-        const coordinates = options?.coordinates ?? block.coordinates;
-
-        // Store the block entry
-        const coordinateKey = this.coordinatesToKey(coordinates);
-        const existingBlock = this.coordinatesToBlockMap.get(coordinateKey);
-
-        if (!existingBlock) {
-            // Store new block entry
-            this.hashToBlockMap.set(blockHash, block);
-            this.coordinatesToBlockMap.set(coordinateKey, block);
-
-            // Update max height unless this is a persistence-only operation
-            if (!options?.justPersist) {
-                this._updateMaxHeight(coordinates.forkId, coordinates.height);
-            }
-
-            return blockHash;
-        }
-
-        if (!block.equals(existingBlock)) {
-            // Not equal => abort
-            return undefined;
-        }
-
-        // They are equal => merge signatures
-        existingBlock.expandSignatures(block.confirmationSignatures);
-        if (block.onChainTimestamp !== undefined) {
-            existingBlock.onChainTimestamp = block.onChainTimestamp;
-        }
-
-        // Return the hash (same object in both maps)
-        return blockHash;
-    }
-
-    private _updateMaxHeight(forkId: ForkId, height: BlockHeight): void {
-        const currentMax = this.forkIdToMaxHeightMap.get(forkId);
-        if (currentMax === undefined || height > currentMax) {
-            this.forkIdToMaxHeightMap.set(forkId, height);
+    private indexRecord(hash: Hash, record: PersistedBlockRecord): void {
+        this.coordinateToHash.set(
+            this.coordinatesToKey(record.coordinates),
+            hash
+        );
+        if (!record.advancesTip) return;
+        const currentMax = this.forkIdToMaxHeightMap.get(
+            record.coordinates.forkId
+        );
+        if (
+            currentMax === undefined ||
+            record.coordinates.height > currentMax
+        ) {
+            this.forkIdToMaxHeightMap.set(
+                record.coordinates.forkId,
+                record.coordinates.height
+            );
         }
     }
 }

--- a/src/storage/DisputeFraudProofStorage.ts
+++ b/src/storage/DisputeFraudProofStorage.ts
@@ -1,7 +1,13 @@
-import { Hash } from "@/types/types";
+import type { DisputeStruct } from "@typechain-types/contracts/V1/types/DisputeTypes";
+import type { DisputeFraudProofStruct } from "@typechain-types/contracts/V1/types/ProofTypes";
+
+import type { Hash } from "@/types/types";
 import { Codec, hash, Type } from "@/utils";
-import { DisputeStruct } from "@typechain-types/contracts/V1/types/DisputeTypes";
-import { DisputeFraudProofStruct } from "@typechain-types/contracts/V1/types/ProofTypes";
+
+import {
+    PersistentCollection,
+    type PersistenceController
+} from "./persistence";
 
 type DisputeHash = Hash;
 
@@ -9,27 +15,44 @@ export class DisputeFraudProofStorage {
     // ====================================
     // STORAGE MAPS
     // ====================================
-    private disputeFraudProofs: Map<DisputeHash, DisputeFraudProofStruct> =
-        new Map();
+    private readonly disputeFraudProofs: PersistentCollection<
+        DisputeHash,
+        DisputeFraudProofStruct
+    >;
 
-    constructor() {}
+    constructor(controller?: PersistenceController) {
+        this.disputeFraudProofs = new PersistentCollection(
+            "disputeFraudProofs",
+            controller
+        );
+    }
 
     // ====================================
     // CREATE
     // ====================================
 
-    storeFraudProof(disputeFraudProof: DisputeFraudProofStruct): Hash {
+    public storeFraudProof(disputeFraudProof: DisputeFraudProofStruct): Hash {
         const disputeHash = hash(
             Codec.encode(disputeFraudProof.dispute, Type.Dispute)
         );
-
-        const existingProof = this.disputeFraudProofs.get(disputeHash);
-        if (existingProof) {
-            return disputeHash;
-        }
-
-        this.disputeFraudProofs.set(disputeHash, disputeFraudProof);
-
+        this.disputeFraudProofs.update(disputeHash, (existing) => {
+            if (existing) {
+                if (
+                    String(existing.proofType) !==
+                        String(disputeFraudProof.proofType) ||
+                    String(existing.participant).toLowerCase() !==
+                        String(disputeFraudProof.participant).toLowerCase() ||
+                    String(existing.encodedProof) !==
+                        String(disputeFraudProof.encodedProof)
+                ) {
+                    throw new Error(
+                        `Incompatible dispute fraud proof for ${disputeHash}`
+                    );
+                }
+                return existing;
+            }
+            return disputeFraudProof;
+        });
         return disputeHash;
     }
 
@@ -40,14 +63,14 @@ export class DisputeFraudProofStorage {
     /**
      * Get fraud proof for a specific dispute
      */
-    getDisputeFraudProofForDispute(
+    public getDisputeFraudProofForDispute(
         dispute: DisputeStruct
     ): DisputeFraudProofStruct | undefined {
         const disputeHash = hash(Codec.encode(dispute, Type.Dispute));
         return this.disputeFraudProofs.get(disputeHash);
     }
 
-    getDisputeFraudProofs(): DisputeFraudProofStruct[] {
+    public getDisputeFraudProofs(): DisputeFraudProofStruct[] {
         return [...this.disputeFraudProofs.values()];
     }
 }

--- a/src/storage/DisputeStorage.ts
+++ b/src/storage/DisputeStorage.ts
@@ -1,11 +1,17 @@
-import { ForkId, Hash } from "@/types/types";
 import { ethers } from "ethers";
-import {
+import type {
     DisputeConfirmationStruct,
     DisputeStruct,
     SignedDisputeStruct
 } from "@typechain-types/contracts/V1/types/DisputeTypes";
+
+import type { ForkId, Hash } from "@/types/types";
 import { Codec, Type } from "@/utils";
+
+import {
+    PersistentCollection,
+    type PersistenceController
+} from "./persistence";
 
 type StoreOptions = {
     hash?: Hash;
@@ -16,12 +22,18 @@ export class DisputeStorage {
     // ====================================
     // STORAGE MAPS
     // ====================================
-    private disputes: Map<Hash, DisputeConfirmationStruct>;
-    private disputedForks: Map<ForkId, DidIDispute>;
+    private readonly disputes: PersistentCollection<
+        Hash,
+        DisputeConfirmationStruct
+    >;
+    private readonly disputedForks: PersistentCollection<ForkId, DidIDispute>;
 
-    constructor() {
-        this.disputes = new Map();
-        this.disputedForks = new Map();
+    constructor(controller?: PersistenceController) {
+        this.disputes = new PersistentCollection("disputes", controller);
+        this.disputedForks = new PersistentCollection(
+            "disputedForks",
+            controller
+        );
     }
 
     // ====================================
@@ -29,67 +41,27 @@ export class DisputeStorage {
     // ====================================
 
     /*────────────────────────────────────────────────────────────────────────────
-      STORE  DISPUTE 
+      STORE SIGNED DISPUTE
     ────────────────────────────────────────────────────────────────────────────*/
-    storeDispute(dispute: SignedDisputeStruct, options?: StoreOptions): Hash {
+    public storeDispute(
+        dispute: SignedDisputeStruct,
+        options?: StoreOptions
+    ): Hash {
         // Convert SignedDispute to DisputeConfirmation (empty signatures)
-        const disputeConfirmation: DisputeConfirmationStruct = {
-            signedDispute: dispute,
-            signatures: [] // Starts empty, ready for peer confirmations
-        };
-
-        return this._storeDisputeConfirmationWithOptions(
-            disputeConfirmation,
+        return this.storeDisputeConfirmation(
+            { signedDispute: dispute, signatures: [] },
             options
         );
     }
 
-    storeDisputedFork(forkId: ForkId, disputed: boolean): void {
+    public storeDisputedFork(forkId: ForkId, disputed: boolean): void {
         this.disputedForks.set(forkId, disputed);
     }
 
     /*────────────────────────────────────────────────────────────────────────────
       STORE DISPUTE CONFIRMATION
     ────────────────────────────────────────────────────────────────────────────*/
-    storeDisputeConfirmation(
-        disputeConfirmation: DisputeConfirmationStruct,
-        options?: StoreOptions
-    ): Hash {
-        return this._storeDisputeConfirmationWithOptions(
-            disputeConfirmation,
-            options
-        );
-    }
-
-    // ====================================
-    // READ
-    // ====================================
-
-    getDisputeConfirmation(
-        disputeHash: Hash
-    ): DisputeConfirmationStruct | undefined {
-        return this.disputes.get(disputeHash);
-    }
-
-    getDispute(disputeHash: Hash): DisputeStruct | undefined {
-        const disputeConfirmation = this.getDisputeConfirmation(disputeHash);
-        return disputeConfirmation
-            ? Codec.decode(
-                  disputeConfirmation.signedDispute.encodedDispute,
-                  Type.Dispute
-              )
-            : undefined;
-    }
-
-    didIDispute(forkId: ForkId): DidIDispute {
-        return this.disputedForks.get(forkId) ?? false;
-    }
-
-    // ====================================
-    // PRIVATE HELPERS
-    // ====================================
-
-    private _storeDisputeConfirmationWithOptions(
+    public storeDisputeConfirmation(
         disputeConfirmation: DisputeConfirmationStruct,
         options?: StoreOptions
     ): Hash {
@@ -97,27 +69,65 @@ export class DisputeStorage {
         const disputeHash =
             options?.hash ??
             ethers.keccak256(disputeConfirmation.signedDispute.encodedDispute);
-
-        const existingDispute = this.disputes.get(disputeHash);
-
-        if (existingDispute !== undefined) {
-            // Merge signatures
-            const signaturesSet = new Set(existingDispute.signatures);
-            for (const newSignature of disputeConfirmation.signatures) {
-                signaturesSet.add(newSignature);
+        this.disputes.update(disputeHash, (existing) => {
+            if (!existing) {
+                // If no existing dispute, store new dispute
+                return disputeConfirmation;
+            }
+            if (
+                !ethers.isBytesLike(
+                    disputeConfirmation.signedDispute.encodedDispute
+                ) ||
+                ethers.hexlify(existing.signedDispute.encodedDispute) !==
+                    ethers.hexlify(
+                        disputeConfirmation.signedDispute.encodedDispute
+                    ) ||
+                ethers.hexlify(existing.signedDispute.signature) !==
+                    ethers.hexlify(disputeConfirmation.signedDispute.signature)
+            ) {
+                throw new Error(
+                    `Incompatible dispute confirmation for ${disputeHash}`
+                );
             }
 
-            const mergedDispute: DisputeConfirmationStruct = {
-                signedDispute: existingDispute.signedDispute,
-                signatures: Array.from(signaturesSet)
+            // Merge signatures
+            const signatures = new Set(existing.signatures.map(ethers.hexlify));
+            for (const signature of disputeConfirmation.signatures) {
+                signatures.add(ethers.hexlify(signature));
+            }
+            return {
+                signedDispute: existing.signedDispute,
+                signatures: [...signatures]
             };
-
-            this.disputes.set(disputeHash, mergedDispute);
-            return disputeHash;
-        }
-        // If no existing dispute, store new dispute
-
-        this.disputes.set(disputeHash, disputeConfirmation);
+        });
         return disputeHash;
     }
+
+    // ====================================
+    // READ
+    // ====================================
+
+    public getDisputeConfirmation(
+        disputeHash: Hash
+    ): DisputeConfirmationStruct | undefined {
+        return this.disputes.get(disputeHash);
+    }
+
+    public getDispute(disputeHash: Hash): DisputeStruct | undefined {
+        const confirmation = this.getDisputeConfirmation(disputeHash);
+        return confirmation
+            ? Codec.decode(
+                  confirmation.signedDispute.encodedDispute,
+                  Type.Dispute
+              )
+            : undefined;
+    }
+
+    public didIDispute(forkId: ForkId): DidIDispute {
+        return this.disputedForks.get(forkId) ?? false;
+    }
+
+    // ====================================
+    // PRIVATE HELPERS
+    // ====================================
 }

--- a/src/storage/EventSyncStorage.ts
+++ b/src/storage/EventSyncStorage.ts
@@ -1,26 +1,41 @@
-import { ChannelId } from "@/types/types";
+import type { ChannelId } from "@/types/types";
+
+import {
+    PersistentCollection,
+    type PersistenceController
+} from "./persistence";
 
 type ChannelKey = string;
 type BlockNumber = number;
 
 export class EventSyncStorage {
-    private readonly latestProcessedBlocks = new Map<ChannelKey, BlockNumber>();
+    private readonly latestProcessedBlocks: PersistentCollection<
+        ChannelKey,
+        BlockNumber
+    >;
 
-    getLatestProcessedBlock(channelId: ChannelId): BlockNumber | undefined {
+    constructor(controller?: PersistenceController) {
+        this.latestProcessedBlocks = new PersistentCollection(
+            "eventSync",
+            controller
+        );
+    }
+
+    public getLatestProcessedBlock(
+        channelId: ChannelId
+    ): BlockNumber | undefined {
         return this.latestProcessedBlocks.get(this.getChannelKey(channelId));
     }
 
-    storeLatestProcessedBlock(
+    public storeLatestProcessedBlock(
         channelId: ChannelId,
         blockNumber: BlockNumber
     ): BlockNumber {
-        const key = this.getChannelKey(channelId);
-        const latest = Math.max(
-            this.latestProcessedBlocks.get(key) ?? 0,
-            blockNumber
+        const latest = this.latestProcessedBlocks.update(
+            this.getChannelKey(channelId),
+            (existing) => Math.max(existing ?? 0, blockNumber)
         );
-        this.latestProcessedBlocks.set(key, latest);
-        return latest;
+        return latest!;
     }
 
     private getChannelKey(channelId: ChannelId): ChannelKey {

--- a/src/storage/ForceExitStorage.ts
+++ b/src/storage/ForceExitStorage.ts
@@ -1,10 +1,22 @@
-export class ForceExitStorage {
-    private shouldIForceExit = false;
+import {
+    PersistentCollection,
+    type PersistenceController
+} from "./persistence";
 
-    setForceExit(shouldForceExit: boolean): void {
-        this.shouldIForceExit = shouldForceExit;
+type ForceExitKey = "value";
+
+export class ForceExitStorage {
+    private readonly value: PersistentCollection<ForceExitKey, boolean>;
+
+    constructor(controller?: PersistenceController) {
+        this.value = new PersistentCollection("forceExit", controller);
     }
-    getForceExit(): boolean {
-        return this.shouldIForceExit;
+
+    public setForceExit(shouldForceExit: boolean): void {
+        this.value.set("value", shouldForceExit);
+    }
+
+    public getForceExit(): boolean {
+        return this.value.get("value") ?? false;
     }
 }

--- a/src/storage/ForceJoinStorage.ts
+++ b/src/storage/ForceJoinStorage.ts
@@ -1,17 +1,28 @@
-import { BlockHeight } from "@/types/types";
+import type { BlockHeight } from "@/types/types";
+
+import {
+    PersistentCollection,
+    type PersistenceController
+} from "./persistence";
+
+type ForceJoinKey = "value";
 
 export class ForceJoinStorage {
-    private joinSubmissionBlockHeight?: BlockHeight;
+    private readonly value: PersistentCollection<ForceJoinKey, BlockHeight>;
 
-    setJoinSubmissionBlockHeight(height: BlockHeight): void {
-        this.joinSubmissionBlockHeight = height;
+    constructor(controller?: PersistenceController) {
+        this.value = new PersistentCollection("forceJoin", controller);
     }
 
-    getJoinSubmissionBlockHeight(): BlockHeight | undefined {
-        return this.joinSubmissionBlockHeight;
+    public setJoinSubmissionBlockHeight(height: BlockHeight): void {
+        this.value.set("value", height);
     }
 
-    clear(): void {
-        this.joinSubmissionBlockHeight = undefined;
+    public getJoinSubmissionBlockHeight(): BlockHeight | undefined {
+        return this.value.get("value");
+    }
+
+    public clear(): void {
+        this.value.delete("value");
     }
 }

--- a/src/storage/FraudProofStorage.ts
+++ b/src/storage/FraudProofStorage.ts
@@ -1,32 +1,47 @@
-import { Address, Hash } from "@/types/types";
-import { FraudProofStruct } from "@typechain-types/contracts/V1/types/ProofTypes";
+import type { FraudProofStruct } from "@typechain-types/contracts/V1/types/ProofTypes";
+
+import type { Address, Hash } from "@/types/types";
 import { hash } from "@/utils";
+
+import {
+    PersistentCollection,
+    type PersistenceController
+} from "./persistence";
 
 export class FraudProofStorage {
     // ====================================
     // STORAGE MAPS
     // ====================================
-    private fraudProofs: Map<Hash, FraudProofStruct> = new Map(); // key: fraudProofId
-    private participantToProofs: Map<Address, Set<Hash>> = new Map(); // participant -> set of fraud proof IDs
+    private readonly fraudProofs: PersistentCollection<Hash, FraudProofStruct>;
+    private readonly participantToProofs = new Map<Address, Set<Hash>>();
 
-    constructor() {}
+    constructor(controller?: PersistenceController) {
+        this.fraudProofs = new PersistentCollection(
+            "fraudProofs",
+            controller,
+            () => this.rebuildIndexes()
+        );
+    }
 
     // ====================================
     // CREATE
     // ====================================
 
-    storeFraudProof(fraudProof: FraudProofStruct): Hash {
+    public storeFraudProof(fraudProof: FraudProofStruct): Hash {
         const proofHash = hash(fraudProof.encodedProof);
+        this.fraudProofs.update(proofHash, (existing) => {
+            if (
+                existing &&
+                (String(existing.proofType) !== String(fraudProof.proofType) ||
+                    String(existing.participant).toLowerCase() !==
+                        String(fraudProof.participant).toLowerCase())
+            ) {
+                throw new Error(`Incompatible fraud proof for ${proofHash}`);
+            }
 
-        // Store the fraud proof
-        this.fraudProofs.set(proofHash, fraudProof);
-
-        // Index by participant
-        if (!this.participantToProofs.has(fraudProof.participant)) {
-            this.participantToProofs.set(fraudProof.participant, new Set());
-        }
-        this.participantToProofs.get(fraudProof.participant)!.add(proofHash);
-
+            // Store the fraud proof
+            return fraudProof;
+        });
         return proofHash;
     }
 
@@ -37,18 +52,30 @@ export class FraudProofStorage {
     /**
      * Get all fraud proofs for a specific participant
      */
-    getFraudProofForParticipant(
+    public getFraudProofForParticipant(
         participant: Address
     ): FraudProofStruct | undefined {
-        const proofIds = this.participantToProofs.get(participant);
-        if (!proofIds || proofIds.size === 0) {
-            return undefined;
-        }
-        const firstId = proofIds.values().next().value;
-        return this.fraudProofs.get(firstId!);
+        const proofIds = this.participantToProofs.get(
+            String(participant).toLowerCase() as Address
+        );
+        const firstId = proofIds?.values().next().value;
+        return firstId ? this.fraudProofs.get(firstId) : undefined;
     }
 
-    getFraudProofByHash(proofHash: Hash): FraudProofStruct | undefined {
+    public getFraudProofByHash(proofHash: Hash): FraudProofStruct | undefined {
         return this.fraudProofs.get(proofHash);
+    }
+
+    public rebuildIndexes(): void {
+        this.participantToProofs.clear();
+        for (const [proofHash, proof] of this.fraudProofs.entries()) {
+            const participant = String(
+                proof.participant
+            ).toLowerCase() as Address;
+            const hashes =
+                this.participantToProofs.get(participant) ?? new Set<Hash>();
+            hashes.add(proofHash);
+            this.participantToProofs.set(participant, hashes);
+        }
     }
 }

--- a/src/storage/MessageBlockStorage.ts
+++ b/src/storage/MessageBlockStorage.ts
@@ -1,51 +1,74 @@
-import { MessageBlockStruct } from "@typechain-types/contracts/V1/types/DataTypes";
-import { BlockHeight, Hash } from "@/types/types";
-import { Codec, hash, Type } from "@/utils";
+import type { MessageBlockStruct } from "@typechain-types/contracts/V1/types/DataTypes";
 import { ZeroHash } from "ethers";
+
+import type { BlockHeight, Hash } from "@/types/types";
+import { Codec, hash, Type } from "@/utils";
+
+import {
+    PersistentCollection,
+    type CollectionId,
+    type PersistenceController
+} from "./persistence";
+import type { PersistedMessageBlockRecord } from "./persistence/storageCodecs";
 
 type StoreOptions = {
     hash?: Hash;
-    justPersist?: boolean; // if true, do not update latest block pointers
+    justPersist?: boolean;
 };
 
 type GetRangeOptions = {
-    upperBlockHash?: Hash; // newer/higher block (start of backwards traversal, inclusive)
-    lowerBlockHash?: Hash; // older/lower block (stop of backwards traversal, exclusive)
+    upperBlockHash?: Hash;
+    lowerBlockHash?: Hash;
 };
 
 export class MessageBlockStorage {
-    private blockMap: Map<Hash, MessageBlockStruct>;
+    private readonly records: PersistentCollection<
+        Hash,
+        PersistedMessageBlockRecord
+    >;
     private latestBlockHash?: Hash;
     private latestBlockHeight?: BlockHeight;
 
-    constructor() {
-        this.blockMap = new Map();
+    constructor(
+        collectionId: Extract<
+            CollectionId,
+            "inboundMessages" | "outboundMessages"
+        > = "inboundMessages",
+        controller?: PersistenceController
+    ) {
+        this.records = new PersistentCollection(collectionId, controller, () =>
+            this.rebuildIndexes()
+        );
     }
 
     // ====================================
     // CREATE / UPDATE
     // ====================================
 
-    store(messageBlock: MessageBlockStruct, options?: StoreOptions): Hash {
+    public store(
+        messageBlock: MessageBlockStruct,
+        options?: StoreOptions
+    ): Hash {
         const blockHash =
             options?.hash ??
             hash(Codec.encode(messageBlock, Type.MessageBlock));
-
-        const blockHeight = this.normalizeBlockHeight(messageBlock.blockHeight);
-
-        if (!this.blockMap.has(blockHash)) {
-            this.blockMap.set(blockHash, messageBlock);
-        }
-
-        if (options?.justPersist) return blockHash;
-
-        if (
-            this.latestBlockHeight === undefined ||
-            blockHeight >= this.latestBlockHeight
-        ) {
-            this.latestBlockHeight = blockHeight;
-            this.latestBlockHash = blockHash;
-        }
+        this.normalizeBlockHeight(messageBlock.blockHeight);
+        this.records.update(blockHash, (record) => {
+            if (
+                record &&
+                Codec.encode(record.block, Type.MessageBlock) !==
+                    Codec.encode(messageBlock, Type.MessageBlock)
+            ) {
+                throw new Error(
+                    `Incompatible message block for hash ${blockHash}`
+                );
+            }
+            return {
+                block: record?.block ?? messageBlock,
+                advancesTip:
+                    (record?.advancesTip ?? false) || !options?.justPersist
+            };
+        });
         return blockHash;
     }
 
@@ -53,32 +76,35 @@ export class MessageBlockStorage {
     // READ
     // ====================================
 
-    getMessageBlock(blockHash: Hash): MessageBlockStruct | undefined {
-        return this.blockMap.get(blockHash);
+    public getMessageBlock(blockHash: Hash): MessageBlockStruct | undefined {
+        return this.records.get(blockHash)?.block;
     }
 
     // [upperBlockHash, lowerBlockHash) - iterate backwards the blockchain
-    *getIterator(
+    public *getIterator(
         options?: GetRangeOptions
     ): Generator<MessageBlockStruct, void, unknown> {
         const { upperBlockHash, lowerBlockHash } = options ?? {};
         const startBlockHash = upperBlockHash ?? this.latestBlockHash;
-        if (!startBlockHash || startBlockHash == ZeroHash) return;
+        if (!startBlockHash || startBlockHash === ZeroHash) return;
 
         let currentHash = startBlockHash;
-        while (currentHash != ZeroHash) {
+        while (currentHash !== ZeroHash) {
             if (lowerBlockHash && currentHash === lowerBlockHash) break;
-            const messageBlock = this.blockMap.get(currentHash);
-            if (!messageBlock)
+            const messageBlock = this.records.get(currentHash)?.block;
+            if (!messageBlock) {
                 throw new Error(
                     `Block hash ${currentHash} not found in storage`
                 );
+            }
             yield messageBlock;
             currentHash = messageBlock.previousBlockHash as Hash;
         }
     }
 
-    getMessageBlocksInRange(options?: GetRangeOptions): MessageBlockStruct[] {
+    public getMessageBlocksInRange(
+        options?: GetRangeOptions
+    ): MessageBlockStruct[] {
         const blocks: MessageBlockStruct[] = [];
         for (const messageBlock of this.getIterator(options)) {
             blocks.unshift(messageBlock);
@@ -86,22 +112,22 @@ export class MessageBlockStorage {
         return blocks;
     }
 
-    getLatestMessageBlock(): MessageBlockStruct | undefined {
-        if (!this.latestBlockHash) return undefined;
-        return this.blockMap.get(this.latestBlockHash);
+    public getLatestMessageBlock(): MessageBlockStruct | undefined {
+        return this.latestBlockHash
+            ? this.records.get(this.latestBlockHash)?.block
+            : undefined;
     }
 
-    getLatestBlockHash(): Hash | undefined {
+    public getLatestBlockHash(): Hash | undefined {
         return this.latestBlockHash;
     }
 
-    getLatestBlockHeight(): BlockHeight | undefined {
+    public getLatestBlockHeight(): BlockHeight | undefined {
         return this.latestBlockHeight;
     }
 
-    getLatestMessageBlocks(limit?: number): MessageBlockStruct[] {
+    public getLatestMessageBlocks(limit?: number): MessageBlockStruct[] {
         if (!this.latestBlockHash) return [];
-
         const blocks: MessageBlockStruct[] = [];
         for (const messageBlock of this.getIterator({
             upperBlockHash: this.latestBlockHash
@@ -112,11 +138,28 @@ export class MessageBlockStorage {
         return blocks;
     }
 
+    public rebuildIndexes(): void {
+        this.latestBlockHash = undefined;
+        this.latestBlockHeight = undefined;
+        for (const [hashValue, record] of this.records.entries()) {
+            if (!record.advancesTip) continue;
+            const height = this.normalizeBlockHeight(record.block.blockHeight);
+            if (
+                this.latestBlockHeight === undefined ||
+                height >= this.latestBlockHeight
+            ) {
+                this.latestBlockHeight = height;
+                this.latestBlockHash = hashValue;
+            }
+        }
+    }
+
     private normalizeBlockHeight(
         height: MessageBlockStruct["blockHeight"]
     ): BlockHeight {
-        if (height === undefined || height === null)
+        if (height === undefined || height === null) {
             throw new Error("MessageBlockStorage - Block height is undefined");
+        }
         return Number(height);
     }
 }

--- a/src/storage/ParticipantSetChangeStorage.ts
+++ b/src/storage/ParticipantSetChangeStorage.ts
@@ -1,60 +1,58 @@
-import { BlockHeight, ForkId } from "@/types/types";
+import type { BlockHeight, ForkId } from "@/types/types";
+
+import {
+    PersistentCollection,
+    type PersistenceController
+} from "./persistence";
 
 export class ParticipantSetChangeStorage {
-    private map: Map<ForkId, Set<BlockHeight>>;
+    private readonly changes: PersistentCollection<ForkId, Set<BlockHeight>>;
 
-    constructor() {
-        this.map = new Map();
+    constructor(controller?: PersistenceController) {
+        this.changes = new PersistentCollection(
+            "participantSetChanges",
+            controller
+        );
     }
 
     // ====================================
     // CREATE
     // ====================================
 
-    storeChangePoint(
+    public storeChangePoint(
         forkId: ForkId,
         blockHeight: BlockHeight
     ): Set<BlockHeight> {
-        const changePoints = this.map.get(forkId) ?? new Set();
-        changePoints.add(blockHeight);
-        this.map.set(forkId, changePoints);
-
-        return this.map.get(forkId) as Set<BlockHeight>;
+        const updated = this.changes.update(forkId, (changePoints) => {
+            const next = changePoints ?? new Set<BlockHeight>();
+            next.add(blockHeight);
+            return next;
+        });
+        return updated!;
     }
 
     // ====================================
     // READ
     // ====================================
 
-    getChangePointsInRange(
+    public getChangePointsInRange(
         forkId: ForkId,
         start?: BlockHeight,
         end?: BlockHeight
     ): BlockHeight[] {
-        const changePoints = this.map.get(forkId);
-        if (!changePoints?.size) {
-            return [];
-        }
+        const changePoints = this.changes.get(forkId);
+        if (!changePoints?.size) return [];
 
         // invalid range
-        if (start !== undefined && end !== undefined && end <= start) {
-            return [];
-        }
-        const list = Array.from(changePoints).sort(
-            (a, b) => Number(a) - Number(b)
-        );
+        if (start !== undefined && end !== undefined && end <= start) return [];
 
-        if (start === undefined && end === undefined) {
-            return list;
-        }
+        const list = [...changePoints].sort((a, b) => a - b);
+        if (start === undefined && end === undefined) return list;
 
         const actualStart = start ?? list[0];
         const actualEnd = end ?? list[list.length - 1] + 1;
-
-        const filteredChangePoints = list.filter(
+        return list.filter(
             (height) => height >= actualStart && height <= actualEnd
         );
-
-        return filteredChangePoints;
     }
 }

--- a/src/storage/QueueStorage.ts
+++ b/src/storage/QueueStorage.ts
@@ -1,6 +1,10 @@
 import { Block } from "@/models";
 import { Address, BlockHeight, ForkId, Hash, Signature } from "@/types/types";
 import Clock from "@/Clock";
+import {
+    PersistentCollection,
+    type PersistenceController
+} from "./persistence";
 
 export type QueueBlockOptions = {
     senderAddress?: Address;
@@ -23,10 +27,16 @@ export class QueueStorage {
     // participant union; overflow is retained as a marker, never rejected.
     private static readonly MAX_ENTRY_SOURCES = 128;
 
-    private queuedBlocks: Map<Hash, QueuedBlockEntry> = new Map();
+    private readonly queuedBlocks: PersistentCollection<Hash, QueuedBlockEntry>;
 
     // Secondary index for efficient queries by coordinates
     private blocksByCoordinates: Map<string, Set<Hash>> = new Map();
+
+    constructor(controller?: PersistenceController) {
+        this.queuedBlocks = new PersistentCollection("queues", controller, () =>
+            this.rebuildIndexes()
+        );
+    }
 
     /**
      * Build a standalone entry for a block copy — the unit of work the
@@ -45,28 +55,24 @@ export class QueueStorage {
 
     /** Queue a block for future processing */
     queueBlock(block: Block, options?: QueueBlockOptions): Hash {
-        // Check if block already exists in queue
-        const existingEntry = this.queuedBlocks.get(block.hash);
+        this.queuedBlocks.update(block.hash, (entry) => {
+            if (entry) {
+                // Check if block already exists in queue
+                // Attribute only the signatures this copy carried to its sender,
+                // never signatures pooled from earlier copies.
+                this.trackSource(
+                    entry,
+                    block.allSignatures,
+                    options?.senderAddress
+                );
+                entry.block.expandSignatures(block.confirmationSignatures);
+                this.mergeOnChainTimestamp(entry.block, block);
+                return entry;
+            }
 
-        if (existingEntry) {
-            // Attribute only the signatures this copy carried to its sender,
-            // never signatures pooled from earlier copies.
-            this.trackSource(
-                existingEntry,
-                block.allSignatures,
-                options?.senderAddress
-            );
-            existingEntry.block.expandSignatures(block.confirmationSignatures);
-            this.mergeOnChainTimestamp(existingEntry.block, block);
-            this.queuedBlocks.set(block.hash, existingEntry);
-            return block.hash;
-        }
-
-        const entry = this.createEntry(block, options);
-
-        // Store the new block confirmation
-        this.queuedBlocks.set(block.hash, entry);
-        this.addHashToCoordinateIndex(block.hash, block.forkId, block.height);
+            // Store the new block confirmation
+            return this.createEntry(block, options);
+        });
 
         return block.hash;
     }
@@ -80,11 +86,7 @@ export class QueueStorage {
             return [];
         }
 
-        const entries = this.dequeueHashes(hashSet);
-
-        this.blocksByCoordinates.delete(coordinateKey);
-
-        return entries;
+        return this.dequeueHashes(hashSet);
     }
 
     tryDequeuePriority(
@@ -109,10 +111,7 @@ export class QueueStorage {
         const hashes = this.blocksByCoordinates.get(lowestKey);
         if (!hashes) return [];
 
-        const entries = this.dequeueHashes(hashes);
-        this.blocksByCoordinates.delete(lowestKey);
-
-        return entries;
+        return this.dequeueHashes(hashes);
     }
 
     isBlockQueued(block: Block, options?: { hash?: Hash }): boolean {
@@ -129,6 +128,10 @@ export class QueueStorage {
         return this.queuedBlocks.get(blockHash);
     }
 
+    public getEntries(): QueuedBlockEntry[] {
+        return [...this.queuedBlocks.values()];
+    }
+
     /**
      * Re-insert a previously dequeued entry, merging its signatures and
      * source attribution into any entry queued for the same block meanwhile.
@@ -136,48 +139,29 @@ export class QueueStorage {
      * `BlockQueueManager` reads the entry back (`getQueuedEntry`) to (re)schedule.
      */
     restoreEntry(entry: QueuedBlockEntry): void {
-        const existing = this.queuedBlocks.get(entry.block.hash);
-        if (!existing) {
-            this.queuedBlocks.set(entry.block.hash, entry);
-            this.addHashToCoordinateIndex(
-                entry.block.hash,
-                entry.block.forkId,
-                entry.block.height
+        this.queuedBlocks.update(entry.block.hash, (existing) => {
+            if (!existing) return entry;
+            existing.block.expandSignatures(entry.block.confirmationSignatures);
+            this.mergeOnChainTimestamp(existing.block, entry.block);
+            existing.firstSeenAt = Math.min(
+                existing.firstSeenAt,
+                entry.firstSeenAt
             );
-            return;
-        }
-
-        existing.block.expandSignatures(entry.block.confirmationSignatures);
-        this.mergeOnChainTimestamp(existing.block, entry.block);
-        existing.firstSeenAt = Math.min(
-            existing.firstSeenAt,
-            entry.firstSeenAt
-        );
-        if (entry.overflowedSources) existing.overflowedSources = true;
-        for (const peer of entry.sourcePeers)
-            this.addSourcePeer(existing, peer);
-        for (const [signature, peers] of entry.signatureSources) {
-            for (const peer of peers) {
-                this.addSignatureSource(existing, signature, peer);
+            if (entry.overflowedSources) existing.overflowedSources = true;
+            for (const peer of entry.sourcePeers) {
+                this.addSourcePeer(existing, peer);
             }
-        }
+            for (const [signature, peers] of entry.signatureSources) {
+                for (const peer of peers) {
+                    this.addSignatureSource(existing, signature, peer);
+                }
+            }
+            return existing;
+        });
     }
 
     removeBlock(blockHash: Hash): QueuedBlockEntry | undefined {
-        const entry = this.queuedBlocks.get(blockHash);
-        if (!entry) return undefined;
-
-        this.queuedBlocks.delete(blockHash);
-        const coordinateKey = this.coordinatesToKey(
-            entry.block.forkId,
-            entry.block.height
-        );
-        const hashes = this.blocksByCoordinates.get(coordinateKey);
-        hashes?.delete(blockHash);
-        if (hashes?.size === 0) {
-            this.blocksByCoordinates.delete(coordinateKey);
-        }
-        return entry;
+        return this.queuedBlocks.takeMany([blockHash])[0];
     }
 
     clearFork(forkId: ForkId): Hash[] {
@@ -187,12 +171,22 @@ export class QueueStorage {
             if (queuedForkId !== String(forkId)) continue;
 
             for (const hash of hashSet) {
-                this.queuedBlocks.delete(hash);
                 removedHashes.push(hash);
             }
-            this.blocksByCoordinates.delete(key);
         }
+        this.queuedBlocks.deleteMany(removedHashes);
         return removedHashes;
+    }
+
+    public rebuildIndexes(): void {
+        this.blocksByCoordinates.clear();
+        for (const [hash, entry] of this.queuedBlocks.entries()) {
+            this.addHashToCoordinateIndex(
+                hash,
+                entry.block.forkId,
+                entry.block.height
+            );
+        }
     }
 
     // ====================================
@@ -217,17 +211,7 @@ export class QueueStorage {
     }
 
     private dequeueHashes(hashSet: Set<Hash>): QueuedBlockEntry[] {
-        const entries: QueuedBlockEntry[] = [];
-
-        for (const hash of hashSet) {
-            const entry = this.queuedBlocks.get(hash);
-            if (entry) {
-                entries.push(entry);
-                this.queuedBlocks.delete(hash);
-            }
-        }
-
-        return entries;
+        return this.queuedBlocks.takeMany([...hashSet]);
     }
 
     private trackSource(

--- a/src/storage/StateMachineStateStorage.ts
+++ b/src/storage/StateMachineStateStorage.ts
@@ -1,25 +1,36 @@
-import { Hash, Bytes } from "@/types/types";
 import { ethers } from "ethers";
+
+import type { Bytes, Hash } from "@/types/types";
+
+import {
+    PersistentCollection,
+    type PersistenceController
+} from "./persistence";
 
 type StoreOptions = {
     hash?: Hash;
 };
 
 export class StateMachineStateStorage {
-    private statesByHash: Map<Hash, Bytes>;
+    private readonly states: PersistentCollection<Hash, Bytes>;
 
-    constructor() {
-        this.statesByHash = new Map();
+    constructor(controller?: PersistenceController) {
+        this.states = new PersistentCollection(
+            "stateMachineStates",
+            controller
+        );
     }
 
     // ====================================
     // CREATE
     // ====================================
 
-    storeStateMachineState(encodedState: Bytes, options?: StoreOptions): Hash {
+    public storeStateMachineState(
+        encodedState: Bytes,
+        options?: StoreOptions
+    ): Hash {
         const hash = options?.hash ?? ethers.keccak256(encodedState);
-        this.statesByHash.set(hash, encodedState);
-
+        this.states.set(hash, encodedState);
         return hash;
     }
 
@@ -27,7 +38,7 @@ export class StateMachineStateStorage {
     // READ
     // ====================================
 
-    getStateMachineState(hash: Hash): Bytes | undefined {
-        return this.statesByHash.get(hash);
+    public getStateMachineState(hash: Hash): Bytes | undefined {
+        return this.states.get(hash);
     }
 }

--- a/src/storage/StateSnapshotStorage.ts
+++ b/src/storage/StateSnapshotStorage.ts
@@ -1,38 +1,63 @@
-import { Hash, ForkId } from "@/types/types";
 import StateSnapshot from "@/models/StateSnapshot";
+import type { ForkId, Hash } from "@/types/types";
+
+import {
+    PersistentCollection,
+    type PersistenceController
+} from "./persistence";
 
 type StateSnapshotHash = Hash;
-
 type StoreOptions = {
     hash?: StateSnapshotHash;
 };
 
 export class StateSnapshotStorage {
-    private snapshotsByHash: Map<StateSnapshotHash, StateSnapshot>;
-    // Store genesis SnapshotData by forkId (forkId = hash(snapshotData)
-    private genesisSnapshotByForkId: Map<ForkId, StateSnapshot>;
+    private readonly snapshots: PersistentCollection<
+        StateSnapshotHash,
+        StateSnapshot
+    >;
 
-    constructor() {
-        this.snapshotsByHash = new Map();
-        this.genesisSnapshotByForkId = new Map();
+    // Store genesis SnapshotData by forkId (forkId = hash(snapshotData)
+    private readonly genesisSnapshotByForkId = new Map<
+        ForkId,
+        StateSnapshotHash
+    >();
+
+    constructor(controller?: PersistenceController) {
+        this.snapshots = new PersistentCollection(
+            "stateSnapshots",
+            controller,
+            () => this.rebuildIndexes()
+        );
     }
 
     // ====================================
     // CREATE
     // ====================================
 
-    storeStateSnapshot(
+    public storeStateSnapshot(
         snapshot: StateSnapshot,
         options?: StoreOptions
     ): StateSnapshotHash {
         const hash = options?.hash ?? snapshot.hash;
-
-        this.snapshotsByHash.set(hash, snapshot);
-
-        if (snapshot.isGenesis) {
-            this.genesisSnapshotByForkId.set(snapshot.forkID, snapshot);
-        }
-
+        this.snapshots.update(hash, (existing) => {
+            const existingGenesis = this.genesisSnapshotByForkId.get(
+                snapshot.forkID
+            );
+            if (
+                snapshot.isGenesis &&
+                existingGenesis &&
+                existingGenesis !== hash
+            ) {
+                throw new Error(
+                    `Conflicting genesis snapshots for fork ${snapshot.forkID}`
+                );
+            }
+            if (existing && existing.encode() !== snapshot.encode()) {
+                throw new Error(`Incompatible state snapshot for hash ${hash}`);
+            }
+            return snapshot;
+        });
         return hash;
     }
 
@@ -43,13 +68,37 @@ export class StateSnapshotStorage {
     /**
      * Get a state snapshot by its hash
      */
-    getStateSnapshotByHash(
+    public getStateSnapshotByHash(
         snapshotHash: StateSnapshotHash
     ): StateSnapshot | undefined {
-        return this.snapshotsByHash.get(snapshotHash);
+        return this.snapshots.get(snapshotHash);
     }
 
-    getGenesisSnapshotByForkId(forkId: ForkId): StateSnapshot | undefined {
-        return this.genesisSnapshotByForkId.get(forkId);
+    public getGenesisSnapshotByForkId(
+        forkId: ForkId
+    ): StateSnapshot | undefined {
+        const hash = this.genesisSnapshotByForkId.get(forkId);
+        return hash ? this.snapshots.get(hash) : undefined;
+    }
+
+    public getSnapshotCount(): number {
+        return this.snapshots.size;
+    }
+
+    public rebuildIndexes(): void {
+        this.genesisSnapshotByForkId.clear();
+        for (const [hash, snapshot] of this.snapshots.entries()) {
+            if (snapshot.isGenesis) {
+                const existingHash = this.genesisSnapshotByForkId.get(
+                    snapshot.forkID
+                );
+                if (existingHash && existingHash !== hash) {
+                    throw new Error(
+                        `Conflicting genesis snapshots for fork ${snapshot.forkID}`
+                    );
+                }
+                this.genesisSnapshotByForkId.set(snapshot.forkID, hash);
+            }
+        }
     }
 }

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -17,6 +17,17 @@ import { ForceJoinStorage } from "./ForceJoinStorage";
 import { DisputeFraudProofStorage } from "./DisputeFraudProofStorage";
 import { BlockCalldataStorage } from "./BlockCalldataStorage";
 import { EventSyncStorage } from "./EventSyncStorage";
+import type { Logger } from "@/utils/logging";
+import {
+    PersistenceController,
+    PersistentCollection,
+    type PersistenceControllerOptions,
+    type PersistenceDatabaseHandle
+} from "./persistence";
+import {
+    createStorageRecordCodec,
+    type RuntimeMetadata
+} from "./persistence/storageCodecs";
 
 export class Storage {
     public readonly blocks: BlockStorage;
@@ -34,27 +45,113 @@ export class Storage {
     public readonly forceJoin: ForceJoinStorage;
     public readonly blockCalldata: BlockCalldataStorage;
     public readonly eventSync: EventSyncStorage;
+    private readonly controller: PersistenceController;
+    private readonly runtimeMetadata: PersistentCollection<
+        "active",
+        RuntimeMetadata
+    >;
+    private persistenceLocation?: string;
 
-    constructor() {
-        this.blocks = deepCopyProxy(new BlockStorage());
-        this.inboundMessages = deepCopyProxy(new MessageBlockStorage());
-        this.outboundMessages = deepCopyProxy(new MessageBlockStorage());
-        this.stateSnapshots = deepCopyProxy(new StateSnapshotStorage());
-        this.stateMachineStates = deepCopyProxy(new StateMachineStateStorage());
-        this.participantSetChanges = deepCopyProxy(
-            new ParticipantSetChangeStorage()
+    constructor(
+        logger?: Logger,
+        persistenceOptions: Pick<
+            PersistenceControllerOptions,
+            "flushIntervalMs" | "maxBatchOperations"
+        > = {}
+    ) {
+        this.controller = new PersistenceController(
+            createStorageRecordCodec(),
+            { logger, ...persistenceOptions }
         );
-        this.queues = deepCopyProxy(new QueueStorage());
-        this.disputes = deepCopyProxy(new DisputeStorage());
-        this.fraudProofs = deepCopyProxy(new FraudProofStorage());
-        this.disputeFraudProofs = deepCopyProxy(new DisputeFraudProofStorage());
-        this.timeout = deepCopyProxy(new TimeoutStorage());
-        this.forceExit = deepCopyProxy(new ForceExitStorage());
-        this.forceJoin = deepCopyProxy(new ForceJoinStorage());
-        this.blockCalldata = deepCopyProxy(new BlockCalldataStorage());
-        this.eventSync = deepCopyProxy(new EventSyncStorage());
-        return deepCopyProxy(this);
+        this.blocks = deepCopyProxy(new BlockStorage(this.controller));
+        this.inboundMessages = deepCopyProxy(
+            new MessageBlockStorage("inboundMessages", this.controller)
+        );
+        this.outboundMessages = deepCopyProxy(
+            new MessageBlockStorage("outboundMessages", this.controller)
+        );
+        this.stateSnapshots = deepCopyProxy(
+            new StateSnapshotStorage(this.controller)
+        );
+        this.stateMachineStates = deepCopyProxy(
+            new StateMachineStateStorage(this.controller)
+        );
+        this.participantSetChanges = deepCopyProxy(
+            new ParticipantSetChangeStorage(this.controller)
+        );
+        this.queues = deepCopyProxy(new QueueStorage(this.controller));
+        this.disputes = deepCopyProxy(new DisputeStorage(this.controller));
+        this.fraudProofs = deepCopyProxy(
+            new FraudProofStorage(this.controller)
+        );
+        this.disputeFraudProofs = deepCopyProxy(
+            new DisputeFraudProofStorage(this.controller)
+        );
+        this.timeout = deepCopyProxy(new TimeoutStorage(this.controller));
+        this.forceExit = deepCopyProxy(new ForceExitStorage(this.controller));
+        this.forceJoin = deepCopyProxy(new ForceJoinStorage(this.controller));
+        this.blockCalldata = deepCopyProxy(
+            new BlockCalldataStorage(this.controller)
+        );
+        this.eventSync = deepCopyProxy(new EventSyncStorage(this.controller));
+        this.runtimeMetadata = new PersistentCollection(
+            "runtimeMetadata",
+            this.controller
+        );
+        return deepCopyProxy(this, {
+            preserveArgumentsFor: new Set([
+                "bind",
+                "setPersistenceFailureHandler",
+                "flush",
+                "close"
+            ])
+        });
     }
+
+    /**
+     * Hydrates EVERY collection above in one pass and rebuilds their derived
+     * indexes; all-or-nothing (a decode failure restores the previous caches
+     * and closes the database). Runs during host construction, before the
+     * StateManager exists - so `StateManager.restorePersistedState` only has to
+     * recover the process-local state that never reaches a collection.
+     */
+    public async bind(
+        databaseHandle: PersistenceDatabaseHandle
+    ): Promise<void> {
+        this.persistenceLocation = databaseHandle.location;
+        this.controller.attachDatabaseHandle(databaseHandle);
+        await this.controller.bind();
+        // TODO(persistence): distinguish legal forward crash prefixes from
+        // referenced corruption before rejecting hydration.
+    }
+
+    public setPersistenceFailureHandler(handler: (error: Error) => void): void {
+        this.controller.setFailureHandler(handler);
+    }
+
+    public setRuntimeMetadata(metadata: RuntimeMetadata): void {
+        this.runtimeMetadata.set("active", metadata);
+    }
+
+    public getRuntimeMetadata(): RuntimeMetadata | undefined {
+        return this.runtimeMetadata.get("active");
+    }
+
+    public flush(): Promise<void> {
+        return this.controller.flush();
+    }
+
+    public close(): Promise<void> {
+        return this.controller.close();
+    }
+
+    public getPersistenceLocation(): string | undefined {
+        return this.persistenceLocation;
+    }
+
+    // TODO(persistence): add proof-aware pruning in a separate design. It must
+    // protect active proof roots, disputes, queue entries, heads, and stale-fork
+    // tombstones, then revalidate writes that raced its reachability scan.
 
     /**
      * Get the state snapshot for given block coordinates.

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -56,7 +56,7 @@ export class Storage {
         logger?: Logger,
         persistenceOptions: Pick<
             PersistenceControllerOptions,
-            "flushIntervalMs" | "maxBatchOperations"
+            "flushIntervalMs" | "maxBatchOperations" | "commitDeadlineMs"
         > = {}
     ) {
         this.controller = new PersistenceController(

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -137,6 +137,20 @@ export class Storage {
         return this.runtimeMetadata.get("active");
     }
 
+    /**
+     * Ensure the collections are hydrated (resume-from-background entry
+     * point). With write-behind persistence the in-memory caches are
+     * authoritative once bound — they may be AHEAD of disk — so a live
+     * re-read would roll them back; "hydrate on resume" therefore means
+     * hydrate exactly once: an already-bound storage resolves immediately,
+     * a hydrate racing the connect-path bind() joins that same run, and a
+     * storage whose handle isn't attached yet resolves as a no-op (the
+     * handle-attach path re-runs the real hydration).
+     */
+    public hydrate(): Promise<void> {
+        return this.controller.bind();
+    }
+
     public flush(): Promise<void> {
         return this.controller.flush();
     }

--- a/src/storage/TimeoutStorage.ts
+++ b/src/storage/TimeoutStorage.ts
@@ -1,35 +1,40 @@
-import { ForkId } from "@/types/types";
+import type { TimeoutStruct } from "@typechain-types/contracts/V1/types/DisputeTypes";
 
-import { TimeoutStruct } from "@typechain-types/contracts/V1/types/DisputeTypes";
+import type { ForkId } from "@/types/types";
+
+import {
+    PersistentCollection,
+    type PersistenceController
+} from "./persistence";
 
 export class TimeoutStorage {
     // ====================================
     // STORAGE MAP
     // ====================================
-    private timeouts: Map<ForkId, TimeoutStruct>;
+    private readonly timeouts: PersistentCollection<ForkId, TimeoutStruct>;
 
-    constructor() {
-        this.timeouts = new Map();
+    constructor(controller?: PersistenceController) {
+        this.timeouts = new PersistentCollection("timeout", controller);
     }
 
     // ====================================
     // CREATE & UPDATE
     // ====================================
 
-    storeTimeout(forkId: ForkId, timeout: TimeoutStruct): void {
-        const existingTimeout = this.timeouts.get(forkId);
-        if (
-            existingTimeout &&
-            timeout.blockHeight > existingTimeout.blockHeight
-        )
-            return;
-        this.timeouts.set(forkId, timeout);
+    public storeTimeout(forkId: ForkId, timeout: TimeoutStruct): void {
+        this.timeouts.update(forkId, (existing) => {
+            if (existing && timeout.blockHeight > existing.blockHeight) {
+                return existing;
+            }
+            return timeout;
+        });
     }
 
     // ====================================
     // READ
     // ====================================
-    getTimeout(forkId: ForkId): TimeoutStruct | undefined {
+
+    public getTimeout(forkId: ForkId): TimeoutStruct | undefined {
         return this.timeouts.get(forkId);
     }
 }

--- a/src/storage/persistence/PersistenceController.ts
+++ b/src/storage/persistence/PersistenceController.ts
@@ -70,6 +70,7 @@ export class PersistenceController {
     private poisonedError?: Error;
     private flushTimer?: ReturnType<typeof setTimeout>;
     private drainPromise?: Promise<void>;
+    private bindPromise?: Promise<void>;
     private closePromise?: Promise<void>;
     private nextRevision = 0;
     private persistedRevision = 0;
@@ -120,7 +121,21 @@ export class PersistenceController {
             this.bound = true;
             return;
         }
+        // Serialize concurrent binds (e.g. a resume-from-background hydrate
+        // racing the connect-path bind) onto one hydration run; the memo is
+        // in-flight only, so a handle attached later still re-runs for real.
+        if (this.bindPromise) return this.bindPromise;
+        this.bindPromise = this.runBind().finally(() => {
+            this.bindPromise = undefined;
+        });
+        return this.bindPromise;
+    }
 
+    private async runBind(): Promise<void> {
+        if (!this.databaseHandle) {
+            this.bound = true;
+            return;
+        }
         const hydrated = new Map<CollectionId, Array<[string, unknown]>>();
         for (const collectionId of this.collections.keys()) {
             hydrated.set(collectionId, []);

--- a/src/storage/persistence/PersistenceController.ts
+++ b/src/storage/persistence/PersistenceController.ts
@@ -1,0 +1,519 @@
+import cloneDeep from "lodash.clonedeep";
+
+import type { Logger } from "@/utils/logging";
+import { retry } from "@/utils/retry";
+
+import type {
+    PersistenceBatchOperation,
+    PersistenceDatabaseHandle
+} from "./PersistenceDatabase";
+import type { PersistentCollection } from "./PersistentCollection";
+import {
+    PersistenceRecordCodec,
+    type CollectionId
+} from "./PersistenceRecordCodec";
+
+const RECORD_PREFIX = "records!v1!";
+const DEFAULT_FLUSH_INTERVAL_MS = 50;
+const DEFAULT_MAX_BATCH_OPERATIONS = 500;
+const DEFAULT_PENDING_WARNING_OPERATIONS = 2_000;
+
+type RegisteredCollection = PersistentCollection<unknown, unknown>;
+type EncodedRecordKey = string;
+type PendingRecord = {
+    operation: PersistenceBatchOperation;
+    revision: number;
+};
+type FlushWaiter = {
+    targetRevision: number;
+    resolve: () => void;
+    reject: (error: Error) => void;
+};
+
+export interface PersistenceControllerOptions {
+    databaseHandle?: PersistenceDatabaseHandle;
+    logger?: Logger;
+    maxRetries?: number;
+    flushIntervalMs?: number;
+    maxBatchOperations?: number;
+    pendingWarningOperations?: number;
+}
+
+export class PersistenceController {
+    private readonly collections = new Map<
+        CollectionId,
+        RegisteredCollection
+    >();
+    private readonly codec: PersistenceRecordCodec;
+    private databaseHandle?: PersistenceDatabaseHandle;
+    private readonly logger?: Logger;
+    private readonly maxRetries: number;
+    private readonly flushIntervalMs: number;
+    private readonly maxBatchOperations: number;
+    private readonly pendingWarningOperations: number;
+    private readonly pendingRecords = new Map<
+        EncodedRecordKey,
+        PendingRecord
+    >();
+    private readonly flushWaiters: FlushWaiter[] = [];
+    private failureHandler?: (error: Error) => void;
+    private poisonedError?: Error;
+    private flushTimer?: ReturnType<typeof setTimeout>;
+    private drainPromise?: Promise<void>;
+    private closePromise?: Promise<void>;
+    private nextRevision = 0;
+    private persistedRevision = 0;
+    private bound = false;
+    private closing = false;
+    private closed = false;
+    private inFailureCleanup = false;
+    private pendingWarningEmitted = false;
+
+    constructor(
+        codec: PersistenceRecordCodec,
+        options: PersistenceControllerOptions = {}
+    ) {
+        this.codec = codec;
+        this.databaseHandle = options.databaseHandle;
+        this.logger = options.logger;
+        this.maxRetries = options.maxRetries ?? 2;
+        this.flushIntervalMs =
+            options.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
+        this.maxBatchOperations =
+            options.maxBatchOperations ?? DEFAULT_MAX_BATCH_OPERATIONS;
+        this.pendingWarningOperations =
+            options.pendingWarningOperations ??
+            DEFAULT_PENDING_WARNING_OPERATIONS;
+        this.bound = !options.databaseHandle;
+    }
+
+    public register<TKey, TValue>(
+        collection: PersistentCollection<TKey, TValue>
+    ): void {
+        if (this.collections.has(collection.id)) {
+            throw new Error(
+                `Persistence collection already registered: ${collection.id}`
+            );
+        }
+        this.collections.set(
+            collection.id,
+            collection as PersistentCollection<unknown, unknown>
+        );
+    }
+
+    public async bind(): Promise<void> {
+        this.assertOpen();
+        if (this.bound) return;
+        if (!this.databaseHandle) {
+            this.bound = true;
+            return;
+        }
+
+        const hydrated = new Map<CollectionId, Array<[string, unknown]>>();
+        for (const collectionId of this.collections.keys()) {
+            hydrated.set(collectionId, []);
+        }
+
+        try {
+            await this.databaseHandle.database.open();
+            for await (const [
+                key,
+                encodedValue
+            ] of this.databaseHandle.database.iterator({
+                gte: RECORD_PREFIX,
+                lt: `${RECORD_PREFIX}\uffff`
+            })) {
+                const parsed = this.parseRecordKey(key);
+                const entries = hydrated.get(parsed.collectionId);
+                if (!entries) {
+                    throw new Error(
+                        `Unknown persistence collection ${parsed.collectionId}`
+                    );
+                }
+                entries.push([
+                    parsed.key,
+                    this.codec.decode(parsed.collectionId, encodedValue)
+                ]);
+            }
+        } catch (error) {
+            try {
+                await this.databaseHandle.close();
+            } catch {
+                // Preserve the bind failure, which has the actionable location.
+            }
+            throw this.withLocation(error);
+        }
+
+        const previousEntries = new Map<
+            CollectionId,
+            Array<[unknown, unknown]>
+        >();
+        for (const [collectionId, collection] of this.collections) {
+            previousEntries.set(
+                collectionId,
+                cloneDeep([...collection.entries()])
+            );
+        }
+
+        try {
+            for (const [collectionId, entries] of hydrated) {
+                this.collections.get(collectionId)!.replace(entries);
+            }
+        } catch (error) {
+            for (const [collectionId, entries] of previousEntries) {
+                this.collections.get(collectionId)!.replace(entries);
+            }
+            try {
+                await this.databaseHandle.close();
+            } catch {
+                // Preserve the hydration failure and its actionable location.
+            }
+            throw this.withLocation(error);
+        }
+        this.bound = true;
+    }
+
+    public attachDatabaseHandle(
+        databaseHandle: PersistenceDatabaseHandle
+    ): void {
+        this.assertOpen();
+        if (this.databaseHandle) {
+            throw new Error("Persistence database is already attached");
+        }
+        this.databaseHandle = databaseHandle;
+        this.bound = false;
+    }
+
+    public setFailureHandler(handler: (error: Error) => void): void {
+        this.failureHandler = handler;
+    }
+
+    public update<TKey, TValue>(
+        collection: PersistentCollection<TKey, TValue>,
+        key: TKey,
+        updater: (currentValue: TValue | undefined) => TValue | undefined
+    ): TValue | undefined {
+        this.assertMutationAllowed();
+        const currentValue = cloneDeep(collection.get(key));
+        const nextValue = updater(currentValue);
+        const committedValue = cloneDeep(nextValue);
+        const operation = this.createOperation(
+            collection.id,
+            key,
+            committedValue
+        );
+        collection.apply(key, committedValue);
+        this.enqueue([operation]);
+        return cloneDeep(committedValue);
+    }
+
+    public clear<TKey, TValue>(
+        collection: PersistentCollection<TKey, TValue>
+    ): void {
+        this.assertMutationAllowed();
+        const operations = [...collection.keys()].map(
+            (key): PersistenceBatchOperation => ({
+                type: "del",
+                key: this.recordKey(collection.id, key)
+            })
+        );
+        if (!operations.length) return;
+        collection.replace([]);
+        this.enqueue(operations);
+    }
+
+    public deleteMany<TKey, TValue>(
+        collection: PersistentCollection<TKey, TValue>,
+        keys: readonly TKey[]
+    ): TValue[] {
+        this.assertMutationAllowed();
+        const existing = [...new Set(keys)].flatMap((key) => {
+            const value = collection.get(key);
+            return value === undefined
+                ? []
+                : [[key, cloneDeep(value)] as const];
+        });
+        if (!existing.length) return [];
+
+        for (const [key] of existing) collection.apply(key, undefined, false);
+        collection.notifyChanged();
+        this.enqueue(
+            existing.map(
+                ([key]): PersistenceBatchOperation => ({
+                    type: "del",
+                    key: this.recordKey(collection.id, key)
+                })
+            )
+        );
+        return existing.map(([, value]) => value);
+    }
+
+    public async flush(): Promise<void> {
+        this.assertOpen();
+        await this.flushThrough(this.nextRevision);
+    }
+
+    public close(): Promise<void> {
+        if (this.closePromise) return this.closePromise;
+        if (this.closed) return Promise.resolve();
+
+        this.closing = true;
+        this.clearFlushTimer();
+        const targetRevision = this.nextRevision;
+        this.closePromise = (async () => {
+            let flushError: Error | undefined;
+            try {
+                await this.flushThrough(targetRevision);
+            } catch (error) {
+                flushError = this.normalizeError(error);
+            }
+            try {
+                await this.databaseHandle?.close();
+            } catch (error) {
+                flushError ??= this.normalizeError(error);
+            } finally {
+                this.closed = true;
+                this.closing = false;
+                this.rejectWaiters(
+                    flushError ?? new Error("Persistence controller is closed")
+                );
+            }
+            if (flushError) throw flushError;
+        })();
+        return this.closePromise;
+    }
+
+    private createOperation<TKey, TValue>(
+        collectionId: CollectionId,
+        key: TKey,
+        value: TValue | undefined
+    ): PersistenceBatchOperation {
+        return value === undefined
+            ? { type: "del", key: this.recordKey(collectionId, key) }
+            : {
+                  type: "put",
+                  key: this.recordKey(collectionId, key),
+                  value: this.codec.encode(collectionId, value)
+              };
+    }
+
+    private enqueue(operations: PersistenceBatchOperation[]): void {
+        if (
+            !operations.length ||
+            !this.databaseHandle ||
+            this.inFailureCleanup
+        ) {
+            return;
+        }
+        if (this.poisonedError) return;
+
+        const revision = ++this.nextRevision;
+        for (const operation of operations) {
+            this.pendingRecords.set(String(operation.key), {
+                operation,
+                revision
+            });
+        }
+        this.maybeWarnPendingSize();
+
+        if (this.pendingRecords.size >= this.maxBatchOperations) {
+            this.clearFlushTimer();
+            this.startDrain();
+        } else {
+            this.scheduleFlush();
+        }
+    }
+
+    private flushThrough(targetRevision: number): Promise<void> {
+        if (!this.databaseHandle || targetRevision <= this.persistedRevision) {
+            return Promise.resolve();
+        }
+        if (this.poisonedError) return Promise.reject(this.poisonedError);
+
+        const promise = new Promise<void>((resolve, reject) => {
+            this.flushWaiters.push({ targetRevision, resolve, reject });
+        });
+        this.clearFlushTimer();
+        this.startDrain();
+        return promise;
+    }
+
+    private scheduleFlush(): void {
+        if (this.flushTimer || this.drainPromise || !this.pendingRecords.size) {
+            return;
+        }
+        this.flushTimer = setTimeout(() => {
+            this.flushTimer = undefined;
+            this.startDrain();
+        }, this.flushIntervalMs);
+        this.flushTimer.unref?.();
+    }
+
+    private startDrain(): void {
+        if (
+            this.drainPromise ||
+            this.poisonedError ||
+            !this.databaseHandle ||
+            !this.pendingRecords.size
+        ) {
+            return;
+        }
+
+        const records = [...this.pendingRecords.values()];
+        this.pendingRecords.clear();
+        const highestRevision = Math.max(
+            ...records.map((record) => record.revision)
+        );
+        this.drainPromise = this.commit(
+            records.map((record) => record.operation)
+        )
+            .then(() => {
+                this.persistedRevision = Math.max(
+                    this.persistedRevision,
+                    highestRevision
+                );
+                this.resolveWaiters();
+            })
+            .catch((error) => this.poison(error))
+            .finally(() => {
+                this.drainPromise = undefined;
+                if (this.poisonedError) return;
+                if (
+                    this.pendingRecords.size >= this.maxBatchOperations ||
+                    this.hasWaitingRevision()
+                ) {
+                    this.startDrain();
+                } else {
+                    this.scheduleFlush();
+                }
+            });
+    }
+
+    private async commit(
+        operations: PersistenceBatchOperation[]
+    ): Promise<void> {
+        if (!operations.length || !this.databaseHandle) return;
+        await retry(() => this.databaseHandle!.database.batch(operations), {
+            maxRetries: this.maxRetries,
+            delayMs: 10,
+            useExponentialBackoff: true,
+            onRetry: (attempt, error) =>
+                this.logger?.warn("Retrying persistence mutation", {
+                    attempt,
+                    error
+                })
+        });
+    }
+
+    private resolveWaiters(): void {
+        for (let index = this.flushWaiters.length - 1; index >= 0; index--) {
+            const waiter = this.flushWaiters[index];
+            if (waiter.targetRevision > this.persistedRevision) continue;
+            this.flushWaiters.splice(index, 1);
+            waiter.resolve();
+        }
+    }
+
+    private rejectWaiters(error: Error): void {
+        for (const waiter of this.flushWaiters.splice(0)) waiter.reject(error);
+    }
+
+    private hasWaitingRevision(): boolean {
+        return this.flushWaiters.some(
+            (waiter) => waiter.targetRevision > this.persistedRevision
+        );
+    }
+
+    private maybeWarnPendingSize(): void {
+        if (this.pendingRecords.size < this.pendingWarningOperations) {
+            this.pendingWarningEmitted = false;
+            return;
+        }
+        if (this.pendingWarningEmitted) return;
+        this.pendingWarningEmitted = true;
+        this.logger?.warn(
+            "Persistence pending-record high-water mark reached",
+            {
+                pendingRecords: this.pendingRecords.size,
+                warningThreshold: this.pendingWarningOperations
+            }
+        );
+    }
+
+    private clearFlushTimer(): void {
+        if (!this.flushTimer) return;
+        clearTimeout(this.flushTimer);
+        this.flushTimer = undefined;
+    }
+
+    private assertOpen(): void {
+        if (this.closed) {
+            throw new Error("Persistence controller is closed");
+        }
+    }
+
+    private assertMutationAllowed(): void {
+        this.assertOpen();
+        if (!this.bound) {
+            throw new Error("Persistence controller is not bound");
+        }
+        if (this.closing && !this.inFailureCleanup) {
+            throw new Error("Persistence controller is closing");
+        }
+    }
+
+    private poison(error: unknown): void {
+        const normalized = this.normalizeError(error);
+        if (this.poisonedError) return;
+        this.poisonedError = normalized;
+        this.logger?.error("Persistence mutation failed", {
+            error: normalized
+        });
+        this.rejectWaiters(normalized);
+        if (!this.failureHandler) return;
+        this.inFailureCleanup = true;
+        try {
+            this.failureHandler(normalized);
+        } catch (handlerError) {
+            this.logger?.error("Persistence failure handler failed", {
+                error: this.normalizeError(handlerError)
+            });
+        } finally {
+            this.inFailureCleanup = false;
+        }
+    }
+
+    private normalizeError(error: unknown): Error {
+        return error instanceof Error ? error : new Error(String(error));
+    }
+
+    private withLocation(error: unknown): Error {
+        const normalized = this.normalizeError(error);
+        const location = this.databaseHandle?.location;
+        return location
+            ? new Error(`${normalized.message} (persistence: ${location})`)
+            : normalized;
+    }
+
+    private recordKey(
+        collectionId: CollectionId,
+        key: unknown
+    ): EncodedRecordKey {
+        return `${RECORD_PREFIX}${collectionId}!${String(key)}`;
+    }
+
+    private parseRecordKey(recordKey: EncodedRecordKey): {
+        collectionId: CollectionId;
+        key: string;
+    } {
+        const remainder = recordKey.slice(RECORD_PREFIX.length);
+        const separator = remainder.indexOf("!");
+        if (separator <= 0) {
+            throw new Error(`Invalid persistence record key ${recordKey}`);
+        }
+        return {
+            collectionId: remainder.slice(0, separator) as CollectionId,
+            key: remainder.slice(separator + 1)
+        };
+    }
+}

--- a/src/storage/persistence/PersistenceController.ts
+++ b/src/storage/persistence/PersistenceController.ts
@@ -17,6 +17,7 @@ const RECORD_PREFIX = "records!v1!";
 const DEFAULT_FLUSH_INTERVAL_MS = 50;
 const DEFAULT_MAX_BATCH_OPERATIONS = 500;
 const DEFAULT_PENDING_WARNING_OPERATIONS = 2_000;
+const DEFAULT_COMMIT_DEADLINE_MS = 30_000;
 
 type RegisteredCollection = PersistentCollection<unknown, unknown>;
 type EncodedRecordKey = string;
@@ -37,6 +38,14 @@ export interface PersistenceControllerOptions {
     flushIntervalMs?: number;
     maxBatchOperations?: number;
     pendingWarningOperations?: number;
+    /**
+     * Deadline for a whole drain attempt (the batch write including its
+     * retries). A rejecting batch already poisons the controller through the
+     * retry path; this catches the batch that HANGS instead — without it a
+     * hung database keeps every flush waiter (and thus every durability
+     * barrier) pending forever with no failure-handler teardown. 0 disables.
+     */
+    commitDeadlineMs?: number;
 }
 
 export class PersistenceController {
@@ -51,6 +60,7 @@ export class PersistenceController {
     private readonly flushIntervalMs: number;
     private readonly maxBatchOperations: number;
     private readonly pendingWarningOperations: number;
+    private readonly commitDeadlineMs: number;
     private readonly pendingRecords = new Map<
         EncodedRecordKey,
         PendingRecord
@@ -84,6 +94,8 @@ export class PersistenceController {
         this.pendingWarningOperations =
             options.pendingWarningOperations ??
             DEFAULT_PENDING_WARNING_OPERATIONS;
+        this.commitDeadlineMs =
+            options.commitDeadlineMs ?? DEFAULT_COMMIT_DEADLINE_MS;
         this.bound = !options.databaseHandle;
     }
 
@@ -393,16 +405,44 @@ export class PersistenceController {
         operations: PersistenceBatchOperation[]
     ): Promise<void> {
         if (!operations.length || !this.databaseHandle) return;
-        await retry(() => this.databaseHandle!.database.batch(operations), {
-            maxRetries: this.maxRetries,
-            delayMs: 10,
-            useExponentialBackoff: true,
-            onRetry: (attempt, error) =>
-                this.logger?.warn("Retrying persistence mutation", {
-                    attempt,
-                    error
-                })
+        await this.withCommitDeadline(
+            retry(() => this.databaseHandle!.database.batch(operations), {
+                maxRetries: this.maxRetries,
+                delayMs: 10,
+                useExponentialBackoff: true,
+                onRetry: (attempt, error) =>
+                    this.logger?.warn("Retrying persistence mutation", {
+                        attempt,
+                        error
+                    })
+            })
+        );
+    }
+
+    /**
+     * Rejects when the commit doesn't settle within the deadline, so a HUNG
+     * batch flows into the same poison path as a rejecting one. The late
+     * settlement of the abandoned batch is harmless: waiters were already
+     * rejected by poison() and the drain loop stops on poisonedError.
+     */
+    private withCommitDeadline(commitPromise: Promise<void>): Promise<void> {
+        if (!this.commitDeadlineMs) return commitPromise;
+        let deadlineTimer: ReturnType<typeof setTimeout>;
+        const deadline = new Promise<never>((_, reject) => {
+            deadlineTimer = setTimeout(
+                () =>
+                    reject(
+                        new Error(
+                            `Persistence commit exceeded its ${this.commitDeadlineMs}ms deadline`
+                        )
+                    ),
+                this.commitDeadlineMs
+            );
+            deadlineTimer.unref?.();
         });
+        return Promise.race([commitPromise, deadline]).finally(() =>
+            clearTimeout(deadlineTimer)
+        );
     }
 
     private resolveWaiters(): void {

--- a/src/storage/persistence/PersistenceDatabase.ts
+++ b/src/storage/persistence/PersistenceDatabase.ts
@@ -1,0 +1,32 @@
+import type { AbstractBatchOperation, AbstractLevel } from "abstract-level";
+
+export type PersistenceKey = string;
+export type EncodedPersistenceValue = string;
+
+export type PersistenceDatabase = AbstractLevel<
+    any,
+    PersistenceKey,
+    EncodedPersistenceValue
+>;
+
+export type PersistenceBatchOperation = AbstractBatchOperation<
+    PersistenceDatabase,
+    PersistenceKey,
+    EncodedPersistenceValue
+>;
+
+export interface PersistenceDatabaseHandle {
+    readonly database: PersistenceDatabase;
+    readonly location: string;
+    close(): Promise<void>;
+    destroy(): Promise<void>;
+}
+
+export interface CreatePersistenceDatabaseOptions {
+    location?: string;
+    namespace: string;
+}
+
+export type CreatePersistenceDatabase = (
+    options: CreatePersistenceDatabaseOptions
+) => Promise<PersistenceDatabaseHandle>;

--- a/src/storage/persistence/PersistenceMigrationRegistry.ts
+++ b/src/storage/persistence/PersistenceMigrationRegistry.ts
@@ -1,0 +1,298 @@
+import type {
+    PersistenceBatchOperation,
+    PersistenceDatabase
+} from "./PersistenceDatabase";
+
+const MIGRATION_PROGRESS_KEY = "metadata!migrationProgress";
+const SCHEMA_VERSION_KEY = "metadata!schemaVersion";
+const DEFAULT_CHUNK_SIZE = 256;
+
+type MigrationPhase = "copy" | "cleanup";
+
+interface MigrationProgress {
+    fromVersion: number;
+    toVersion: number;
+    phase: MigrationPhase;
+    cursor?: string;
+}
+
+export interface PersistenceMigrationRecord {
+    key: string;
+    value: string;
+}
+
+export interface PersistenceMigration {
+    fromVersion: number;
+    toVersion: number;
+    transformRecord(
+        record: PersistenceMigrationRecord
+    ): PersistenceMigrationRecord | undefined;
+}
+
+export class PersistenceMigrationRegistry {
+    private readonly migrations = new Map<number, PersistenceMigration>();
+    private readonly chunkSize: number;
+
+    constructor(
+        migrations: readonly PersistenceMigration[] = [],
+        chunkSize = DEFAULT_CHUNK_SIZE
+    ) {
+        if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
+            throw new Error(
+                "Persistence migration chunk size must be positive"
+            );
+        }
+        this.chunkSize = chunkSize;
+        for (const migration of migrations) {
+            if (migration.toVersion !== migration.fromVersion + 1) {
+                throw new Error(
+                    `Persistence migration ${migration.fromVersion} must target the next schema version`
+                );
+            }
+            if (this.migrations.has(migration.fromVersion)) {
+                throw new Error(
+                    `Duplicate persistence migration from schema version ${migration.fromVersion}`
+                );
+            }
+            this.migrations.set(migration.fromVersion, migration);
+        }
+    }
+
+    public async migrate(
+        database: PersistenceDatabase,
+        storedVersion: number,
+        targetVersion: number,
+        partitionNamespace: string
+    ): Promise<void> {
+        let currentVersion = await this.resumePendingMigration(
+            database,
+            storedVersion,
+            partitionNamespace
+        );
+
+        while (currentVersion < targetVersion) {
+            const migration = this.migrations.get(currentVersion);
+            if (!migration) {
+                throw this.unsupportedVersion(
+                    currentVersion,
+                    partitionNamespace
+                );
+            }
+            await this.runMigration(database, migration);
+            currentVersion = migration.toVersion;
+        }
+
+        if (currentVersion !== targetVersion) {
+            throw this.unsupportedVersion(currentVersion, partitionNamespace);
+        }
+    }
+
+    private async resumePendingMigration(
+        database: PersistenceDatabase,
+        storedVersion: number,
+        partitionNamespace: string
+    ): Promise<number> {
+        const encodedProgress = await getOptional(
+            database,
+            MIGRATION_PROGRESS_KEY
+        );
+        if (!encodedProgress) return storedVersion;
+
+        const progress = decodeProgress(encodedProgress);
+        const migration = this.migrations.get(progress.fromVersion);
+        if (
+            !migration ||
+            migration.toVersion !== progress.toVersion ||
+            (progress.phase === "copy" &&
+                storedVersion !== progress.fromVersion) ||
+            (progress.phase === "cleanup" &&
+                storedVersion !== progress.toVersion)
+        ) {
+            throw new Error(
+                `Invalid persistence migration progress for partition ${partitionNamespace}`
+            );
+        }
+
+        await this.runMigration(database, migration, progress);
+        return migration.toVersion;
+    }
+
+    private async runMigration(
+        database: PersistenceDatabase,
+        migration: PersistenceMigration,
+        initialProgress: MigrationProgress = {
+            fromVersion: migration.fromVersion,
+            toVersion: migration.toVersion,
+            phase: "copy"
+        }
+    ): Promise<void> {
+        let progress = initialProgress;
+        while (progress.phase === "copy") {
+            progress = await this.copyChunk(database, migration, progress);
+        }
+        await this.cleanup(database, migration, progress);
+    }
+
+    private async copyChunk(
+        database: PersistenceDatabase,
+        migration: PersistenceMigration,
+        progress: MigrationProgress
+    ): Promise<MigrationProgress> {
+        const sourcePrefix = recordPrefix(migration.fromVersion);
+        const targetPrefix = recordPrefix(migration.toVersion);
+        const records = await readChunk(
+            database,
+            sourcePrefix,
+            progress.cursor,
+            this.chunkSize
+        );
+        const operations: PersistenceBatchOperation[] = [];
+
+        for (const record of records) {
+            const transformed = migration.transformRecord({
+                key: record.key.slice(sourcePrefix.length),
+                value: record.value
+            });
+            if (transformed) {
+                operations.push({
+                    type: "put",
+                    key: `${targetPrefix}${transformed.key}`,
+                    value: transformed.value
+                });
+            }
+        }
+
+        const isFinalChunk = records.length < this.chunkSize;
+        const nextProgress: MigrationProgress = isFinalChunk
+            ? {
+                  fromVersion: migration.fromVersion,
+                  toVersion: migration.toVersion,
+                  phase: "cleanup"
+              }
+            : {
+                  ...progress,
+                  cursor: records.at(-1)!.key
+              };
+
+        if (isFinalChunk) {
+            operations.push({
+                type: "put",
+                key: SCHEMA_VERSION_KEY,
+                value: String(migration.toVersion)
+            });
+        }
+        operations.push({
+            type: "put",
+            key: MIGRATION_PROGRESS_KEY,
+            value: JSON.stringify(nextProgress)
+        });
+        await database.batch(operations);
+        return nextProgress;
+    }
+
+    private async cleanup(
+        database: PersistenceDatabase,
+        migration: PersistenceMigration,
+        initialProgress: MigrationProgress
+    ): Promise<void> {
+        let progress = initialProgress;
+        const sourcePrefix = recordPrefix(migration.fromVersion);
+
+        while (true) {
+            const records = await readChunk(
+                database,
+                sourcePrefix,
+                progress.cursor,
+                this.chunkSize
+            );
+            const isFinalChunk = records.length < this.chunkSize;
+            const operations: PersistenceBatchOperation[] = records.map(
+                (record) => ({
+                    type: "del",
+                    key: record.key
+                })
+            );
+
+            if (isFinalChunk) {
+                operations.push({
+                    type: "del",
+                    key: MIGRATION_PROGRESS_KEY
+                });
+            } else {
+                progress = {
+                    ...progress,
+                    cursor: records.at(-1)!.key
+                };
+                operations.push({
+                    type: "put",
+                    key: MIGRATION_PROGRESS_KEY,
+                    value: JSON.stringify(progress)
+                });
+            }
+            await database.batch(operations);
+            if (isFinalChunk) return;
+        }
+    }
+
+    private unsupportedVersion(
+        version: number,
+        partitionNamespace: string
+    ): Error {
+        return new Error(
+            `Unsupported persistence schema version ${version} for partition ${partitionNamespace}`
+        );
+    }
+}
+
+async function readChunk(
+    database: PersistenceDatabase,
+    prefix: string,
+    cursor: string | undefined,
+    limit: number
+): Promise<PersistenceMigrationRecord[]> {
+    const records: PersistenceMigrationRecord[] = [];
+    for await (const [key, value] of database.iterator({
+        ...(cursor ? { gt: cursor } : { gte: prefix }),
+        lt: `${prefix}\uffff`,
+        limit
+    })) {
+        records.push({ key, value });
+    }
+    return records;
+}
+
+function recordPrefix(version: number): string {
+    return `records!v${version}!`;
+}
+
+function decodeProgress(encoded: string): MigrationProgress {
+    const progress = JSON.parse(encoded) as Partial<MigrationProgress>;
+    if (
+        !Number.isInteger(progress.fromVersion) ||
+        !Number.isInteger(progress.toVersion) ||
+        (progress.phase !== "copy" && progress.phase !== "cleanup") ||
+        (progress.cursor !== undefined && typeof progress.cursor !== "string")
+    ) {
+        throw new Error("Invalid persistence migration progress metadata");
+    }
+    return progress as MigrationProgress;
+}
+
+async function getOptional(
+    database: PersistenceDatabase,
+    key: string
+): Promise<string | undefined> {
+    try {
+        return await database.get(key);
+    } catch (error) {
+        if (
+            typeof error === "object" &&
+            error !== null &&
+            "code" in error &&
+            error.code === "LEVEL_NOT_FOUND"
+        ) {
+            return undefined;
+        }
+        throw error;
+    }
+}

--- a/src/storage/persistence/PersistencePartition.ts
+++ b/src/storage/persistence/PersistencePartition.ts
@@ -1,0 +1,206 @@
+import { ethers } from "ethers";
+
+import { createPersistenceDatabase } from "@platform/persistenceDatabase";
+
+import type {
+    PersistenceDatabase,
+    PersistenceDatabaseHandle
+} from "./PersistenceDatabase";
+import {
+    PersistenceMigrationRegistry,
+    type PersistenceMigration
+} from "./PersistenceMigrationRegistry";
+
+const CURRENT_SCHEMA_VERSION = 1;
+const IDENTITY_KEY = "metadata!identity";
+const SCHEMA_VERSION_KEY = "metadata!schemaVersion";
+const SIGNER_SECRET_KEY = "metadata!signerSecret";
+
+export interface PersistenceOptions {
+    /**
+     * Backend root/name prefix. One persistent runtime owns each channel
+     * partition. Same-machine multi-peer setups must use distinct locations or
+     * disable persistence.
+     */
+    location?: string;
+    flushIntervalMs?: number;
+    maxBatchOperations?: number;
+    reset?: boolean;
+}
+
+export interface PersistencePartitionIdentity {
+    chainId: string;
+    stateChannelManagerAddress: string;
+    stateMachineAddress: string;
+    channelId: string;
+}
+
+export interface OpenPersistencePartitionOptions {
+    identity: PersistencePartitionIdentity;
+    persistence: PersistenceOptions;
+    signerSecret: string;
+    existingPartition: "allow" | "reject";
+    migrations?: readonly PersistenceMigration[];
+}
+
+export interface OpenPersistencePartitionResult {
+    databaseHandle: PersistenceDatabaseHandle;
+    signerSecret: string;
+    namespace: string;
+}
+
+export function getPersistenceNamespace(
+    identity: PersistencePartitionIdentity
+): string {
+    const normalized = normalizeIdentity(identity);
+    return ethers.keccak256(
+        ethers.toUtf8Bytes(
+            [
+                normalized.chainId,
+                normalized.stateChannelManagerAddress,
+                normalized.stateMachineAddress,
+                normalized.channelId
+            ].join(":")
+        )
+    );
+}
+
+export async function openPersistencePartition(
+    options: OpenPersistencePartitionOptions
+): Promise<OpenPersistencePartitionResult> {
+    const identity = normalizeIdentity(options.identity);
+    const namespace = getPersistenceNamespace(identity);
+    let databaseHandle = await createPersistenceDatabase({
+        location: options.persistence.location,
+        namespace
+    });
+
+    try {
+        await databaseHandle.database.open();
+        if (options.persistence.reset) {
+            await databaseHandle.destroy();
+            databaseHandle = await createPersistenceDatabase({
+                location: options.persistence.location,
+                namespace
+            });
+            await databaseHandle.database.open();
+        }
+        const storedIdentity = await getOptional(
+            databaseHandle.database,
+            IDENTITY_KEY
+        );
+        const storedVersion = await getOptional(
+            databaseHandle.database,
+            SCHEMA_VERSION_KEY
+        );
+        const storedSignerSecret = await getOptional(
+            databaseHandle.database,
+            SIGNER_SECRET_KEY
+        );
+        const exists =
+            storedIdentity !== undefined ||
+            storedVersion !== undefined ||
+            storedSignerSecret !== undefined;
+
+        if (exists && options.existingPartition === "reject") {
+            throw new Error(
+                `Persistence partition already exists: ${namespace}`
+            );
+        }
+
+        if (!exists) {
+            // TODO(persistence): encrypt signer secrets with a caller-supplied
+            // key before writing them to backend metadata.
+            await databaseHandle.database.batch([
+                {
+                    type: "put",
+                    key: IDENTITY_KEY,
+                    value: JSON.stringify(identity)
+                },
+                {
+                    type: "put",
+                    key: SCHEMA_VERSION_KEY,
+                    value: String(CURRENT_SCHEMA_VERSION)
+                },
+                {
+                    type: "put",
+                    key: SIGNER_SECRET_KEY,
+                    value: options.signerSecret
+                }
+            ]);
+            return {
+                databaseHandle,
+                signerSecret: options.signerSecret,
+                namespace
+            };
+        }
+
+        if (
+            storedIdentity === undefined ||
+            storedVersion === undefined ||
+            storedSignerSecret === undefined
+        ) {
+            throw new Error(
+                `Incomplete persistence metadata for partition ${namespace}`
+            );
+        }
+        if (storedIdentity !== JSON.stringify(identity)) {
+            throw new Error(
+                `Persistence identity mismatch for partition ${namespace}`
+            );
+        }
+
+        const schemaVersion = Number(storedVersion);
+        if (schemaVersion !== CURRENT_SCHEMA_VERSION) {
+            await new PersistenceMigrationRegistry(options.migrations).migrate(
+                databaseHandle.database,
+                schemaVersion,
+                CURRENT_SCHEMA_VERSION,
+                namespace
+            );
+        }
+
+        return {
+            databaseHandle,
+            signerSecret: storedSignerSecret,
+            namespace
+        };
+    } catch (error) {
+        await databaseHandle.close();
+        throw error;
+    }
+}
+
+function normalizeIdentity(
+    identity: PersistencePartitionIdentity
+): PersistencePartitionIdentity {
+    return {
+        chainId: BigInt(identity.chainId).toString(),
+        stateChannelManagerAddress: ethers
+            .getAddress(identity.stateChannelManagerAddress)
+            .toLowerCase(),
+        stateMachineAddress: ethers
+            .getAddress(identity.stateMachineAddress)
+            .toLowerCase(),
+        channelId: ethers.hexlify(identity.channelId).toLowerCase()
+    };
+}
+
+async function getOptional(
+    database: PersistenceDatabase,
+    key: string
+): Promise<string | undefined> {
+    try {
+        return await database.get(key);
+    } catch (error) {
+        if (
+            typeof error === "object" &&
+            error !== null &&
+            "code" in error &&
+            error.code === "LEVEL_NOT_FOUND"
+        ) {
+            return undefined;
+        }
+        throw error;
+    }
+}

--- a/src/storage/persistence/PersistencePartition.ts
+++ b/src/storage/persistence/PersistencePartition.ts
@@ -25,6 +25,7 @@ export interface PersistenceOptions {
     location?: string;
     flushIntervalMs?: number;
     maxBatchOperations?: number;
+    commitDeadlineMs?: number;
     reset?: boolean;
 }
 

--- a/src/storage/persistence/PersistenceRecordCodec.ts
+++ b/src/storage/persistence/PersistenceRecordCodec.ts
@@ -1,0 +1,66 @@
+export type CollectionId =
+    | "blocks"
+    | "inboundMessages"
+    | "outboundMessages"
+    | "stateSnapshots"
+    | "stateMachineStates"
+    | "participantSetChanges"
+    | "queues"
+    | "disputes"
+    | "disputedForks"
+    | "fraudProofs"
+    | "disputeFraudProofs"
+    | "timeout"
+    | "forceExit"
+    | "forceJoin"
+    | "blockCalldata"
+    | "eventSync"
+    | "runtimeMetadata";
+
+export interface PersistenceValueCodec<TValue> {
+    encode(value: TValue): string;
+    decode(encodedValue: string): TValue;
+}
+
+export class PersistenceRecordCodec {
+    private readonly codecs = new Map<
+        CollectionId,
+        PersistenceValueCodec<unknown>
+    >();
+
+    public register<TValue>(
+        collectionId: CollectionId,
+        codec: PersistenceValueCodec<TValue>
+    ): PersistenceValueCodec<TValue> {
+        if (this.codecs.has(collectionId)) {
+            throw new Error(
+                `Persistence codec already registered for ${collectionId}`
+            );
+        }
+        this.codecs.set(collectionId, codec as PersistenceValueCodec<unknown>);
+        return codec;
+    }
+
+    public encode<TValue>(collectionId: CollectionId, value: TValue): string {
+        return this.get<TValue>(collectionId).encode(value);
+    }
+
+    public decode<TValue>(
+        collectionId: CollectionId,
+        encodedValue: string
+    ): TValue {
+        return this.get<TValue>(collectionId).decode(encodedValue);
+    }
+
+    private get<TValue>(
+        collectionId: CollectionId
+    ): PersistenceValueCodec<TValue> {
+        const codec = this.codecs.get(collectionId);
+        if (!codec) {
+            throw new Error(
+                `Persistence codec is not registered for ${collectionId}`
+            );
+        }
+        return codec as PersistenceValueCodec<TValue>;
+    }
+}

--- a/src/storage/persistence/PersistentCollection.ts
+++ b/src/storage/persistence/PersistentCollection.ts
@@ -1,0 +1,138 @@
+import cloneDeep from "lodash.clonedeep";
+
+import type { CollectionId } from "./PersistenceRecordCodec";
+import type { PersistenceController } from "./PersistenceController";
+
+export type PersistentCollectionUpdate<TValue> = (
+    currentValue: TValue | undefined
+) => TValue | undefined;
+
+export class PersistentCollection<TKey, TValue> {
+    public readonly id: CollectionId;
+    private readonly cache = new Map<TKey, TValue>();
+    private controller?: PersistenceController;
+    private readonly onCacheChanged?: () => void;
+
+    constructor(
+        id: CollectionId,
+        controller?: PersistenceController,
+        onCacheChanged?: () => void
+    ) {
+        this.id = id;
+        this.controller = controller;
+        this.onCacheChanged = onCacheChanged;
+        controller?.register(this);
+    }
+
+    public attach(controller: PersistenceController): void {
+        if (this.controller === controller) return;
+        if (this.controller) {
+            throw new Error(`${this.id} is already attached to a controller`);
+        }
+        this.controller = controller;
+        controller.register(this);
+    }
+
+    public get(key: TKey): TValue | undefined {
+        return this.cache.get(key);
+    }
+
+    public has(key: TKey): boolean {
+        return this.cache.has(key);
+    }
+
+    public entries(): IterableIterator<[TKey, TValue]> {
+        return this.cache.entries();
+    }
+
+    public keys(): IterableIterator<TKey> {
+        return this.cache.keys();
+    }
+
+    public values(): IterableIterator<TValue> {
+        return this.cache.values();
+    }
+
+    public get size(): number {
+        return this.cache.size;
+    }
+
+    public set(key: TKey, value: TValue): TValue {
+        if (!this.controller) {
+            const copiedValue = cloneDeep(value);
+            this.cache.set(key, copiedValue);
+            this.notifyChanged();
+            return cloneDeep(copiedValue);
+        }
+        return this.controller.update(this, key, () =>
+            cloneDeep(value)
+        ) as TValue;
+    }
+
+    public update(
+        key: TKey,
+        updater: PersistentCollectionUpdate<TValue>
+    ): TValue | undefined {
+        if (!this.controller) {
+            const nextValue = updater(cloneDeep(this.cache.get(key)));
+            const committedValue = cloneDeep(nextValue);
+            this.apply(key, committedValue);
+            return cloneDeep(committedValue);
+        }
+        return this.controller.update(this, key, updater);
+    }
+
+    public delete(key: TKey): boolean {
+        if (!this.cache.has(key)) return false;
+        this.update(key, () => undefined);
+        return true;
+    }
+
+    public deleteMany(keys: readonly TKey[]): void {
+        this.takeMany(keys);
+    }
+
+    public takeMany(keys: readonly TKey[]): TValue[] {
+        if (!this.controller) {
+            const values = keys.flatMap((key) => {
+                const value = this.cache.get(key);
+                this.cache.delete(key);
+                return value === undefined ? [] : [cloneDeep(value)];
+            });
+            if (values.length) this.notifyChanged();
+            return values;
+        }
+        return this.controller.deleteMany(this, keys);
+    }
+
+    public clear(): void {
+        if (!this.controller) {
+            if (!this.cache.size) return;
+            this.cache.clear();
+            this.notifyChanged();
+            return;
+        }
+        this.controller.clear(this);
+    }
+
+    public apply(key: TKey, value: TValue | undefined, notify = true): void {
+        if (value === undefined) {
+            this.cache.delete(key);
+        } else {
+            this.cache.set(key, value);
+        }
+        if (notify) this.notifyChanged();
+    }
+
+    public replace(entries: Iterable<[TKey, TValue]>): void {
+        this.cache.clear();
+        for (const [key, value] of entries) {
+            this.cache.set(key, value);
+        }
+        this.notifyChanged();
+    }
+
+    public notifyChanged(): void {
+        this.onCacheChanged?.();
+    }
+}

--- a/src/storage/persistence/browser/createPersistenceDatabase.ts
+++ b/src/storage/persistence/browser/createPersistenceDatabase.ts
@@ -1,0 +1,91 @@
+import { BrowserLevel } from "browser-level";
+
+import type {
+    CreatePersistenceDatabaseOptions,
+    PersistenceDatabaseHandle
+} from "../PersistenceDatabase";
+
+type LockRelease = () => void;
+
+async function acquireLease(name: string): Promise<{
+    release: LockRelease;
+    completion: Promise<void>;
+}> {
+    if (!navigator.locks) {
+        throw new Error("Browser persistence requires the Web Locks API");
+    }
+
+    let settleAcquired!: (acquired: boolean) => void;
+    let release!: LockRelease;
+    const acquired = new Promise<boolean>((resolve) => {
+        settleAcquired = resolve;
+    });
+    const completion = navigator.locks.request(
+        name,
+        { ifAvailable: true },
+        async (lock) => {
+            settleAcquired(lock !== null);
+            if (!lock) return;
+            await new Promise<void>((resolve) => {
+                release = resolve;
+            });
+        }
+    );
+
+    if (!(await acquired)) {
+        await completion;
+        throw new Error(`Persistence partition is already open: ${name}`);
+    }
+    return { release, completion };
+}
+
+export async function createPersistenceDatabase(
+    options: CreatePersistenceDatabaseOptions
+): Promise<PersistenceDatabaseHandle> {
+    const namePrefix = options.location ?? "peer3-state-channels-plus-";
+    const location = `${namePrefix}${options.namespace}`;
+    const lease = await acquireLease(
+        `${namePrefix}${options.namespace}:writer`
+    );
+    const database = new BrowserLevel<string, string>(options.namespace, {
+        prefix: namePrefix,
+        keyEncoding: "utf8",
+        valueEncoding: "utf8"
+    });
+
+    try {
+        await database.open();
+    } catch (error) {
+        lease.release();
+        await lease.completion;
+        throw error;
+    }
+
+    let closed = false;
+    return {
+        database,
+        location,
+        close: async () => {
+            if (closed) return;
+            closed = true;
+            try {
+                await database.close();
+            } finally {
+                lease.release();
+                await lease.completion;
+            }
+        },
+        destroy: async () => {
+            if (!closed) {
+                closed = true;
+                try {
+                    await database.close();
+                } finally {
+                    lease.release();
+                    await lease.completion;
+                }
+            }
+            await BrowserLevel.destroy(options.namespace, namePrefix);
+        }
+    };
+}

--- a/src/storage/persistence/index.ts
+++ b/src/storage/persistence/index.ts
@@ -1,0 +1,6 @@
+export * from "./PersistenceController";
+export * from "./PersistenceDatabase";
+export * from "./PersistenceMigrationRegistry";
+export * from "./PersistenceRecordCodec";
+export * from "./PersistentCollection";
+export * from "./PersistencePartition";

--- a/src/storage/persistence/node/createPersistenceDatabase.ts
+++ b/src/storage/persistence/node/createPersistenceDatabase.ts
@@ -1,0 +1,72 @@
+import { mkdir, chmod } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import type {
+    CreatePersistenceDatabaseOptions,
+    PersistenceDatabaseHandle
+} from "../PersistenceDatabase";
+
+export async function createPersistenceDatabase(
+    options: CreatePersistenceDatabaseOptions
+): Promise<PersistenceDatabaseHandle> {
+    const root = options.location ?? getDefaultRoot();
+    const location = path.join(root, options.namespace);
+    await mkdir(root, { recursive: true, mode: 0o700 });
+    await chmod(root, 0o700);
+
+    let ClassicLevel: typeof import("classic-level").ClassicLevel;
+    try {
+        ({ ClassicLevel } = await import("classic-level"));
+    } catch (error) {
+        throw new Error(
+            `Node persistence requires the optional classic-level package: ${String(error)}`
+        );
+    }
+
+    const database = new ClassicLevel<string, string>(location, {
+        keyEncoding: "utf8",
+        valueEncoding: "utf8"
+    });
+    let closed = false;
+    return {
+        database,
+        location,
+        close: async () => {
+            if (closed) return;
+            closed = true;
+            await database.close();
+        },
+        destroy: async () => {
+            if (!closed) {
+                closed = true;
+                await database.close();
+            }
+            await ClassicLevel.destroy(location);
+        }
+    };
+}
+
+function getDefaultRoot(): string {
+    if (process.platform === "darwin") {
+        return path.join(
+            homedir(),
+            "Library",
+            "Application Support",
+            "peer3",
+            "state-channels-plus"
+        );
+    }
+    if (process.platform === "win32" && process.env.LOCALAPPDATA) {
+        return path.join(
+            process.env.LOCALAPPDATA,
+            "peer3",
+            "state-channels-plus"
+        );
+    }
+    return path.join(
+        process.env.XDG_DATA_HOME ?? path.join(homedir(), ".local", "share"),
+        "peer3",
+        "state-channels-plus"
+    );
+}

--- a/src/storage/persistence/storageCodecs.ts
+++ b/src/storage/persistence/storageCodecs.ts
@@ -1,0 +1,389 @@
+import { ethers } from "ethers";
+import type { MessageBlockStruct } from "@typechain-types/contracts/V1/types/DataTypes";
+import type {
+    DisputeConfirmationStruct,
+    TimeoutStruct
+} from "@typechain-types/contracts/V1/types/DisputeTypes";
+import type {
+    DisputeFraudProofStruct,
+    FraudProofStruct
+} from "@typechain-types/contracts/V1/types/ProofTypes";
+
+import { Block } from "@/models";
+import StateSnapshot from "@/models/StateSnapshot";
+import type {
+    BlockCalldata,
+    BlockHeight,
+    Bytes,
+    ForkId,
+    Hash
+} from "@/types/types";
+import { Codec, Type } from "@/utils";
+
+import type { QueuedBlockEntry } from "../QueueStorage";
+import {
+    PersistenceRecordCodec,
+    type PersistenceValueCodec
+} from "./PersistenceRecordCodec";
+
+const abiCoder = ethers.AbiCoder.defaultAbiCoder();
+
+export interface PersistedBlockRecord {
+    block: Block;
+    coordinates: {
+        forkId: ForkId;
+        height: BlockHeight;
+    };
+    advancesTip: boolean;
+}
+
+export interface PersistedMessageBlockRecord {
+    block: MessageBlockStruct;
+    advancesTip: boolean;
+}
+
+export interface RuntimeMetadata {
+    activeForkId?: ForkId;
+    headHash?: Hash;
+    snapshotHash?: Hash;
+    stateHash?: Hash;
+}
+
+function blockCodec(): PersistenceValueCodec<PersistedBlockRecord> {
+    return {
+        encode: (record) => {
+            const encodedConfirmation = Codec.encode(
+                record.block.blockConfirmationStruct,
+                Type.BlockConfirmation
+            );
+            return abiCoder.encode(
+                ["bytes", "bool", "uint256", "bytes32", "uint256", "bool"],
+                [
+                    encodedConfirmation,
+                    record.block.onChainTimestamp !== undefined,
+                    record.block.onChainTimestamp ?? 0,
+                    record.coordinates.forkId,
+                    record.coordinates.height,
+                    record.advancesTip
+                ]
+            );
+        },
+        decode: (encodedValue) => {
+            const [
+                encodedConfirmation,
+                hasOnChainTimestamp,
+                onChainTimestamp,
+                forkId,
+                height,
+                advancesTip
+            ] = abiCoder.decode(
+                ["bytes", "bool", "uint256", "bytes32", "uint256", "bool"],
+                encodedValue
+            );
+            const block = Block.fromBlockConfirmation(
+                Codec.decode(encodedConfirmation, Type.BlockConfirmation),
+                hasOnChainTimestamp ? Number(onChainTimestamp) : undefined
+            );
+            return {
+                block,
+                coordinates: {
+                    forkId: forkId as ForkId,
+                    height: Number(height)
+                },
+                advancesTip
+            };
+        }
+    };
+}
+
+function messageCodec(): PersistenceValueCodec<PersistedMessageBlockRecord> {
+    return {
+        encode: (record) =>
+            abiCoder.encode(
+                ["bytes", "bool"],
+                [
+                    Codec.encode(record.block, Type.MessageBlock),
+                    record.advancesTip
+                ]
+            ),
+        decode: (encodedValue) => {
+            const [encodedBlock, advancesTip] = abiCoder.decode(
+                ["bytes", "bool"],
+                encodedValue
+            );
+            return {
+                block: Codec.decode(encodedBlock, Type.MessageBlock),
+                advancesTip
+            };
+        }
+    };
+}
+
+function queueCodec(): PersistenceValueCodec<QueuedBlockEntry> {
+    return {
+        encode: (entry) =>
+            abiCoder.encode(
+                [
+                    "bytes",
+                    "uint256",
+                    "address[]",
+                    "tuple(bytes signature,address[] peers)[]",
+                    "bool",
+                    "bool",
+                    "uint256"
+                ],
+                [
+                    Codec.encode(
+                        entry.block.blockConfirmationStruct,
+                        Type.BlockConfirmation
+                    ),
+                    entry.firstSeenAt,
+                    [...entry.sourcePeers],
+                    [...entry.signatureSources].map(([signature, peers]) => ({
+                        signature,
+                        peers: [...peers]
+                    })),
+                    entry.overflowedSources ?? false,
+                    entry.block.onChainTimestamp !== undefined,
+                    entry.block.onChainTimestamp ?? 0
+                ]
+            ),
+        decode: (encodedValue) => {
+            const [
+                encodedConfirmation,
+                firstSeenAt,
+                sourcePeers,
+                signatureSources,
+                overflowedSources,
+                hasOnChainTimestamp,
+                onChainTimestamp
+            ] = abiCoder.decode(
+                [
+                    "bytes",
+                    "uint256",
+                    "address[]",
+                    "tuple(bytes signature,address[] peers)[]",
+                    "bool",
+                    "bool",
+                    "uint256"
+                ],
+                encodedValue
+            );
+            return {
+                block: Block.fromBlockConfirmation(
+                    Codec.decode(encodedConfirmation, Type.BlockConfirmation),
+                    hasOnChainTimestamp ? Number(onChainTimestamp) : undefined
+                ),
+                firstSeenAt: Number(firstSeenAt),
+                sourcePeers: new Set(sourcePeers),
+                signatureSources: new Map(
+                    signatureSources.map(
+                        (entry: { signature: string; peers: string[] }) => [
+                            entry.signature,
+                            new Set(entry.peers)
+                        ]
+                    )
+                ),
+                overflowedSources
+            };
+        }
+    };
+}
+
+function fraudProofCodec(): PersistenceValueCodec<FraudProofStruct> {
+    return {
+        encode: (proof) =>
+            abiCoder.encode(
+                ["uint256", "address", "bytes"],
+                [proof.proofType, proof.participant, proof.encodedProof]
+            ),
+        decode: (encodedValue) => {
+            const [proofType, participant, encodedProof] = abiCoder.decode(
+                ["uint256", "address", "bytes"],
+                encodedValue
+            );
+            return { proofType, participant, encodedProof };
+        }
+    };
+}
+
+function disputeFraudProofCodec(): PersistenceValueCodec<DisputeFraudProofStruct> {
+    return {
+        encode: (proof) =>
+            abiCoder.encode(
+                ["uint256", "address", "bytes", "bytes"],
+                [
+                    proof.proofType,
+                    proof.participant,
+                    Codec.encode(proof.dispute, Type.Dispute),
+                    proof.encodedProof
+                ]
+            ),
+        decode: (encodedValue) => {
+            const [proofType, participant, encodedDispute, encodedProof] =
+                abiCoder.decode(
+                    ["uint256", "address", "bytes", "bytes"],
+                    encodedValue
+                );
+            return {
+                proofType,
+                participant,
+                dispute: Codec.decode(encodedDispute, Type.Dispute),
+                encodedProof
+            };
+        }
+    };
+}
+
+function blockCalldataCodec(): PersistenceValueCodec<BlockCalldata> {
+    return {
+        encode: (calldata) =>
+            abiCoder.encode(
+                ["bytes", "uint256"],
+                [
+                    Codec.encode(calldata.signedBlock, Type.SignedBlock),
+                    calldata.onChainTimestamp
+                ]
+            ),
+        decode: (encodedValue) => {
+            const [encodedSignedBlock, onChainTimestamp] = abiCoder.decode(
+                ["bytes", "uint256"],
+                encodedValue
+            );
+            return {
+                signedBlock: Codec.decode(encodedSignedBlock, Type.SignedBlock),
+                onChainTimestamp: Number(onChainTimestamp)
+            };
+        }
+    };
+}
+
+function runtimeMetadataCodec(): PersistenceValueCodec<RuntimeMetadata> {
+    return {
+        encode: (value) =>
+            abiCoder.encode(
+                [
+                    "bool",
+                    "bytes32",
+                    "bool",
+                    "bytes32",
+                    "bool",
+                    "bytes32",
+                    "bool",
+                    "bytes32"
+                ],
+                [
+                    value.activeForkId !== undefined,
+                    value.activeForkId ?? ethers.ZeroHash,
+                    value.headHash !== undefined,
+                    value.headHash ?? ethers.ZeroHash,
+                    value.snapshotHash !== undefined,
+                    value.snapshotHash ?? ethers.ZeroHash,
+                    value.stateHash !== undefined,
+                    value.stateHash ?? ethers.ZeroHash
+                ]
+            ),
+        decode: (encodedValue) => {
+            const [
+                hasActiveForkId,
+                activeForkId,
+                hasHeadHash,
+                headHash,
+                hasSnapshotHash,
+                snapshotHash,
+                hasStateHash,
+                stateHash
+            ] = abiCoder.decode(
+                [
+                    "bool",
+                    "bytes32",
+                    "bool",
+                    "bytes32",
+                    "bool",
+                    "bytes32",
+                    "bool",
+                    "bytes32"
+                ],
+                encodedValue
+            );
+            return {
+                activeForkId: hasActiveForkId
+                    ? (activeForkId as ForkId)
+                    : undefined,
+                headHash: hasHeadHash ? (headHash as Hash) : undefined,
+                snapshotHash: hasSnapshotHash
+                    ? (snapshotHash as Hash)
+                    : undefined,
+                stateHash: hasStateHash ? (stateHash as Hash) : undefined
+            };
+        }
+    };
+}
+
+export function createStorageRecordCodec(): PersistenceRecordCodec {
+    const registry = new PersistenceRecordCodec();
+    registry.register("blocks", blockCodec());
+    registry.register("inboundMessages", messageCodec());
+    registry.register("outboundMessages", messageCodec());
+    registry.register<StateSnapshot>("stateSnapshots", {
+        encode: (snapshot) => ethers.hexlify(snapshot.encode()),
+        decode: (encodedValue) => StateSnapshot.decode(encodedValue)
+    });
+    registry.register<Bytes>("stateMachineStates", {
+        encode: (encodedState) => ethers.hexlify(encodedState),
+        decode: (encodedValue) => encodedValue as Bytes
+    });
+    registry.register<Set<BlockHeight>>("participantSetChanges", {
+        encode: (heights) =>
+            abiCoder.encode(
+                ["uint256[]"],
+                [[...heights].sort((a, b) => a - b)]
+            ),
+        decode: (encodedValue) => {
+            const [heights] = abiCoder.decode(["uint256[]"], encodedValue);
+            return new Set(
+                (heights as bigint[]).map((height) => Number(height))
+            );
+        }
+    });
+    registry.register("queues", queueCodec());
+    registry.register<DisputeConfirmationStruct>("disputes", {
+        encode: (confirmation) =>
+            ethers.hexlify(
+                Codec.encode(confirmation, Type.DisputeConfirmation)
+            ),
+        decode: (encodedValue) =>
+            Codec.decode(encodedValue, Type.DisputeConfirmation)
+    });
+    registry.register<boolean>("disputedForks", {
+        encode: (value) => abiCoder.encode(["bool"], [value]),
+        decode: (encodedValue) => abiCoder.decode(["bool"], encodedValue)[0]
+    });
+    registry.register("fraudProofs", fraudProofCodec());
+    registry.register("disputeFraudProofs", disputeFraudProofCodec());
+    registry.register<TimeoutStruct>("timeout", {
+        encode: (timeout) =>
+            ethers.hexlify(Codec.encode(timeout, Type.Timeout)),
+        decode: (encodedValue) => Codec.decode(encodedValue, Type.Timeout)
+    });
+    registry.register<boolean>("forceExit", {
+        encode: (value) => abiCoder.encode(["bool"], [value]),
+        decode: (encodedValue) => abiCoder.decode(["bool"], encodedValue)[0]
+    });
+    registry.register<number>("forceJoin", {
+        encode: (value) => abiCoder.encode(["int256"], [value]),
+        decode: (encodedValue) =>
+            Number(abiCoder.decode(["int256"], encodedValue)[0])
+    });
+    registry.register("blockCalldata", blockCalldataCodec());
+    registry.register<number>("eventSync", {
+        encode: (value) => abiCoder.encode(["uint256"], [value]),
+        decode: (encodedValue) =>
+            Number(abiCoder.decode(["uint256"], encodedValue)[0])
+    });
+    registry.register<RuntimeMetadata>(
+        "runtimeMetadata",
+        runtimeMetadataCodec()
+    );
+    return registry;
+}

--- a/src/storage/persistence/validatePersistedRuntimeState.ts
+++ b/src/storage/persistence/validatePersistedRuntimeState.ts
@@ -1,0 +1,158 @@
+import { ethers } from "ethers";
+
+import type { Block } from "@/models";
+import type Storage from "@/storage";
+import type { Bytes, ChannelId } from "@/types/types";
+
+import type { RuntimeMetadata } from "./storageCodecs";
+
+export interface PersistedRuntimeState {
+    metadata: Required<
+        Pick<RuntimeMetadata, "activeForkId" | "snapshotHash" | "stateHash">
+    > &
+        Pick<RuntimeMetadata, "headHash">;
+    encodedState: Bytes;
+}
+
+export function validatePersistedRuntimeState(
+    storage: Storage,
+    channelId: ChannelId
+): PersistedRuntimeState | undefined {
+    try {
+        return validateUnchecked(storage, channelId);
+    } catch (error) {
+        const normalized =
+            error instanceof Error ? error : new Error(String(error));
+        const location = storage.getPersistenceLocation();
+        if (!location || normalized.message.includes("(persistence:")) {
+            throw normalized;
+        }
+        throw new Error(`${normalized.message} (persistence: ${location})`);
+    }
+}
+
+function validateUnchecked(
+    storage: Storage,
+    channelId: ChannelId
+): PersistedRuntimeState | undefined {
+    const metadata = storage.getRuntimeMetadata();
+    if (!metadata) return undefined;
+
+    if (
+        !metadata.activeForkId ||
+        !metadata.snapshotHash ||
+        !metadata.stateHash
+    ) {
+        throw new Error("Persisted runtime metadata is incomplete");
+    }
+    const completeMetadata = {
+        ...metadata,
+        activeForkId: metadata.activeForkId,
+        snapshotHash: metadata.snapshotHash,
+        stateHash: metadata.stateHash
+    };
+    const snapshot = storage.stateSnapshots.getStateSnapshotByHash(
+        completeMetadata.snapshotHash
+    );
+    if (!snapshot) {
+        throw new Error(
+            `Persisted runtime metadata references missing snapshot ${completeMetadata.snapshotHash}`
+        );
+    }
+    const encodedState = storage.stateMachineStates.getStateMachineState(
+        completeMetadata.stateHash
+    );
+    if (!encodedState) {
+        throw new Error(
+            `Persisted runtime metadata references missing state ${completeMetadata.stateHash}`
+        );
+    }
+    if (snapshot.forkID !== completeMetadata.activeForkId) {
+        throw new Error(
+            "Persisted runtime metadata snapshot belongs to another fork"
+        );
+    }
+    if (
+        completeMetadata.headHash &&
+        !storage.blocks.getBlock(completeMetadata.headHash)
+    ) {
+        throw new Error(
+            `Persisted runtime metadata references missing head ${completeMetadata.headHash}`
+        );
+    }
+    if (completeMetadata.headHash) {
+        const head = storage.blocks.getBlock(completeMetadata.headHash)!;
+        if (head.forkId !== completeMetadata.activeForkId) {
+            throw new Error(
+                "Persisted runtime metadata head belongs to another fork"
+            );
+        }
+        if (
+            ethers.hexlify(head.stateSnapshotHash) !==
+            ethers.hexlify(completeMetadata.snapshotHash)
+        ) {
+            throw new Error(
+                "Persisted runtime metadata head and snapshot disagree"
+            );
+        }
+        if (
+            ethers.hexlify(snapshot.stateMachineStateHash) !==
+            ethers.hexlify(completeMetadata.stateHash)
+        ) {
+            throw new Error(
+                "Persisted runtime metadata snapshot and state disagree"
+            );
+        }
+        let previousBlock: Block | undefined;
+        for (let height = 0; height <= head.height; height++) {
+            const block = storage.blocks.getBlock(
+                completeMetadata.activeForkId,
+                height
+            );
+            if (!block) {
+                throw new Error(
+                    `Persisted canonical block missing at height ${height}`
+                );
+            }
+            if (
+                previousBlock &&
+                ethers.hexlify(block.previousBlockHash) !==
+                    ethers.hexlify(previousBlock.hash)
+            ) {
+                throw new Error(
+                    `Persisted canonical block linkage is broken at height ${height}`
+                );
+            }
+            const blockSnapshot = storage.stateSnapshots.getStateSnapshotByHash(
+                block.stateSnapshotHash
+            );
+            if (!blockSnapshot) {
+                throw new Error(
+                    `Persisted block ${block.hash} references a missing snapshot`
+                );
+            }
+            if (
+                !storage.stateMachineStates.getStateMachineState(
+                    blockSnapshot.stateMachineStateHash
+                )
+            ) {
+                throw new Error(
+                    `Persisted snapshot ${blockSnapshot.hash} references a missing state`
+                );
+            }
+            previousBlock = block;
+        }
+    }
+    for (const entry of storage.queues.getEntries()) {
+        if (
+            String(entry.block.channelId).toLowerCase() !==
+            String(channelId).toLowerCase()
+        ) {
+            throw new Error(
+                `Persisted queue entry ${entry.block.hash} belongs to another channel`
+            );
+        }
+    }
+
+    return { metadata: completeMetadata, encodedState };
+}

--- a/src/utils/Codec.ts
+++ b/src/utils/Codec.ts
@@ -65,13 +65,15 @@ import {
     MessageBlockEthersType,
     BalanceEthersType,
     SignedBlockEthersType,
-    StateProofEthersType
+    StateProofEthersType,
+    TimeoutEthersType
 } from "@/types";
 import {
     DisputeStruct,
     DisputeConfirmationStruct,
     DisputeAuditingDataStruct,
-    StateProofStruct
+    StateProofStruct,
+    TimeoutStruct
 } from "@typechain-types/contracts/V1/types/DisputeTypes";
 import { Bytes, Timestamp } from "@/types/types";
 import { DisputeFraudProofType, FraudProofType } from "@/types/sol-enums";
@@ -145,7 +147,8 @@ type StructType =
     | BalanceStruct
     | SignedBlockStruct
     | StateProofStruct
-    | SyncPayload;
+    | SyncPayload
+    | TimeoutStruct;
 
 // Enum for better autocomplete and type safety
 export enum Type {
@@ -169,7 +172,8 @@ export enum Type {
     Balance,
     SignedBlock,
     StateProof,
-    SyncPayload
+    SyncPayload,
+    Timeout
 }
 
 export class Codec {
@@ -200,6 +204,7 @@ export class Codec {
         [Type.SignedBlock, SignedBlockEthersType],
         [Type.StateProof, StateProofEthersType],
         [Type.SyncPayload, SyncPayloadEthersType],
+        [Type.Timeout, TimeoutEthersType],
         // Fraud proofs
         [FraudProofType.BlockDoubleSign, BlockDoubleSignProofEthersType],
         [
@@ -413,6 +418,7 @@ export class Codec {
         encoded: Bytes,
         type: Type.StateProof
     ): StateProofStruct;
+    public static decode(encoded: Bytes, type: Type.Timeout): TimeoutStruct;
     public static decode(
         encoded: Bytes,
         type: DisputeFraudProofType.DisputeInvalidBlockStructure

--- a/src/utils/DeepCopyProxy.ts
+++ b/src/utils/DeepCopyProxy.ts
@@ -1,6 +1,9 @@
 import cloneDeep from "lodash.clonedeep";
 
-export function deepCopyProxy<T extends object>(original: T): T {
+export function deepCopyProxy<T extends object>(
+    original: T,
+    options?: { preserveArgumentsFor?: ReadonlySet<PropertyKey> }
+): T {
     return new Proxy(original, {
         get(target, prop) {
             const originalValue = Reflect.get(target, prop);
@@ -9,7 +12,9 @@ export function deepCopyProxy<T extends object>(original: T): T {
             if (typeof originalValue === "function") {
                 return function (...args: any[]) {
                     // Deep copy arguments
-                    const copiedArgs = args.map(cloneDeep);
+                    const copiedArgs = options?.preserveArgumentsFor?.has(prop)
+                        ? args
+                        : args.map(cloneDeep);
 
                     // Call original method
                     const result = originalValue.apply(target, copiedArgs);
@@ -21,6 +26,10 @@ export function deepCopyProxy<T extends object>(original: T): T {
                         typeof result.next === "function"
                     ) {
                         return result;
+                    }
+
+                    if (result instanceof Promise) {
+                        return result.then((value) => cloneDeep(value));
                     }
 
                     // Deep copy other results

--- a/test/browser/p2pWebRTCAppWorker.js
+++ b/test/browser/p2pWebRTCAppWorker.js
@@ -69,6 +69,7 @@ self.onmessage = async (event) => {
             {
                 peerId,
                 signerSecret,
+                persistence: false,
                 config: {
                     PROVIDER_URL: providerUrl,
                     // Inline host in this worker realm — no nested SDK worker.

--- a/test/browser/p2pWebRTCE2E.js
+++ b/test/browser/p2pWebRTCE2E.js
@@ -211,6 +211,7 @@ async function setupPeer(
         deployLocalStateMachine,
         {
             peerId,
+            persistence: false,
             config: {
                 PROVIDER_URL: providerUrl,
                 RUN_SDK_IN_THREAD: true,

--- a/test/browser/persistence-restart.html
+++ b/test/browser/persistence-restart.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+    <body>
+        <script type="module" src="./persistenceRestart.js"></script>
+    </body>
+</html>

--- a/test/browser/persistenceRestart.js
+++ b/test/browser/persistenceRestart.js
@@ -1,0 +1,234 @@
+import { Storage } from "../../src/storage/Storage.ts";
+import { openPersistencePartition } from "../../src/storage/persistence/PersistencePartition.ts";
+
+function deleteDatabase(name) {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.deleteDatabase(name);
+        request.onsuccess = () => resolve();
+        request.onerror = () =>
+            reject(request.error ?? new Error(`Failed to delete ${name}`));
+        request.onblocked = () =>
+            reject(new Error(`Deletion blocked for ${name}`));
+    });
+}
+
+globalThis.runPersistenceRestartBrowserSmoke = async () => {
+    const prefix = `peer3-persistence-test-${crypto.randomUUID()}-`;
+    const identity = {
+        chainId: "31337",
+        stateChannelManagerAddress:
+            "0x1000000000000000000000000000000000000001",
+        stateMachineAddress: "0x2000000000000000000000000000000000000002",
+        channelId:
+            "0x3000000000000000000000000000000000000000000000000000000000000003"
+    };
+    const originalSigner =
+        "0x4000000000000000000000000000000000000000000000000000000000000004";
+    let openHandle;
+    let databaseName;
+
+    try {
+        const first = await openPersistencePartition({
+            identity,
+            persistence: { location: prefix },
+            signerSecret: originalSigner,
+            existingPartition: "allow"
+        });
+        openHandle = first.databaseHandle;
+        databaseName = `${prefix}${first.namespace}`;
+
+        let leaseRejected = false;
+        try {
+            await openPersistencePartition({
+                identity,
+                persistence: { location: prefix },
+                signerSecret:
+                    "0x5000000000000000000000000000000000000000000000000000000000000005",
+                existingPartition: "allow"
+            });
+        } catch {
+            leaseRejected = true;
+        }
+        await openHandle.close();
+        openHandle = undefined;
+
+        const second = await openPersistencePartition({
+            identity,
+            persistence: { location: prefix },
+            signerSecret:
+                "0x6000000000000000000000000000000000000000000000000000000000000006",
+            existingPartition: "allow"
+        });
+        openHandle = second.databaseHandle;
+        const firstStorage = new Storage(undefined, {
+            flushIntervalMs: 60_000
+        });
+        await firstStorage.bind(openHandle);
+        openHandle = undefined;
+        for (let height = 1; height <= 10; height++) {
+            firstStorage.forceJoin.setJoinSubmissionBlockHeight(height);
+        }
+        await firstStorage.flush();
+        await firstStorage.close();
+
+        const third = await openPersistencePartition({
+            identity,
+            persistence: { location: prefix },
+            signerSecret:
+                "0x7000000000000000000000000000000000000000000000000000000000000007",
+            existingPartition: "allow"
+        });
+        openHandle = third.databaseHandle;
+        const secondStorage = new Storage(undefined, {
+            flushIntervalMs: 20
+        });
+        await secondStorage.bind(openHandle);
+        openHandle = undefined;
+        const explicitBatchRecovered =
+            secondStorage.forceJoin.getJoinSubmissionBlockHeight() === 10;
+        secondStorage.forceExit.setForceExit(true);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        const automaticFlushPersisted =
+            (await third.databaseHandle.database.get(
+                "records!v1!forceExit!value"
+            )) !== undefined;
+        await secondStorage.close();
+
+        const fourth = await openPersistencePartition({
+            identity,
+            persistence: { location: prefix },
+            signerSecret:
+                "0x8000000000000000000000000000000000000000000000000000000000000008",
+            existingPartition: "allow"
+        });
+        openHandle = fourth.databaseHandle;
+        const recoveredStorage = new Storage();
+        await recoveredStorage.bind(openHandle);
+        openHandle = undefined;
+        const forceExitRecovered = recoveredStorage.forceExit.getForceExit();
+        await recoveredStorage.close();
+
+        return {
+            leaseRejected,
+            signerRecovered: third.signerSecret === originalSigner,
+            explicitBatchRecovered,
+            automaticFlushPersisted,
+            forceExitRecovered
+        };
+    } finally {
+        await openHandle?.close();
+        if (databaseName) await deleteDatabase(databaseName);
+    }
+};
+
+globalThis.runPersistenceBrowserBenchmark = async () => {
+    const prefix = `peer3-persistence-benchmark-${crypto.randomUUID()}-`;
+    const identity = {
+        chainId: "31337",
+        stateChannelManagerAddress:
+            "0x1000000000000000000000000000000000000001",
+        stateMachineAddress: "0x2000000000000000000000000000000000000002",
+        channelId:
+            "0x9000000000000000000000000000000000000000000000000000000000000009"
+    };
+    const signerSecret =
+        "0xa00000000000000000000000000000000000000000000000000000000000000a";
+    const partition = await openPersistencePartition({
+        identity,
+        persistence: { location: prefix },
+        signerSecret,
+        existingPartition: "allow"
+    });
+    const databaseName = `${prefix}${partition.namespace}`;
+    const database = partition.databaseHandle.database;
+    const originalBatch = database.batch.bind(database);
+    let batchCalls = 0;
+    let submittedOperations = 0;
+    database.batch = async (operations) => {
+        batchCalls += 1;
+        submittedOperations += operations.length;
+        await originalBatch(operations);
+    };
+    const storage = new Storage(undefined, {
+        flushIntervalMs: 60_000,
+        maxBatchOperations: Number.MAX_SAFE_INTEGER
+    });
+    await storage.bind(partition.databaseHandle);
+    const samples = [];
+
+    try {
+        for (const mode of ["database-first", "write-behind"]) {
+            for (const workload of ["distinct", "repeated"]) {
+                for (const writes of [10, 100, 1000]) {
+                    for (let run = -5; run < 30; run++) {
+                        const batchCallsBefore = batchCalls;
+                        const operationsBefore = submittedOperations;
+                        const mutationStartedAt = performance.now();
+                        if (mode === "database-first") {
+                            for (let index = 0; index < writes; index++) {
+                                const key =
+                                    workload === "repeated"
+                                        ? "value"
+                                        : `value-${index}`;
+                                await database.batch([
+                                    {
+                                        type: "put",
+                                        key: `benchmark!${key}`,
+                                        value: `0x${index
+                                            .toString(16)
+                                            .padStart(64, "0")}`
+                                    }
+                                ]);
+                            }
+                        } else if (workload === "repeated") {
+                            for (let index = 0; index < writes; index++) {
+                                storage.forceJoin.setJoinSubmissionBlockHeight(
+                                    index
+                                );
+                            }
+                        } else {
+                            for (let index = 0; index < writes; index++) {
+                                const channelId = `0x${index
+                                    .toString(16)
+                                    .padStart(64, "0")}`;
+                                storage.eventSync.storeLatestProcessedBlock(
+                                    channelId,
+                                    index
+                                );
+                            }
+                        }
+                        const mutationCallMs =
+                            performance.now() - mutationStartedAt;
+                        const flushStartedAt = performance.now();
+                        if (mode === "write-behind") await storage.flush();
+                        const flushMs = performance.now() - flushStartedAt;
+                        if (run >= 0) {
+                            samples.push({
+                                mode,
+                                workload,
+                                writes,
+                                mutationCallMs,
+                                flushMs,
+                                totalMs: mutationCallMs + flushMs,
+                                batchCalls: batchCalls - batchCallsBefore,
+                                submittedOperations:
+                                    submittedOperations - operationsBefore
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        return {
+            environment: {
+                userAgent: navigator.userAgent,
+                warmups: 5,
+                measuredRuns: 30
+            },
+            samples
+        };
+    } finally {
+        await storage.close();
+        await deleteDatabase(databaseName);
+    }
+};

--- a/test/browser/run-p2p-webrtc-e2e.mjs
+++ b/test/browser/run-p2p-webrtc-e2e.mjs
@@ -83,6 +83,10 @@ const platformAliases = {
         projectRoot,
         "src/evm/p2pRuntime/browser/P2pRuntimeWorkerRuntime.ts"
     ),
+    "@platform/persistenceDatabase": path.join(
+        projectRoot,
+        "src/storage/persistence/browser/createPersistenceDatabase.ts"
+    ),
     "@": path.join(projectRoot, "src"),
     "@test": path.join(projectRoot, "test"),
     "@typechain-types": path.join(projectRoot, "typechain-types"),
@@ -227,10 +231,26 @@ try {
             "runP2pWebRTCMainThreadE2E",
             "p2p WebRTC main-thread e2e"
         );
-        assert.equal(mainThread.bridgePortA, true, "peer A must surface a bridge port");
-        assert.equal(mainThread.bridgePortB, true, "peer B must surface a bridge port");
-        assert.equal(mainThread.connectedAtoB, true, "peer A must connect to peer B");
-        assert.equal(mainThread.connectedBtoA, true, "peer B must connect to peer A");
+        assert.equal(
+            mainThread.bridgePortA,
+            true,
+            "peer A must surface a bridge port"
+        );
+        assert.equal(
+            mainThread.bridgePortB,
+            true,
+            "peer B must surface a bridge port"
+        );
+        assert.equal(
+            mainThread.connectedAtoB,
+            true,
+            "peer A must connect to peer B"
+        );
+        assert.equal(
+            mainThread.connectedBtoA,
+            true,
+            "peer B must connect to peer A"
+        );
         assert.ok(
             mainThread.rtcConnected >= 1,
             `main-thread: expected >=1 main-thread WebRTC connection, got ${mainThread.rtcConnected}`
@@ -246,8 +266,16 @@ try {
             bubbleUp.bridgesInstalled >= 2,
             `bubble-up: expected 2 bubbled-up bridges installed, got ${bubbleUp.bridgesInstalled}`
         );
-        assert.equal(bubbleUp.connectedAtoB, true, "bubble-up: peer A must connect to peer B");
-        assert.equal(bubbleUp.connectedBtoA, true, "bubble-up: peer B must connect to peer A");
+        assert.equal(
+            bubbleUp.connectedAtoB,
+            true,
+            "bubble-up: peer A must connect to peer B"
+        );
+        assert.equal(
+            bubbleUp.connectedBtoA,
+            true,
+            "bubble-up: peer B must connect to peer A"
+        );
         assert.ok(
             bubbleUp.rtcConnected >= 1,
             `bubble-up: expected >=1 main-thread WebRTC connection, got ${bubbleUp.rtcConnected}`

--- a/test/browser/run-persistence-restart.mjs
+++ b/test/browser/run-persistence-restart.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const browserTestDir = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(browserTestDir, "../..");
+
+const [{ createServer }, { chromium }] = await Promise.all([
+    import("vite"),
+    import("playwright")
+]);
+
+const server = await createServer({
+    configFile: false,
+    root: projectRoot,
+    resolve: {
+        alias: {
+            "@platform/contractExecutorWorkerRuntime": path.join(
+                projectRoot,
+                "src/evm/contractExecutor/browser/ContractExecutorWorkerRuntime.ts"
+            ),
+            "@platform/persistenceDatabase": path.join(
+                projectRoot,
+                "src/storage/persistence/browser/createPersistenceDatabase.ts"
+            ),
+            "@platform/createLogger": path.join(
+                projectRoot,
+                "src/utils/logging/browser/createLogger.ts"
+            ),
+            "@platform/DeployUtils": path.join(
+                projectRoot,
+                "src/utils/browser/DeployUtils.ts"
+            ),
+            "@platform/LocalDiscoveryServer": path.join(
+                projectRoot,
+                "src/utils/browser/LocalDiscoveryServer.ts"
+            ),
+            "@platform/precompileModuleLoader": path.join(
+                projectRoot,
+                "src/evm/browser/precompileModuleLoader.ts"
+            ),
+            "@platform/moduleLoader": path.join(
+                projectRoot,
+                "src/utils/moduleLoader/browser/importModuleFromManifest.ts"
+            ),
+            "@platform/p2pRuntimeChannel": path.join(
+                projectRoot,
+                "src/evm/p2pRuntime/browser/P2pRuntimeChannel.ts"
+            ),
+            "@platform/p2pRuntimeWorkerRuntime": path.join(
+                projectRoot,
+                "src/evm/p2pRuntime/browser/P2pRuntimeWorkerRuntime.ts"
+            ),
+            "@": path.join(projectRoot, "src"),
+            "@test": path.join(projectRoot, "test"),
+            "@typechain-types": path.join(projectRoot, "typechain-types")
+        }
+    },
+    server: {
+        host: "127.0.0.1",
+        port: 0,
+        strictPort: false
+    }
+});
+
+let browser;
+try {
+    await server.listen();
+    const address = server.httpServer?.address();
+    if (!address || typeof address === "string") {
+        throw new Error("Vite did not expose a browser test server port");
+    }
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage();
+    const browserErrors = [];
+    page.on("pageerror", (error) => browserErrors.push(error));
+    page.on("console", (message) => {
+        if (message.type() === "error") {
+            browserErrors.push(new Error(message.text()));
+        }
+    });
+    await page.goto(
+        `http://127.0.0.1:${address.port}/test/browser/persistence-restart.html`,
+        { waitUntil: "networkidle" }
+    );
+    await page.waitForFunction(() =>
+        Boolean(
+            globalThis.runPersistenceRestartBrowserSmoke &&
+                globalThis.runPersistenceBrowserBenchmark
+        )
+    );
+    const result = await page.evaluate(() =>
+        globalThis.runPersistenceRestartBrowserSmoke()
+    );
+
+    assert.equal(result.leaseRejected, true);
+    assert.equal(result.signerRecovered, true);
+    assert.equal(result.explicitBatchRecovered, true);
+    assert.equal(result.automaticFlushPersisted, true);
+    assert.equal(result.forceExitRecovered, true);
+    const benchmark = await page.evaluate(() =>
+        globalThis.runPersistenceBrowserBenchmark()
+    );
+    const benchmarkDirectory = path.join(
+        projectRoot,
+        "temp/plan-implementations/16-write-behind-persistence"
+    );
+    await mkdir(benchmarkDirectory, { recursive: true });
+    await writeFile(
+        path.join(benchmarkDirectory, "benchmark-browser.json"),
+        `${JSON.stringify(benchmark, null, 2)}\n`
+    );
+    assert.equal(browserErrors.length, 0, browserErrors[0]?.stack);
+    console.log("Browser persistence restart smoke passed");
+} finally {
+    await browser?.close();
+    await server.close();
+}

--- a/test/browser/run-worker-contract-executor.mjs
+++ b/test/browser/run-worker-contract-executor.mjs
@@ -60,6 +60,10 @@ const server = await createServer({
                 projectRoot,
                 "src/evm/p2pRuntime/browser/P2pRuntimeWorkerRuntime.ts"
             ),
+            "@platform/persistenceDatabase": path.join(
+                projectRoot,
+                "src/storage/persistence/browser/createPersistenceDatabase.ts"
+            ),
             "@": path.join(projectRoot, "src"),
             "@test": path.join(projectRoot, "test"),
             "@typechain-types": path.join(projectRoot, "typechain-types")

--- a/test/e2e/E2E-BlockQueueManager.test.ts
+++ b/test/e2e/E2E-BlockQueueManager.test.ts
@@ -956,10 +956,10 @@ describe("E2E: BlockQueueManager", function () {
                         );
                     const originalDispute =
                         disputeManager.dispute.bind(disputeManager);
-                    fraudProofService.createWrongGenesisProof = (
+                    fraudProofService.createWrongGenesisProof = async (
                         ...a: unknown[]
                     ) => {
-                        proofHash = originalProof(...a);
+                        proofHash = await originalProof(...a);
                         return proofHash;
                     };
                     // Record-only: an on-chain dispute against an honest
@@ -1197,13 +1197,13 @@ describe("E2E: BlockQueueManager", function () {
 
                         // Duplicate copies merge into the entry - age it
                         // precisely instead of sleeping.
-                        ageEntryBy(hash, 4);
+                        await ageEntryBy(hash, 4);
                         const aged = manager.scheduleQueueTimeout(hash);
                         const agedDelayMs =
                             scheduled[scheduled.length - 1]?.delayMs;
                         const cancelledAfterAging = cancelled.length;
 
-                        ageEntryBy(hash, agreementTime); // past the deadline
+                        await ageEntryBy(hash, agreementTime); // past the deadline
                         const atDeadline = manager.scheduleQueueTimeout(hash);
                         const cancelledAfterDeadlineAttempt = cancelled.length;
                         const scheduledCount = scheduled.length;

--- a/test/e2e/E2E-CustomRpcRequestResponse.test.ts
+++ b/test/e2e/E2E-CustomRpcRequestResponse.test.ts
@@ -178,6 +178,7 @@ describe("E2E: custom RPC request/response over the runtime port", function () {
                 PingPongRpc
             >(scm, stateMachineTemplate, deployLocalStateMachine, {
                 signerSecret: runtimeWallet.privateKey,
+                persistence: false,
                 customRpcManifest: { module: PING_PONG_MANIFEST },
                 config: {
                     PROVIDER_URL: hardhatNodeUrl,

--- a/test/e2e/E2E-ForceJoinDispute.test.ts
+++ b/test/e2e/E2E-ForceJoinDispute.test.ts
@@ -31,7 +31,11 @@ describe("E2E: Force Join Dispute", function () {
         //  on the 3rd block, the force-join dispute is triggered
 
         const forkId = h.activeForkId!;
-        await h.transition.advanceState({ count: 3 });
+        await h.transition.advanceState({
+            count: 3,
+            waitForPeers: [0, 1],
+            waitForFinalization: true
+        });
 
         // Block assembly can include pending inbound messages again. Dispute
         // construction always reads the real inbound head while this stub is

--- a/test/e2e/E2E-FraudProofsBlockConfirmation.test.ts
+++ b/test/e2e/E2E-FraudProofsBlockConfirmation.test.ts
@@ -187,7 +187,7 @@ describe("E2E: Block Fraud Proofs", function () {
         // One-off white-box mutation: queue the latest block host-side.
         await h.execOnHost(
             observer,
-            (sm, args) => {
+            async (sm, args) => {
                 const latest = sm.storage.blocks.getLatestBlock(args.forkId);
                 if (!latest) throw new Error("no latest block to queue");
                 sm.storage.queues.queueBlock(latest);

--- a/test/e2e/E2E-MaliciousUpdateSnapshot.test.ts
+++ b/test/e2e/E2E-MaliciousUpdateSnapshot.test.ts
@@ -240,7 +240,7 @@ describe("E2E: Malicious updateSnapshot", function () {
             h.peers.map((p) =>
                 h.execOnHost(
                     p,
-                    (sm, args) => {
+                    async (sm, args) => {
                         sm.storage.stateMachineStates.storeStateMachineState(
                             args.encoded,
                             { hash: args.hash }

--- a/test/e2e/E2E-PersistenceRestart.test.ts
+++ b/test/e2e/E2E-PersistenceRestart.test.ts
@@ -1,0 +1,125 @@
+import { expect } from "chai";
+
+import { MathTestSession as TestSession } from "@test/harness";
+
+describe("E2E: Persistence restart", function () {
+    it("holds recovered-state publication behind the storage barrier", async function () {
+        this.timeout(90_000);
+
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(3, 0);
+        await h.transition.advanceState({
+            waitForPeers: [0],
+            waitForFinalization: false
+        });
+
+        const result = await h.execOnHost(h.getPeer(0), async (sm) => {
+            const block = sm.storage.blocks.getLatestBlock(sm.forkId)!;
+            const snapshot = sm.storage.stateSnapshots.getStateSnapshotByHash(
+                block.stateSnapshotHash
+            )!;
+            const encodedState =
+                sm.storage.stateMachineStates.getStateMachineState(
+                    snapshot.stateMachineStateHash
+                )!;
+            const storage = sm.storage;
+            const hostStateManager = sm as any;
+            const originalFlush = storage.flush.bind(storage);
+            const originalSetStatus = hostStateManager.setStatus.bind(sm);
+            let release!: () => void;
+            let entered!: () => void;
+            const held = new Promise<void>((resolve) => {
+                release = resolve;
+            });
+            const flushEntered = new Promise<void>((resolve) => {
+                entered = resolve;
+            });
+            let statusPublications = 0;
+            storage.flush = async () => {
+                entered();
+                await held;
+            };
+            hostStateManager.setStatus = (...args: unknown[]) => {
+                statusPublications += 1;
+                return originalSetStatus(...args);
+            };
+
+            try {
+                const update = sm.unsafeSetLatestState(
+                    snapshot.toStruct(),
+                    encodedState
+                );
+                await flushEntered;
+                const callsBeforeRelease = statusPublications;
+                release();
+                await update;
+                return {
+                    callsBeforeRelease,
+                    callsAfterRelease: statusPublications
+                };
+            } finally {
+                release();
+                storage.flush = originalFlush;
+                hostStateManager.setStatus = originalSetStatus;
+            }
+        });
+
+        expect(result.callsBeforeRelease).to.equal(0);
+        expect(result.callsAfterRelease).to.equal(1);
+    });
+
+    it("restores persisted state before attaching the channel listener", async function () {
+        this.timeout(90_000);
+
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(3, 0);
+        await h.transition.advanceState({
+            waitForPeers: [0],
+            waitForFinalization: false
+        });
+
+        const result = await h.execOnHost(h.getPeer(0), async (sm) => {
+            const stateMachine = (sm as any).diamondStateMachine;
+            const listener = (sm as any).stateChannelEventListener;
+            const originalSetState = stateMachine.setState.bind(stateMachine);
+            const originalSetChannelId = listener.setChannelId.bind(listener);
+            let release!: () => void;
+            let restoreEntered!: () => void;
+            const held = new Promise<void>((resolve) => {
+                release = resolve;
+            });
+            const entered = new Promise<void>((resolve) => {
+                restoreEntered = resolve;
+            });
+            let listenerCalls = 0;
+            stateMachine.setState = async (...args: unknown[]) => {
+                restoreEntered();
+                await held;
+                return originalSetState(...args);
+            };
+            listener.setChannelId = async (...args: unknown[]) => {
+                listenerCalls += 1;
+                return originalSetChannelId(...args);
+            };
+
+            try {
+                const channelSetup = sm.setChannelId(sm.channelId);
+                await entered;
+                const callsBeforeRestore = listenerCalls;
+                release();
+                await channelSetup;
+                return {
+                    callsBeforeRestore,
+                    callsAfterRestore: listenerCalls
+                };
+            } finally {
+                release();
+                stateMachine.setState = originalSetState;
+                listener.setChannelId = originalSetChannelId;
+            }
+        });
+
+        expect(result.callsBeforeRestore).to.equal(0);
+        expect(result.callsAfterRestore).to.equal(1);
+    });
+});

--- a/test/e2e/E2E-RuntimeTransportModes.test.ts
+++ b/test/e2e/E2E-RuntimeTransportModes.test.ts
@@ -1,5 +1,9 @@
 import { expect } from "chai";
+import { ClassicLevel } from "classic-level";
 import { ethers, NonceManager } from "ethers";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 import { EvmStateMachine } from "@/evm";
 import MathStateMachineArtifact from "../../artifacts/contracts/V1/examples/MathStateMachine/MathStateMachine.sol/MathStateMachine.json";
@@ -16,10 +20,20 @@ import {
 } from "@typechain-types";
 import { ContractFactory } from "ethers";
 import { startHardhatNode, type NodeHandle } from "@test/utils/nodeInfra";
+import type { PersistenceOptions } from "@/storage/persistence";
 
 let hardhatNodeUrl = process.env.HARDHAT_NODE_URL;
 const DEFAULT_HARDHAT_MNEMONIC =
     "test test test test test test test test test test test junk";
+
+interface RuntimeModeOptions {
+    runSdkInThread: boolean;
+    vmDedicatedThread: boolean;
+    generateSigner?: boolean;
+    signerSecret?: string;
+    persistence?: false | PersistenceOptions;
+    channelId?: string;
+}
 
 async function waitForNode(url: string): Promise<void> {
     const provider = new ethers.JsonRpcProvider(url);
@@ -34,12 +48,7 @@ async function waitForNode(url: string): Promise<void> {
     }, 30_000);
 }
 
-async function setupP2pInstance(options: {
-    runSdkInThread: boolean;
-    vmDedicatedThread: boolean;
-    generateSigner?: boolean;
-}) {
-    const { runSdkInThread, vmDedicatedThread, generateSigner } = options;
+async function createP2pInstanceFactory() {
     if (!hardhatNodeUrl) throw new Error("Hardhat node URL is not initialized");
     const provider = new ethers.JsonRpcProvider(hardhatNodeUrl);
     const deployerWallet = ethers.HDNodeWallet.fromPhrase(
@@ -93,22 +102,34 @@ async function setupP2pInstance(options: {
         return receipt.contractAddress;
     };
 
-    return EvmStateMachine.p2pSetup(
-        StateChannelManagerProxy__factory.connect(
-            scmDeployment.address,
-            runtimeSigner
-        ),
-        deployedStateMachine,
-        deployStateMachine,
-        {
-            config: {
-                PROVIDER_URL: hardhatNodeUrl,
-                RUN_SDK_IN_THREAD: runSdkInThread,
-                VM_DEDICATED_THREAD: vmDedicatedThread
-            },
-            signerSecret: generateSigner ? undefined : runtimeWallet.privateKey
-        }
-    );
+    return (options: RuntimeModeOptions) =>
+        EvmStateMachine.p2pSetup(
+            StateChannelManagerProxy__factory.connect(
+                scmDeployment.address,
+                runtimeSigner
+            ),
+            deployedStateMachine,
+            deployStateMachine,
+            {
+                config: {
+                    PROVIDER_URL: hardhatNodeUrl,
+                    RUN_SDK_IN_THREAD: options.runSdkInThread,
+                    VM_DEDICATED_THREAD: options.vmDedicatedThread
+                },
+                persistence: options.persistence ?? false,
+                channelId: options.channelId,
+                signerSecret:
+                    options.signerSecret ??
+                    (options.generateSigner
+                        ? undefined
+                        : runtimeWallet.privateKey)
+            }
+        );
+}
+
+async function setupP2pInstance(options: RuntimeModeOptions) {
+    const createP2pInstance = await createP2pInstanceFactory();
+    return createP2pInstance(options);
 }
 
 describe("E2E: p2pSetup runtime modes", function () {
@@ -307,6 +328,104 @@ describe("E2E: p2pSetup runtime modes", function () {
             ).to.have.length(4);
         } finally {
             await p2pInstance.dispose();
+        }
+    });
+
+    it("recovers the channel signer after a persisted runtime restart", async function () {
+        this.timeout(90_000);
+        const location = await mkdtemp(
+            path.join(tmpdir(), "state-channels-plus-runtime-persistence-")
+        );
+        const createP2pInstance = await createP2pInstanceFactory();
+        const channelId = ethers.hexlify(ethers.randomBytes(32));
+
+        try {
+            const first = await createP2pInstance({
+                runSdkInThread: false,
+                vmDedicatedThread: false,
+                persistence: { location },
+                channelId,
+                signerSecret: ethers.Wallet.createRandom().privateKey
+            });
+            let persistedSignerAddress: string;
+            try {
+                persistedSignerAddress = await first.p2pSigner.getAddress();
+            } finally {
+                await first.dispose();
+            }
+
+            const second = await createP2pInstance({
+                runSdkInThread: false,
+                vmDedicatedThread: false,
+                persistence: { location },
+                channelId,
+                signerSecret: ethers.Wallet.createRandom().privateKey
+            });
+            try {
+                expect(await second.p2pSigner.getAddress()).to.equal(
+                    persistedSignerAddress
+                );
+            } finally {
+                await second.dispose();
+            }
+        } finally {
+            await rm(location, { recursive: true, force: true });
+        }
+    });
+
+    it("reports a corrupt partition location and resets only on request", async function () {
+        this.timeout(90_000);
+        const location = await mkdtemp(
+            path.join(tmpdir(), "state-channels-plus-runtime-reset-")
+        );
+        const createP2pInstance = await createP2pInstanceFactory();
+        const channelId = ethers.hexlify(ethers.randomBytes(32));
+        const options = {
+            runSdkInThread: false,
+            vmDedicatedThread: false,
+            channelId,
+            signerSecret: ethers.Wallet.createRandom().privateKey
+        };
+
+        try {
+            const first = await createP2pInstance({
+                ...options,
+                persistence: { location }
+            });
+            await first.dispose();
+
+            const [namespace] = await readdir(location);
+            const partitionLocation = path.join(location, namespace);
+            const database = new ClassicLevel<string, string>(
+                partitionLocation,
+                {
+                    keyEncoding: "utf8",
+                    valueEncoding: "utf8"
+                }
+            );
+            await database.open();
+            await database.put("records!v1!unknown!record", "corrupt");
+            await database.close();
+
+            let recoveryError: Error | undefined;
+            try {
+                const unexpected = await createP2pInstance({
+                    ...options,
+                    persistence: { location }
+                });
+                await unexpected.dispose();
+            } catch (error) {
+                recoveryError = error as Error;
+            }
+            expect(recoveryError?.message).to.include(partitionLocation);
+
+            const reset = await createP2pInstance({
+                ...options,
+                persistence: { location, reset: true }
+            });
+            await reset.dispose();
+        } finally {
+            await rm(location, { recursive: true, force: true });
         }
     });
 });

--- a/test/e2e/persistence/durabilityBarrier.test.ts
+++ b/test/e2e/persistence/durabilityBarrier.test.ts
@@ -1,0 +1,410 @@
+import type { AbstractBatchOperation } from "abstract-level";
+import { expect } from "chai";
+import { MemoryLevel } from "memory-level";
+
+import { MathTestSession as TestSession, sleep } from "@test/harness";
+import * as factory from "@test/factory";
+import Storage from "@/storage";
+import type { PersistenceDatabaseHandle } from "@/storage/persistence";
+
+/**
+ * The durability barrier (`await storage.flush()`) sits immediately before
+ * every signature-release broadcast, so no signature is gossiped before the
+ * just-signed state is durable. This is the slashing guarantee of the
+ * persistence layer.
+ *
+ * Two release sites, both exercised here against a real StateManager on a real
+ * peer (poked host-side through the control RPC):
+ *  - SITE 1 (paths A/B) - StateManager.tryCommitState, inside the StateManager
+ *    mutex (the step-9 flush before the step-7 gossip).
+ *  - SITE 2 (path C) - BlockValidationStrategy.goodNewSignaturesOnExistingBlock,
+ *    a detached macrotask outside any mutex.
+ *
+ * The stuck-barrier condition is reproduced on the live Storage by parking
+ * flush() on a releasable gate - the same observable state the controller
+ * enters while the database batch hangs (flush() stays pending). The final
+ * tests assert that stuck state directly on a real Storage bound to a
+ * MemoryLevel database whose batch is gated/failing.
+ *
+ * The release-site behaviors run in ONE harness session/`it`: the repo's
+ * harness cannot stand up a second full peer session in the same process (an
+ * unrelated teardown limitation, reproducible with E2E-StateTransition), so
+ * the scenarios are sequenced within a single session rather than split
+ * across `it`s that would each re-`start()`.
+ */
+
+/** Parks a peer's live durability barrier on a releasable gate, host-side. */
+function installPendingBarrier(sm: {
+    storage: { flush: () => Promise<void> };
+}): void {
+    const storage = sm.storage as unknown as {
+        flush: () => Promise<void>;
+        __origFlush?: () => Promise<void>;
+        __durabilityGate?: Promise<void>;
+        __releaseDurability?: () => void;
+    };
+    storage.__origFlush = sm.storage.flush.bind(sm.storage);
+    storage.__durabilityGate = new Promise<void>((res) => {
+        storage.__releaseDurability = res;
+    });
+    sm.storage.flush = () => storage.__durabilityGate!;
+}
+
+/** Releases a parked barrier and restores the real flush. */
+function releasePendingBarrier(sm: {
+    storage: { flush: () => Promise<void> };
+}): void {
+    const storage = sm.storage as unknown as {
+        flush: () => Promise<void>;
+        __origFlush?: () => Promise<void>;
+        __releaseDurability?: () => void;
+    };
+    storage.__releaseDurability?.();
+    if (storage.__origFlush) {
+        sm.storage.flush = storage.__origFlush;
+    }
+}
+
+type GatedDatabase = MemoryLevel<string, string>;
+type BatchOperation = AbstractBatchOperation<GatedDatabase, string, string>;
+
+/** A MemoryLevel-backed handle whose batch() parks on a releasable gate. */
+function createGatedHandle(): {
+    handle: PersistenceDatabaseHandle;
+    releaseBatch: () => void;
+} {
+    const database: GatedDatabase = new MemoryLevel({
+        keyEncoding: "utf8",
+        valueEncoding: "utf8"
+    });
+    const originalBatch = database.batch.bind(database);
+    let releaseBatch!: () => void;
+    const gate = new Promise<void>((res) => (releaseBatch = res));
+    database.batch = (async (operations: BatchOperation[]): Promise<void> => {
+        await gate;
+        return originalBatch(operations);
+    }) as GatedDatabase["batch"];
+    return {
+        handle: {
+            database,
+            location: "memory:durability-barrier-gated",
+            close: () => database.close(),
+            destroy: () => database.clear()
+        },
+        releaseBatch
+    };
+}
+
+/** A MemoryLevel-backed handle whose batch() always fails. */
+function createFailingHandle(): PersistenceDatabaseHandle {
+    const database: GatedDatabase = new MemoryLevel({
+        keyEncoding: "utf8",
+        valueEncoding: "utf8"
+    });
+    database.batch = (async (_operations: BatchOperation[]): Promise<void> => {
+        throw new Error("injected commit failure");
+    }) as GatedDatabase["batch"];
+    return {
+        database,
+        location: "memory:durability-barrier-failing",
+        close: () => database.close(),
+        destroy: () => database.clear()
+    };
+}
+
+describe("E2E: durability barrier (sign-before-durable)", function () {
+    it("withholds every release-site broadcast until state is durable; unparked flush broadcasts normally", async function () {
+        this.timeout(120000);
+
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(2);
+        const forkId = h.activeForkId!;
+
+        // ---- unparked flush preserves broadcast behavior ----
+        // With the real flush() both release sites fire normally and the
+        // peers converge.
+        await h.transition.advanceState({ count: 2 });
+        await h.assert.sync.peersInSyncWait();
+        await h.assert.sync.blockHeight({ expectedHeight: 1 });
+
+        // ---- mutex-path broadcast is withheld while the barrier is pending ----
+        const authorIndex = (await h.query.getNextPeerToWrite()).index;
+        const author = h.getPeer(authorIndex);
+        const receiver = h.peers.find((p) => p.index !== authorIndex)!;
+
+        const receiverHeightBefore = (await h
+            .control(receiver)
+            .query.getLatestBlockHeight(forkId)
+            .request())!;
+        const authorHeightBefore = (await h
+            .control(author)
+            .query.getLatestBlockHeight(forkId)
+            .request())!;
+
+        // Park the author's barrier so tryCommitState stalls right after its
+        // writes, immediately before the release broadcast.
+        await h.execOnHost(author, installPendingBarrier);
+
+        // Fire the author's block; tryCommitState stores it, then blocks at the
+        // barrier before broadcasting. It will not resolve until released.
+        const submitP = h.transition
+            .increment(1, { waitForSync: false })
+            .catch((e) => e);
+
+        try {
+            // Give tryCommitState time to store the block and reach the barrier.
+            await sleep(2500);
+
+            const authorHeightDuring = (await h
+                .control(author)
+                .query.getLatestBlockHeight(forkId)
+                .request())!;
+            const receiverHeightDuring = (await h
+                .control(receiver)
+                .query.getLatestBlockHeight(forkId)
+                .request())!;
+
+            // Writes happened (author advanced) but the signature was NOT
+            // gossiped: the barrier withholds the broadcast, so the receiver
+            // never saw the new block.
+            expect(
+                authorHeightDuring,
+                "author must persist the block before the barrier"
+            ).to.equal(authorHeightBefore + 1);
+            expect(
+                receiverHeightDuring,
+                "receiver must not see the withheld broadcast"
+            ).to.equal(receiverHeightBefore);
+        } finally {
+            // Always release so the mutex frees and teardown is clean.
+            await h.execOnHost(author, releasePendingBarrier);
+        }
+
+        await submitP;
+
+        // Once durable, the withheld broadcast fires and the receiver converges.
+        await h.assert.sync.peersInSyncWait();
+        const receiverHeightAfter = (await h
+            .control(receiver)
+            .query.getLatestBlockHeight(forkId)
+            .request())!;
+        expect(receiverHeightAfter).to.equal(receiverHeightBefore + 1);
+
+        // ---- path-C (stored-merge re-gossip) broadcast is withheld ----
+        // The LIVE "new signatures on an already-stored block" re-gossip is
+        // reached via the real scheduling entry point
+        // BlockQueueManager.scheduleStoredBlockConfirmationMerge — a detached
+        // macrotask holding no mutex — which delegates to
+        // StateManager.tryMergeStoredBlockConfirmation, which in turn calls
+        // strategy.goodNewSignaturesOnExistingBlock (the strategy owns the
+        // barrier + broadcast policy). We synthesize the new-signature condition
+        // by stripping the confirmation signatures off a stored, co-signed block
+        // and feeding the full confirmation back through that scheduler, then
+        // assert the merged re-gossip is withheld while the barrier is pending,
+        // fires after release, and never raises an unhandled rejection.
+        const pathC = await h.execOnHost(
+            h.getPeer(0),
+            async (sm, args) => {
+                const wait = (ms: number) =>
+                    new Promise<void>((r) => setTimeout(r, ms));
+                const forkId = sm.forkId;
+
+                // Find a stored, co-signed block (>=1 confirmation signature).
+                let full = sm.storage.blocks.getLatestBlock(forkId);
+                let height = full ? full.height : -1;
+                while (
+                    full &&
+                    full.confirmationSignatures.size === 0 &&
+                    height > 0
+                ) {
+                    height -= 1;
+                    full = sm.storage.blocks.getBlock(forkId, height);
+                }
+                if (!full || full.confirmationSignatures.size === 0) {
+                    return {
+                        setupFailed: true,
+                        withheldWhilePending: false,
+                        unhandledWhilePending: 0,
+                        broadcastAfterRelease: false
+                    };
+                }
+
+                // Strip the confirmation signatures off the RAW stored record
+                // so the incoming full confirmation carries them as "new". The
+                // deepCopyProxy returns non-function properties as-is, so
+                // `records` is the live PersistentCollection and its get() is
+                // the uncloned cache entry (a cache-only mutation is exactly
+                // what we want here — no persist op for the synthetic strip).
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const rawBlocks = sm.storage.blocks as any;
+                const rawRecord = rawBlocks.records.get(full.hash);
+                rawRecord.block.removeConfirmationSignatures(
+                    new Set(rawRecord.block.confirmationSignatures)
+                );
+                const entry = sm.storage.queues.createEntry(full);
+
+                // Count actual re-gossip broadcasts (stable cached service proxy;
+                // an own-prop assignment shadows the generated method).
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const svc = sm.p2pManager.remoteRpc
+                    .stateTransitionService as any;
+                const realOnBlockConfirmation =
+                    svc.onBlockConfirmation.bind(svc);
+                let broadcasts = 0;
+                svc.onBlockConfirmation = (struct: unknown) => {
+                    const handle = realOnBlockConfirmation(struct);
+                    const realBroadcast = handle.broadcast.bind(handle);
+                    handle.broadcast = () => {
+                        broadcasts += 1;
+                        return realBroadcast();
+                    };
+                    return handle;
+                };
+
+                // Park the barrier on a releasable gate.
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const storage = sm.storage as any;
+                storage.__origFlush = sm.storage.flush.bind(sm.storage);
+                storage.__durabilityGate = new Promise<void>((res) => {
+                    storage.__releaseDurability = res;
+                });
+                sm.storage.flush = () => storage.__durabilityGate;
+
+                let unhandledCount = 0;
+                const onUnhandled = () => {
+                    unhandledCount += 1;
+                };
+                process.on("unhandledRejection", onUnhandled);
+
+                try {
+                    // Real scheduling entry point -> detached macrotask ->
+                    // handleStoredBlockConfirmationMerge ->
+                    // tryMergeStoredBlockConfirmation ->
+                    // strategy.goodNewSignaturesOnExistingBlock -> storeBlock ->
+                    // barrier.
+                    sm.blockQueueManager.scheduleStoredBlockConfirmationMerge(
+                        entry,
+                        sm.getActiveValidationStrategy()
+                    );
+
+                    await wait(args.windowMs);
+                    const withheldWhilePending = broadcasts === 0;
+                    const unhandledWhilePending = unhandledCount;
+
+                    storage.__releaseDurability();
+                    sm.storage.flush = storage.__origFlush;
+                    await wait(500);
+                    const broadcastAfterRelease = broadcasts > 0;
+
+                    return {
+                        setupFailed: false,
+                        withheldWhilePending,
+                        unhandledWhilePending,
+                        broadcastAfterRelease
+                    };
+                } finally {
+                    process.removeListener("unhandledRejection", onUnhandled);
+                    storage.__releaseDurability?.();
+                    if (storage.__origFlush) {
+                        sm.storage.flush = storage.__origFlush;
+                    }
+                    delete svc.onBlockConfirmation;
+                }
+            },
+            { windowMs: 800 }
+        );
+
+        expect(
+            pathC.setupFailed,
+            "path-C setup must find a co-signed block"
+        ).to.equal(false);
+        expect(
+            pathC.withheldWhilePending,
+            "stored-merge must not re-gossip while the barrier is pending"
+        ).to.equal(true);
+        expect(
+            pathC.unhandledWhilePending,
+            "the detached stored-merge macrotask must not raise an unhandled rejection"
+        ).to.equal(0);
+        // After durability the withheld re-gossip fires.
+        expect(pathC.broadcastAfterRelease).to.equal(true);
+    });
+
+    it("flush() stays pending while the database batch hangs (withhold primitive)", async function () {
+        // The exact primitive both release sites await: with a database whose
+        // batch() hangs, flush() stays pending (it neither resolves nor
+        // rejects), so any code that awaits it before broadcasting can never
+        // release a signature. This is the hang case — distinct from the
+        // rejecting-batch poison case PersistenceController.test.ts covers.
+        const { handle, releaseBatch } = createGatedHandle();
+        const storage = new Storage();
+        await storage.bind(handle);
+
+        // A pending write gives the flush an op to commit (and hang on).
+        storage.blocks.storeBlock(factory.block());
+
+        const outcome = await Promise.race([
+            storage.flush().then(() => "resolved" as const),
+            sleep(500).then(() => "pending" as const)
+        ]);
+        expect(outcome).to.equal("pending");
+
+        // Once the batch completes the parked flush resolves and teardown is
+        // clean.
+        releaseBatch();
+        await storage.flush();
+        await storage.close();
+
+        // A Storage never bound to a database, by contrast, resolves promptly.
+        const okStorage = new Storage();
+        okStorage.blocks.storeBlock(factory.block());
+        const okOutcome = await Promise.race([
+            okStorage.flush().then(() => "resolved" as const),
+            sleep(500).then(() => "pending" as const)
+        ]);
+        expect(okOutcome).to.equal("resolved");
+        await okStorage.close();
+    });
+
+    it("a poisoned controller rejects the barrier, fires the failure handler, and close() refuses to swallow the lost writes", async function () {
+        // The failing-batch case: the controller retries, then poisons. The
+        // release sites rely on three behaviors asserted here at the Storage
+        // surface: flush() rejects (the broadcast never fires), the failure
+        // handler runs (P2pRuntimeHost wires it to stateManager.abort), and
+        // close() rejects rather than silently discarding undurable writes.
+        const storage = new Storage();
+        let failureHandlerError: Error | undefined;
+        storage.setPersistenceFailureHandler((error) => {
+            failureHandlerError = error;
+        });
+        await storage.bind(createFailingHandle());
+
+        storage.blocks.storeBlock(factory.block());
+
+        let flushError: unknown;
+        try {
+            await storage.flush();
+        } catch (err) {
+            flushError = err;
+        }
+        expect(
+            flushError,
+            "flush() must reject once the controller is poisoned"
+        ).to.not.be.undefined;
+        expect(
+            failureHandlerError,
+            "the persistence failure handler must fire on poison"
+        ).to.not.be.undefined;
+
+        let closeError: unknown;
+        try {
+            await storage.close();
+        } catch (err) {
+            closeError = err;
+        }
+        expect(
+            closeError,
+            "close() must reject when the final flush can't durably commit"
+        ).to.not.be.undefined;
+    });
+});

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -358,8 +358,8 @@ export function stateSnapshot(
     };
     const stateSnapshotObj = {
         ...defaultStateSnapshot,
-        snapshotData: snapshotDataObj,
-        ...overrides
+        ...overrides,
+        snapshotData: snapshotDataObj
     };
 
     return StateSnapshot.from(stateSnapshotObj as StateSnapshotStruct);

--- a/test/fixtures/PeerTestHarness.ts
+++ b/test/fixtures/PeerTestHarness.ts
@@ -748,6 +748,7 @@ export class PeerTestHarness<
                 customPrecompiles: this.options.customPrecompiles!,
                 customRpcManifest: this.resolveHarnessRpcManifest(),
                 signerSecret,
+                persistence: false,
                 config: this.harnessConfig,
                 handlerExecutionContext: useWorker
                     ? undefined

--- a/test/fixtures/customRpc/harnessControl/services/dispute/DisputeRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/dispute/DisputeRpcMethods.ts
@@ -188,7 +188,10 @@ export class DisputeRpcMethods extends ARpcMethods {
     }
 
     /** Plant a fresh timeout for `participant` at head+1 height on `forkId`. */
-    public plantFreshTimeout(forkId: ForkId, participant: string): boolean {
+    public async plantFreshTimeout(
+        forkId: ForkId,
+        participant: string
+    ): Promise<boolean> {
         const latestBlock = this.service.storage.blocks.getLatestBlock(forkId);
         if (!latestBlock) {
             throw new Error(`plantFreshTimeout: no latest block for ${forkId}`);

--- a/test/fixtures/customRpc/harnessControl/services/query/QueryRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/query/QueryRpcMethods.ts
@@ -59,6 +59,10 @@ export class QueryRpcMethods extends ARpcMethods {
         return this.service.sm.signerAddress as string;
     }
 
+    public flushStorage(): Promise<void> {
+        return this.service.storage.flush();
+    }
+
     public getForkId(): string {
         return this.service.sm.forkId as string;
     }
@@ -316,11 +320,7 @@ export class QueryRpcMethods extends ARpcMethods {
 
     /** Number of distinct state snapshots stored. */
     public getSnapshotCount(): number {
-        // Reads the storage's private index (no public count accessor).
-        const store = this.service.storage.stateSnapshots as unknown as {
-            snapshotsByHash: Map<string, unknown>;
-        };
-        return store.snapshotsByHash.size;
+        return this.service.storage.stateSnapshots.getSnapshotCount();
     }
 
     /**

--- a/test/fixtures/customRpc/harnessControl/services/spectate/SpectateControlRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/spectate/SpectateControlRpcMethods.ts
@@ -77,7 +77,9 @@ export class SpectateControlRpcMethods extends ARpcMethods<
     }
 
     /** Store a block straight into storage (`justPersist`); returns its hash. */
-    public storeBlockJustPersist(encodedSignedBlock: string): string {
+    public async storeBlockJustPersist(
+        encodedSignedBlock: string
+    ): Promise<string> {
         const block = Block.fromSignedBlock(
             Codec.decode(encodedSignedBlock, Type.SignedBlock)
         );

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -448,11 +448,11 @@ export class StubService extends ARpcService<
     }
 
     /** Store a snapshot listing `participants` at the given coordinates. */
-    private storeSnapshotAt(
+    private async storeSnapshotAt(
         participants: Address[],
         height: number,
         forkId: ForkId = this.sm.forkId
-    ): Hash {
+    ): Promise<Hash> {
         const snapshot = factory.stateSnapshot({
             forkId,
             blockHeight: height,
@@ -492,7 +492,7 @@ export class StubService extends ARpcService<
     /** Author only in a resulting snapshot bound to the block's own coordinates. */
     public async probeAuthorGateMatchingResultingSnapshot(): Promise<string> {
         const outsider = this.randomAddress();
-        const snapshotHash = this.storeSnapshotAt(
+        const snapshotHash = await this.storeSnapshotAt(
             [outsider],
             this.nextHeight()
         );
@@ -502,7 +502,7 @@ export class StubService extends ARpcService<
     /** Author only in a resulting snapshot from a different height. */
     public async probeAuthorGateStaleHeightSnapshot(): Promise<string> {
         const outsider = this.randomAddress();
-        const snapshotHash = this.storeSnapshotAt(
+        const snapshotHash = await this.storeSnapshotAt(
             [outsider],
             this.nextHeight() + 100
         );
@@ -512,7 +512,7 @@ export class StubService extends ARpcService<
     /** Author only in a resulting snapshot from a different fork, same height. */
     public async probeAuthorGateWrongForkSnapshot(): Promise<string> {
         const outsider = this.randomAddress();
-        const snapshotHash = this.storeSnapshotAt(
+        const snapshotHash = await this.storeSnapshotAt(
             [outsider],
             this.nextHeight(),
             id("probeAuthorGate-wrong-fork") as ForkId
@@ -523,7 +523,7 @@ export class StubService extends ARpcService<
     /** Resulting snapshot matches the coordinates but omits the author. */
     public async probeAuthorGateMatchingSnapshotExcludingAuthor(): Promise<string> {
         const outsider = this.randomAddress();
-        const snapshotHash = this.storeSnapshotAt(
+        const snapshotHash = await this.storeSnapshotAt(
             [this.randomAddress()],
             this.nextHeight()
         );

--- a/test/storage/BlockCalldataStorage.test.ts
+++ b/test/storage/BlockCalldataStorage.test.ts
@@ -4,7 +4,7 @@ import { BlockCalldataStorage } from "@/storage/BlockCalldataStorage";
 import * as factory from "../factory";
 
 describe("BlockCalldataStorage", function () {
-    it("returns calldata only for the exact signed block hash", function () {
+    it("returns calldata only for the exact signed block hash", async function () {
         const storage = new BlockCalldataStorage();
         const block = factory.block();
         storage.storeBlockCalldata({

--- a/test/storage/BlockStorage.test.ts
+++ b/test/storage/BlockStorage.test.ts
@@ -38,7 +38,7 @@ describe("BlockStorage", () => {
     });
 
     describe("CREATE - storeBlockConfirmation()", () => {
-        it("should merge signatures with deduplication on duplicate insert", () => {
+        it("should merge signatures with deduplication on duplicate insert", async () => {
             // Create shared and unique signatures
             const sharedSignature = sig();
             const uniqueSignature1 = sig();
@@ -77,7 +77,7 @@ describe("BlockStorage", () => {
             );
         });
 
-        it("should overwrite on-chain timestamp on duplicate insert", () => {
+        it("should overwrite on-chain timestamp on duplicate insert", async () => {
             storage.storeBlock(
                 Block.fromBlockConfirmation(mockBlockConfirmation, 20)
             );
@@ -92,15 +92,16 @@ describe("BlockStorage", () => {
             );
         });
 
-        it("should insert block confirmation with auto-computed keys", () => {
+        it("should insert block confirmation with auto-computed keys", async () => {
             const block = Block.fromBlockConfirmation(mockBlockConfirmation);
             const hash = storage.storeBlock(block);
 
             const stored = storage.getBlock(hash!);
-            expect(stored).to.equal(block);
+            expect(stored?.equals(block)).to.be.true;
+            expect(stored).to.not.equal(block);
         });
 
-        it("should insert block confirmation with provided keys", () => {
+        it("should insert block confirmation with provided keys", async () => {
             const block = Block.fromBlockConfirmation(mockBlockConfirmation);
             const hash = storage.storeBlock(block, {
                 coordinates: { forkId: mockForkId, height: mockHeight }
@@ -108,36 +109,37 @@ describe("BlockStorage", () => {
 
             const stored = storage.getBlock(hash!);
             const storedByCoords = storage.getBlock(mockForkId, mockHeight);
-            expect(stored).to.equal(block);
-            expect(storedByCoords).to.equal(block);
+            expect(stored?.equals(block)).to.be.true;
+            expect(storedByCoords?.equals(block)).to.be.true;
+            expect(stored).to.not.equal(block);
         });
     });
 
     describe("READ - getBlockEntry()", () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             const block = Block.fromBlockConfirmation(mockBlockConfirmation);
             storage.storeBlock(block, {
                 coordinates: { forkId: mockForkId, height: mockHeight }
             });
         });
 
-        it("should get block by hash", () => {
+        it("should get block by hash", async () => {
             const result = storage.getBlock(mockBlockHash);
             expect(result?.equals(mockBlock)).to.be.true;
         });
 
-        it("should get block by coordinates", () => {
+        it("should get block by coordinates", async () => {
             const result = storage.getBlock(mockForkId, mockHeight);
             expect(result?.equals(mockBlock)).to.be.true;
         });
 
-        it("should return undefined for non-existent blocks", () => {
+        it("should return undefined for non-existent blocks", async () => {
             expect(storage.getBlock(ethers.hexlify(ethers.randomBytes(32)))).to
                 .be.undefined;
             expect(storage.getBlock("nonexistent", 999)).to.be.undefined;
         });
 
-        it("should maintain consistency between lookups", () => {
+        it("should maintain consistency between lookups", async () => {
             const byHash = storage.getBlock(mockBlockHash);
             const byCoords = storage.getBlock(mockForkId, mockHeight);
             expect(byHash).to.equal(byCoords); // Same object reference
@@ -145,13 +147,13 @@ describe("BlockStorage", () => {
     });
 
     describe("UPDATE - insertSignature()", () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             storage.storeBlock(mockBlock, {
                 coordinates: { forkId: mockForkId, height: mockHeight }
             });
         });
 
-        it("should insert signature by hash", () => {
+        it("should insert signature by hash", async () => {
             const newSig = sig();
             const result = storage.insertSignature(newSig, mockBlockHash);
 
@@ -159,7 +161,7 @@ describe("BlockStorage", () => {
             expect(result?.allSignatures.has(newSig)).to.be.true;
         });
 
-        it("should insert signature by coordinates", () => {
+        it("should insert signature by coordinates", async () => {
             const newSig = sig();
             const result = storage.insertSignature(
                 newSig,
@@ -171,7 +173,7 @@ describe("BlockStorage", () => {
             expect(result?.allSignatures.has(newSig)).to.be.true;
         });
 
-        it("should return undefined for non-existent blocks", () => {
+        it("should return undefined for non-existent blocks", async () => {
             const newSig = sig();
             expect(storage.insertSignature(newSig, "nonexistent")).to.be
                 .undefined;
@@ -179,7 +181,7 @@ describe("BlockStorage", () => {
                 .undefined;
         });
 
-        it("should modify same object regardless of lookup method", () => {
+        it("should modify same object regardless of lookup method", async () => {
             const newSig = sig();
 
             // Insert via hash
@@ -190,7 +192,7 @@ describe("BlockStorage", () => {
             expect(block?.allSignatures.has(newSig)).to.be.true;
         });
 
-        it("should prevent duplicate signatures", () => {
+        it("should prevent duplicate signatures", async () => {
             const newSig = sig();
             const prevNumSignatures = mockBlock.confirmationSignatures.size;
             const expectedNumSignatures = prevNumSignatures + 1;
@@ -210,7 +212,7 @@ describe("BlockStorage", () => {
             expect(result2?.confirmationSignatures.has(newSig)).to.be.true;
         });
 
-        it("should prevent duplicate signatures by coordinates", () => {
+        it("should prevent duplicate signatures by coordinates", async () => {
             const newSig = sig();
             const prevNumSignatures = mockBlock.confirmationSignatures.size;
             const expectedNumSignatures = prevNumSignatures + 1;
@@ -238,7 +240,7 @@ describe("BlockStorage", () => {
             expect(result2?.confirmationSignatures.has(newSig)).to.be.true;
         });
 
-        it("should allow multiple unique signatures", () => {
+        it("should allow multiple unique signatures", async () => {
             const prevNumSignatures = mockBlock.confirmationSignatures.size;
             const expectedNumSignatures = prevNumSignatures + 3;
             expect(
@@ -257,7 +259,7 @@ describe("BlockStorage", () => {
     });
 
     describe("READ - getIterator() DESC clamp", () => {
-        it("clamps an absurd startHeight to maxHeight instead of looping the empty range", () => {
+        it("clamps an absurd startHeight to maxHeight instead of looping the empty range", async () => {
             storage.storeBlock(mockBlock);
 
             // Without the clamp this would loop from ~9e15 down to 0 and hang
@@ -275,23 +277,23 @@ describe("BlockStorage", () => {
     });
 
     describe("DELETE - deleteBlock()", () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             storage.storeBlock(mockBlock);
         });
 
-        it("should delete by hash", () => {
+        it("should delete by hash", async () => {
             expect(storage.deleteBlock(mockBlockHash)).to.be.true;
             expect(storage.getBlock(mockBlockHash)).to.be.undefined;
             expect(storage.getBlock(mockForkId, mockHeight)).to.be.undefined;
         });
 
-        it("should delete by coordinates", () => {
+        it("should delete by coordinates", async () => {
             expect(storage.deleteBlock(mockForkId, mockHeight)).to.be.true;
             expect(storage.getBlock(mockBlockHash)).to.be.undefined;
             expect(storage.getBlock(mockForkId, mockHeight)).to.be.undefined;
         });
 
-        it("should return false when deleting non-existent blocks", () => {
+        it("should return false when deleting non-existent blocks", async () => {
             expect(storage.deleteBlock("nonexistent")).to.be.false;
             expect(storage.deleteBlock("nonexistent", 999)).to.be.false;
         });
@@ -304,7 +306,7 @@ describe("BlockStorage", () => {
             storageWithProxy = new Storage();
         });
 
-        it("altering object inside storage (adding signatures) doesn't affect original object", () => {
+        it("altering object inside storage (adding signatures) doesn't affect original object", async () => {
             // Create a blockConfirmation with initial signatures
             const originalBlockConfirmation = factory.blockConfirmation({
                 signedBlock: mockSignedBlock,
@@ -344,7 +346,7 @@ describe("BlockStorage", () => {
             );
         });
 
-        it("altering object outside storage doesn't affect object inside storage", () => {
+        it("altering object outside storage doesn't affect object inside storage", async () => {
             // Store a blockConfirmation
             const originalBlockConfirmation = factory.blockConfirmation({
                 signedBlock: mockSignedBlock,
@@ -379,7 +381,7 @@ describe("BlockStorage", () => {
 
     describe("CONFLICT DETECTION - _storeBlockEntryWithOptions()", () => {
         describe("Different blocks with same coordinates", () => {
-            it("should return undefined when storing different blocks with same coordinates", () => {
+            it("should return undefined when storing different blocks with same coordinates", async () => {
                 // Store first block
                 storage.storeBlock(
                     Block.fromBlockConfirmation(mockBlockConfirmation)
@@ -402,7 +404,7 @@ describe("BlockStorage", () => {
                 expect(result).to.be.undefined;
             });
 
-            it("should not store conflicting block in coordinates map", () => {
+            it("should not store conflicting block in coordinates map", async () => {
                 // Store first block
                 storage.storeBlock(mockBlock);
 
@@ -427,7 +429,7 @@ describe("BlockStorage", () => {
         });
 
         describe("Different blocks with same hash but different coordinates", () => {
-            it("should return hash when storing block with same hash but different coordinates", () => {
+            it("should reject a stored hash with different coordinates", async () => {
                 // Store first block
                 storage.storeBlock(
                     Block.fromBlockConfirmation(mockBlockConfirmation)
@@ -445,12 +447,21 @@ describe("BlockStorage", () => {
                     }
                 );
 
-                expect(result).to.equal(mockBlockHash);
+                expect(result).to.equal(undefined);
+                expect(
+                    storage.getBlock(
+                        differentCoordinates.forkId,
+                        differentCoordinates.height
+                    )
+                ).to.equal(undefined);
+                expect(
+                    storage.getBlock(mockBlockHash)?.coordinates
+                ).to.deep.equal(mockBlock.coordinates);
             });
         });
 
-        describe("Reference equality", () => {
-            it("should maintain reference equality between hash and coordinates maps", () => {
+        describe("Clone replacement", () => {
+            it("should replace the cached block without mutating an earlier read", async () => {
                 // Store a block
                 const hash = storage.storeBlock(
                     Block.fromBlockConfirmation(mockBlockConfirmation)
@@ -471,10 +482,9 @@ describe("BlockStorage", () => {
                 expect(blockByHash?.confirmationSignatures.has(newSignature)).to
                     .be.true;
                 expect(blockByCoords?.confirmationSignatures.has(newSignature))
-                    .to.be.true;
+                    .to.be.false;
 
-                // Verify they are the same object reference
-                expect(blockByHash).to.equal(blockByCoords);
+                expect(blockByHash).to.not.equal(blockByCoords);
             });
         });
     });
@@ -509,7 +519,7 @@ describe("ForkIdToMaxHeightMap", () => {
     }
 
     describe("ADDING - Max Height Updates", () => {
-        it("should update max height when adding block with higher height", () => {
+        it("should update max height when adding block with higher height", async () => {
             // Add block at height 5
             const blockConfirmation1 = createBlockWithCoordinates(forkId, 5);
             storage.storeBlock(Block.fromBlockConfirmation(blockConfirmation1));
@@ -535,7 +545,7 @@ describe("ForkIdToMaxHeightMap", () => {
             expect(heighestBlockData.coordinates.height).to.equal(10);
         });
 
-        it("should not update max height when adding block with lower height", () => {
+        it("should not update max height when adding block with lower height", async () => {
             // Add block at height 10 first
             storage.storeBlock(
                 Block.fromBlockConfirmation(
@@ -566,7 +576,7 @@ describe("ForkIdToMaxHeightMap", () => {
             expect(secondBlockData.coordinates.height).to.equal(5);
         });
 
-        it("should handle multiple forks independently", () => {
+        it("should handle multiple forks independently", async () => {
             const forkId1 = factory.hash();
             const forkId2 = factory.hash();
 
@@ -586,7 +596,7 @@ describe("ForkIdToMaxHeightMap", () => {
     });
 
     describe("REMOVING - Max Height Updates", () => {
-        it("should update max height when removing the highest block", () => {
+        it("should update max height when removing the highest block", async () => {
             // Add blocks at heights 0, 5, 10
             for (const height of [0, 5, 10]) {
                 const blockConfirmation = createBlockWithCoordinates(
@@ -613,7 +623,7 @@ describe("ForkIdToMaxHeightMap", () => {
             ).to.equal(0);
         });
 
-        it("should not update max height when removing non-highest block", () => {
+        it("should not update max height when removing non-highest block", async () => {
             // Add blocks at heights 0, 5, 10
             for (const height of [0, 5, 10]) {
                 const blockConfirmation = createBlockWithCoordinates(
@@ -640,7 +650,7 @@ describe("ForkIdToMaxHeightMap", () => {
             ).to.equal(0);
         });
 
-        it("should handle removing the only block in a fork", () => {
+        it("should handle removing the only block in a fork", async () => {
             // Add single block at height 5
             const blockConfirmation = createBlockWithCoordinates(forkId, 5);
             storage.storeBlock(Block.fromBlockConfirmation(blockConfirmation));
@@ -654,12 +664,12 @@ describe("ForkIdToMaxHeightMap", () => {
     });
 
     describe("GETTING - getIterator", () => {
-        it("should return empty when no blocks exist on fork", () => {
+        it("should return empty when no blocks exist on fork", async () => {
             const block = storage.getIterator(forkId).next().value;
             expect(block).to.be.undefined;
         });
 
-        it("should return blocks in correct order", () => {
+        it("should return blocks in correct order", async () => {
             // Add blocks in random order
             for (const height of [10, 0, 5]) {
                 const blockConfirmation = createBlockWithCoordinates(

--- a/test/storage/DisputeStorage.test.ts
+++ b/test/storage/DisputeStorage.test.ts
@@ -29,16 +29,16 @@ describe("DisputeStorage", () => {
     });
 
     describe("CREATE - storeDispute()", () => {
-        it("should store SignedDispute with auto-computed hash and return hash with empty signatures", () => {
+        it("should store SignedDispute with auto-computed hash and return hash with empty signatures", async () => {
             const hash = storage.storeDispute(mockSignedDispute);
 
             expect(hash).to.equal(mockDisputeHash);
             const stored = storage.getDisputeConfirmation(hash);
-            expect(stored?.signedDispute).to.equal(mockSignedDispute);
+            expect(stored?.signedDispute).to.deep.equal(mockSignedDispute);
             expect(stored?.signatures).to.deep.equal([]);
         });
 
-        it("should store SignedDispute with provided hash", () => {
+        it("should store SignedDispute with provided hash", async () => {
             const customHash = ethers.hexlify(ethers.randomBytes(32));
             const hash = storage.storeDispute(mockSignedDispute, {
                 hash: customHash
@@ -46,11 +46,11 @@ describe("DisputeStorage", () => {
 
             expect(hash).to.equal(customHash);
             const stored = storage.getDisputeConfirmation(customHash);
-            expect(stored?.signedDispute).to.equal(mockSignedDispute);
+            expect(stored?.signedDispute).to.deep.equal(mockSignedDispute);
             expect(stored?.signatures).to.deep.equal([]);
         });
 
-        it("should return same hash on duplicate insert and preserve existing signatures", () => {
+        it("should return same hash on duplicate insert and preserve existing signatures", async () => {
             // First store with empty signatures
             const hash1 = storage.storeDispute(mockSignedDispute);
             expect(hash1).to.equal(mockDisputeHash);
@@ -72,17 +72,17 @@ describe("DisputeStorage", () => {
     });
 
     describe("CREATE - storeDisputeConfirmation()", () => {
-        it("should store DisputeConfirmation with auto-computed hash", () => {
+        it("should store DisputeConfirmation with auto-computed hash", async () => {
             const hash = storage.storeDisputeConfirmation(
                 mockDisputeConfirmation
             );
 
             expect(hash).to.equal(mockDisputeHash);
             const stored = storage.getDisputeConfirmation(hash);
-            expect(stored).to.equal(mockDisputeConfirmation);
+            expect(stored).to.deep.equal(mockDisputeConfirmation);
         });
 
-        it("should store DisputeConfirmation with provided hash", () => {
+        it("should store DisputeConfirmation with provided hash", async () => {
             const customHash = ethers.hexlify(ethers.randomBytes(32));
             const hash = storage.storeDisputeConfirmation(
                 mockDisputeConfirmation,
@@ -91,10 +91,10 @@ describe("DisputeStorage", () => {
 
             expect(hash).to.equal(customHash);
             const stored = storage.getDisputeConfirmation(customHash);
-            expect(stored).to.equal(mockDisputeConfirmation);
+            expect(stored).to.deep.equal(mockDisputeConfirmation);
         });
 
-        it("should merge signatures with deduplication on duplicate insert", () => {
+        it("should merge signatures with deduplication on duplicate insert", async () => {
             // Create shared and unique signatures
             const sharedSignature = sig();
             const uniqueSignature1 = sig();
@@ -138,7 +138,7 @@ describe("DisputeStorage", () => {
             expect(signatureSet.size).to.equal(stored?.signatures.length);
         });
 
-        it("should handle empty signatures array", () => {
+        it("should handle empty signatures array", async () => {
             const disputeWithEmptySignatures = {
                 ...mockDisputeConfirmation,
                 signatures: []
@@ -152,7 +152,7 @@ describe("DisputeStorage", () => {
             expect(stored?.signatures).to.deep.equal([]);
         });
 
-        it("should preserve original SignedDispute when merging signatures", () => {
+        it("should reject an incompatible SignedDispute for the same hash", () => {
             // Store first dispute
             const hash1 = storage.storeDisputeConfirmation(
                 mockDisputeConfirmation
@@ -166,33 +166,25 @@ describe("DisputeStorage", () => {
             };
 
             // Store second dispute with same hash
-            const hash2 = storage.storeDisputeConfirmation(secondDispute, {
-                hash: hash1
-            });
-
-            expect(hash1).to.equal(hash2);
-
-            const stored = storage.getDisputeConfirmation(hash1);
-            // Should preserve the original SignedDispute
-            expect(stored?.signedDispute).to.equal(mockSignedDispute);
-            // Should have merged signatures
-            expect(stored?.signatures.length).to.be.greaterThan(
-                mockDisputeConfirmation.signatures.length
-            );
+            expect(() =>
+                storage.storeDisputeConfirmation(secondDispute, {
+                    hash: hash1
+                })
+            ).to.throw(`Incompatible dispute confirmation for ${hash1}`);
         });
     });
 
     describe("READ - getDisputeConfirmation()", () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             storage.storeDisputeConfirmation(mockDisputeConfirmation);
         });
 
-        it("should get dispute confirmation by hash", () => {
+        it("should get dispute confirmation by hash", async () => {
             const result = storage.getDisputeConfirmation(mockDisputeHash);
-            expect(result).to.equal(mockDisputeConfirmation);
+            expect(result).to.deep.equal(mockDisputeConfirmation);
         });
 
-        it("should return undefined for non-existent dispute", () => {
+        it("should return undefined for non-existent dispute", async () => {
             const nonExistentHash = ethers.hexlify(ethers.randomBytes(32));
             expect(storage.getDisputeConfirmation(nonExistentHash)).to.be
                 .undefined;
@@ -200,7 +192,7 @@ describe("DisputeStorage", () => {
     });
 
     describe("Edge cases and behavior", () => {
-        it("should handle multiple different disputes", () => {
+        it("should handle multiple different disputes", async () => {
             const dispute1 = factory.signedDispute();
             const dispute2 = factory.signedDispute();
             const dispute3 = factory.signedDispute();
@@ -217,16 +209,16 @@ describe("DisputeStorage", () => {
             // All disputes should be retrievable
             expect(
                 storage.getDisputeConfirmation(hash1)?.signedDispute
-            ).to.equal(dispute1);
+            ).to.deep.equal(dispute1);
             expect(
                 storage.getDisputeConfirmation(hash2)?.signedDispute
-            ).to.equal(dispute2);
+            ).to.deep.equal(dispute2);
             expect(
                 storage.getDisputeConfirmation(hash3)?.signedDispute
-            ).to.equal(dispute3);
+            ).to.deep.equal(dispute3);
         });
 
-        it("should maintain signatures across different storage methods", () => {
+        it("should maintain signatures across different storage methods", async () => {
             // Store with storeDispute first
             const hash1 = storage.storeDispute(mockSignedDispute);
 
@@ -245,7 +237,7 @@ describe("DisputeStorage", () => {
             expect(stored?.signatures).to.have.lengthOf(1);
         });
 
-        it("should handle large signature arrays efficiently", () => {
+        it("should handle large signature arrays efficiently", async () => {
             const largeSignatureArray = Array.from({ length: 100 }, () =>
                 sig()
             );

--- a/test/storage/EventSyncStorage.test.ts
+++ b/test/storage/EventSyncStorage.test.ts
@@ -5,7 +5,7 @@ import { EventSyncStorage } from "@/storage/EventSyncStorage";
 import { ChannelId } from "@/types/types";
 
 describe("EventSyncStorage", () => {
-    it("stores independent monotonic watermarks per normalized channel", () => {
+    it("stores independent monotonic watermarks per normalized channel", async () => {
         const storage = new EventSyncStorage();
         const channelA = ethers.id("event-sync-a") as ChannelId;
         const channelB = ethers.id("event-sync-b") as ChannelId;
@@ -21,7 +21,7 @@ describe("EventSyncStorage", () => {
         expect(storage.getLatestProcessedBlock(channelB)).to.equal(15);
     });
 
-    it("has no cursor until an event-bearing block is published", () => {
+    it("has no cursor until an event-bearing block is published", async () => {
         const storage = new EventSyncStorage();
         const channelId = ethers.id("event-sync-empty") as ChannelId;
 

--- a/test/storage/ExitChannelBlockStorage.test.ts
+++ b/test/storage/ExitChannelBlockStorage.test.ts
@@ -25,19 +25,21 @@ describe("MessageBlockStorage - outbound behavior", () => {
     });
 
     describe("store()", () => {
-        it("stores block with computed hash", () => {
+        it("stores block with computed hash", async () => {
             const hash = storage.store(mockExitBlock);
             expect(hash).to.equal(mockBlockHash);
-            expect(storage.getMessageBlock(hash)).to.equal(mockExitBlock);
+            expect(storage.getMessageBlock(hash)).to.deep.equal(mockExitBlock);
         });
 
-        it("accepts provided hash", () => {
+        it("accepts provided hash", async () => {
             const customHash = factory.hash();
-            const hash = storage.store(mockExitBlock, { hash: customHash });
+            const hash = storage.store(mockExitBlock, {
+                hash: customHash
+            });
             expect(hash).to.equal(customHash);
         });
 
-        it("ignores duplicate stores", () => {
+        it("ignores duplicate stores", async () => {
             const hash1 = storage.store(mockExitBlock);
             const hash2 = storage.store(mockExitBlock);
             expect(hash1).to.equal(hash2);
@@ -45,21 +47,21 @@ describe("MessageBlockStorage - outbound behavior", () => {
     });
 
     describe("read operations", () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             storage.store(mockExitBlock);
         });
 
-        it("returns undefined for unknown hashes", () => {
+        it("returns undefined for unknown hashes", async () => {
             const randomHash = factory.hash();
             expect(storage.getMessageBlock(randomHash)).to.be.undefined;
         });
 
-        it("retrieves block by hash", () => {
+        it("retrieves block by hash", async () => {
             const block = storage.getMessageBlock(mockBlockHash);
-            expect(block).to.equal(mockExitBlock);
+            expect(block).to.deep.equal(mockExitBlock);
         });
 
-        it("returns ordered message blocks when iterating by range", () => {
+        it("returns ordered message blocks when iterating by range", async () => {
             const nextBlock = {
                 ...mockExitBlock,
                 previousBlockHash: mockBlockHash,
@@ -77,7 +79,7 @@ describe("MessageBlockStorage - outbound behavior", () => {
     });
 
     describe("latest block helpers", () => {
-        it("returns the most recent block", () => {
+        it("returns the most recent block", async () => {
             const baseHash = storage.store(mockExitBlock);
 
             const newerBlock = {
@@ -95,7 +97,7 @@ describe("MessageBlockStorage - outbound behavior", () => {
             expect(latestBlocks[0]).to.deep.equal(newerBlock);
         });
 
-        it("returns blocks sorted from newest to oldest when no limit is provided", () => {
+        it("returns blocks sorted from newest to oldest when no limit is provided", async () => {
             storage.store(mockExitBlock);
             const followingBlock = {
                 ...mockExitBlock,

--- a/test/storage/JoinChannelBlockStorage.test.ts
+++ b/test/storage/JoinChannelBlockStorage.test.ts
@@ -29,27 +29,27 @@ describe("MessageBlockStorage - inbound blocks", () => {
     });
 
     describe("store()", () => {
-        it("stores block with computed hash", () => {
+        it("stores block with computed hash", async () => {
             const hash = storage.store(mockMessageBlock);
             expect(hash).to.equal(mockBlockHash);
 
             const storedBlock = storage.getMessageBlock(hash);
-            expect(storedBlock).to.equal(mockMessageBlock);
+            expect(storedBlock).to.deep.equal(mockMessageBlock);
         });
 
-        it("respects provided hash override", () => {
+        it("respects provided hash override", async () => {
             const customHash = factory.hash();
             const hash = storage.store(mockMessageBlock, {
                 hash: customHash
             });
 
             expect(hash).to.equal(customHash);
-            expect(storage.getMessageBlock(customHash)).to.equal(
+            expect(storage.getMessageBlock(customHash)).to.deep.equal(
                 mockMessageBlock
             );
         });
 
-        it("ignores metadata on duplicate store", () => {
+        it("ignores metadata on duplicate store", async () => {
             const hash1 = storage.store(mockMessageBlock);
             const hash2 = storage.store(mockMessageBlock);
             expect(hash1).to.equal(hash2);
@@ -57,16 +57,16 @@ describe("MessageBlockStorage - inbound blocks", () => {
     });
 
     describe("read operations", () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             storage.store(mockMessageBlock);
         });
 
-        it("returns undefined for unknown hashes", () => {
+        it("returns undefined for unknown hashes", async () => {
             const randomHash = factory.hash();
             expect(storage.getMessageBlock(randomHash)).to.be.undefined;
         });
 
-        it("retrieves ordered entries in range", () => {
+        it("retrieves ordered entries in range", async () => {
             const secondBlock = {
                 ...mockMessageBlock,
                 previousBlockHash: mockBlockHash,
@@ -85,13 +85,13 @@ describe("MessageBlockStorage - inbound blocks", () => {
     });
 
     describe("latest block helpers", () => {
-        it("returns undefined when storage is empty", () => {
+        it("returns undefined when storage is empty", async () => {
             expect(storage.getLatestMessageBlock()).to.be.undefined;
             expect(storage.getLatestMessageBlocks()).to.deep.equal([]);
             expect(storage.getLatestBlockHeight()).to.be.undefined;
         });
 
-        it("tracks the highest block height even when stored out of order", () => {
+        it("tracks the highest block height even when stored out of order", async () => {
             const genesisHash = storage.store(mockMessageBlock);
 
             const middleBlock = {

--- a/test/storage/ParticipantSetChangeStorage.test.ts
+++ b/test/storage/ParticipantSetChangeStorage.test.ts
@@ -15,7 +15,7 @@ describe("ParticipantSetChangeStorage", () => {
     });
 
     describe("CREATE - storeChangePoint()", () => {
-        it("should store change point and return the set", () => {
+        it("should store change point and return the set", async () => {
             const blockHeight: BlockHeight = 100;
             const result = storage.storeChangePoint(forkId1, blockHeight);
 
@@ -24,7 +24,7 @@ describe("ParticipantSetChangeStorage", () => {
             expect(result.size).to.equal(1);
         });
 
-        it("should insert across different forks", () => {
+        it("should insert across different forks", async () => {
             const height1: BlockHeight = 100;
             const height2: BlockHeight = 200;
 
@@ -37,7 +37,7 @@ describe("ParticipantSetChangeStorage", () => {
             expect(result2.has(height1)).to.be.false;
         });
 
-        it("should handle duplicate insertions", () => {
+        it("should handle duplicate insertions", async () => {
             const blockHeight: BlockHeight = 100;
 
             const result1 = storage.storeChangePoint(forkId1, blockHeight);
@@ -45,16 +45,17 @@ describe("ParticipantSetChangeStorage", () => {
 
             expect(result1.size).to.equal(1);
             expect(result2.size).to.equal(1);
-            expect(result1).to.equal(result2);
+            expect(result1).to.deep.equal(result2);
+            expect(result1).to.not.equal(result2);
             expect(result1.has(blockHeight)).to.be.true;
         });
 
-        it("should add multiple change points to same fork", () => {
+        it("should add multiple change points to same fork", async () => {
             const heights = [100, 200, 300];
 
-            heights.forEach((height) => {
+            for (const height of heights) {
                 storage.storeChangePoint(forkId1, height);
-            });
+            }
 
             const result = storage.storeChangePoint(forkId1, 400);
             expect(result.size).to.equal(4);
@@ -66,17 +67,17 @@ describe("ParticipantSetChangeStorage", () => {
     });
 
     describe("READ - getChangePointsInRange()", () => {
-        beforeEach(() => {
-            [100, 200, 300, 400, 500].forEach((height) => {
+        beforeEach(async () => {
+            for (const height of [100, 200, 300, 400, 500]) {
                 storage.storeChangePoint(forkId1, height);
-            });
-            [150, 250].forEach((height) => {
+            }
+            for (const height of [150, 250]) {
                 storage.storeChangePoint(forkId2, height);
-            });
+            }
         });
 
         describe("Non-existent fork", () => {
-            it("should return empty array for non-existent fork id", () => {
+            it("should return empty array for non-existent fork id", async () => {
                 const result =
                     storage.getChangePointsInRange("non-existent-fork");
                 expect(result).to.deep.equal([]);
@@ -84,17 +85,17 @@ describe("ParticipantSetChangeStorage", () => {
         });
 
         describe("Get all change points", () => {
-            it("should get all when both start and end are undefined", () => {
+            it("should get all when both start and end are undefined", async () => {
                 const result = storage.getChangePointsInRange(forkId1);
                 expect(result).to.have.lengthOf(5);
                 expect(result).to.include.members([100, 200, 300, 400, 500]);
             });
 
-            it("should return sorted results when getting all", () => {
+            it("should return sorted results when getting all", async () => {
                 const newFork = "unsorted-fork";
-                [300, 100, 500, 200, 400].forEach((height) => {
+                for (const height of [300, 100, 500, 200, 400]) {
                     storage.storeChangePoint(newFork, height);
-                });
+                }
 
                 const result = storage.getChangePointsInRange(newFork);
                 expect(result).to.deep.equal([100, 200, 300, 400, 500]);
@@ -102,7 +103,7 @@ describe("ParticipantSetChangeStorage", () => {
         });
 
         describe("Range queries with start undefined", () => {
-            it("should get all from beginning when start is undefined", () => {
+            it("should get all from beginning when start is undefined", async () => {
                 const result = storage.getChangePointsInRange(
                     forkId1,
                     undefined,
@@ -111,7 +112,7 @@ describe("ParticipantSetChangeStorage", () => {
                 expect(result).to.deep.equal([100, 200, 300]);
             });
 
-            it("should get single element when start undefined and end is just after first", () => {
+            it("should get single element when start undefined and end is just after first", async () => {
                 const result = storage.getChangePointsInRange(
                     forkId1,
                     undefined,
@@ -122,19 +123,19 @@ describe("ParticipantSetChangeStorage", () => {
         });
 
         describe("Range queries with end undefined", () => {
-            it("should get all from start to end when end is undefined", () => {
+            it("should get all from start to end when end is undefined", async () => {
                 const result = storage.getChangePointsInRange(forkId1, 250);
                 expect(result).to.deep.equal([300, 400, 500]);
             });
 
-            it("should get all from exact match when end undefined", () => {
+            it("should get all from exact match when end undefined", async () => {
                 const result = storage.getChangePointsInRange(forkId1, 300);
                 expect(result).to.deep.equal([300, 400, 500]);
             });
         });
 
         describe("Invalid range scenarios", () => {
-            it("should return empty array when end <= start", () => {
+            it("should return empty array when end <= start", async () => {
                 const result1 = storage.getChangePointsInRange(
                     forkId1,
                     300,
@@ -152,12 +153,12 @@ describe("ParticipantSetChangeStorage", () => {
         });
 
         describe("Range boundaries", () => {
-            it("should handle start < actual smallest block height", () => {
+            it("should handle start < actual smallest block height", async () => {
                 const result = storage.getChangePointsInRange(forkId1, 50, 250);
                 expect(result).to.deep.equal([100, 200]);
             });
 
-            it("should handle end > actual largest block height", () => {
+            it("should handle end > actual largest block height", async () => {
                 const result = storage.getChangePointsInRange(
                     forkId1,
                     350,
@@ -166,7 +167,7 @@ describe("ParticipantSetChangeStorage", () => {
                 expect(result).to.deep.equal([400, 500]);
             });
 
-            it("should handle both start and end outside actual range", () => {
+            it("should handle both start and end outside actual range", async () => {
                 const result1 = storage.getChangePointsInRange(forkId1, 50, 80);
                 expect(result1).to.deep.equal([]);
 
@@ -180,7 +181,7 @@ describe("ParticipantSetChangeStorage", () => {
         });
 
         describe("Range inclusivity/exclusivity", () => {
-            it("should be inclusive of start and inclusive of end", () => {
+            it("should be inclusive of start and inclusive of end", async () => {
                 const result = storage.getChangePointsInRange(
                     forkId1,
                     200,
@@ -189,7 +190,7 @@ describe("ParticipantSetChangeStorage", () => {
                 expect(result).to.deep.equal([200, 300, 400]);
             });
 
-            it("should include exact start value", () => {
+            it("should include exact start value", async () => {
                 const result = storage.getChangePointsInRange(
                     forkId1,
                     300,
@@ -198,7 +199,7 @@ describe("ParticipantSetChangeStorage", () => {
                 expect(result).to.deep.equal([300, 400]);
             });
 
-            it("should include exact end value", () => {
+            it("should include exact end value", async () => {
                 const result = storage.getChangePointsInRange(
                     forkId1,
                     200,
@@ -207,7 +208,7 @@ describe("ParticipantSetChangeStorage", () => {
                 expect(result).to.deep.equal([200, 300]);
             });
 
-            it("should work with single-element ranges", () => {
+            it("should work with single-element ranges", async () => {
                 const result = storage.getChangePointsInRange(
                     forkId1,
                     300,
@@ -216,7 +217,7 @@ describe("ParticipantSetChangeStorage", () => {
                 expect(result).to.deep.equal([300]);
             });
 
-            it("should return empty for gap ranges", () => {
+            it("should return empty for gap ranges", async () => {
                 const result = storage.getChangePointsInRange(
                     forkId1,
                     350,

--- a/test/storage/QueueStorage.test.ts
+++ b/test/storage/QueueStorage.test.ts
@@ -40,13 +40,13 @@ describe("QueueStorage", () => {
     });
 
     describe("Queue Operations", () => {
-        it("should queue blocks", () => {
+        it("should queue blocks", async () => {
             const hash = storage.queueBlock(mockBlock);
             expect(storage.isBlockQueued(mockBlock)).to.be.true;
             expect(storage.isBlockQueued(mockBlock, { hash })).to.be.true;
         });
 
-        it("should queue multiple blocks on same coordinates", () => {
+        it("should queue multiple blocks on same coordinates", async () => {
             const block1 = Block.fromSignedBlock(
                 factory.signedBlock({
                     encodedBlock: factory
@@ -90,7 +90,7 @@ describe("QueueStorage", () => {
     });
 
     describe("Signature Merging", () => {
-        it("should merge signatures when queueing same block multiple times", () => {
+        it("should merge signatures when queueing same block multiple times", async () => {
             const sharedSig = sig();
             const uniqueSig1 = sig();
             const uniqueSig2 = sig();
@@ -119,7 +119,7 @@ describe("QueueStorage", () => {
             );
         });
 
-        it("should merge signatures with existing queued block", () => {
+        it("should merge signatures with existing queued block", async () => {
             storage.queueBlock(mockBlock);
             storage.queueBlock(
                 Block.fromBlockConfirmation({
@@ -133,7 +133,7 @@ describe("QueueStorage", () => {
             expect(dequeued[0].block.confirmationSignatures.size).to.equal(2);
         });
 
-        it("should merge on-chain timestamp when queueing same block again", () => {
+        it("should merge on-chain timestamp when queueing same block again", async () => {
             const onChainTimestamp = 1234567890;
             storage.queueBlock(mockBlock);
 
@@ -148,7 +148,7 @@ describe("QueueStorage", () => {
             );
         });
 
-        it("bounds attribution and retains an early-tracked source under a later junk flood", () => {
+        it("bounds attribution and retains an early-tracked source under a later junk flood", async () => {
             // An honest supplier is tracked first, then a byzantine peer floods
             // the same hash from many distinct addresses.
             const honest = factory.randomAddress();
@@ -175,7 +175,7 @@ describe("QueueStorage", () => {
             expect(storage.isBlockQueued(mockBlock)).to.equal(true);
         });
 
-        it("junk-first: a flood that fills the cap first still lets a later valid copy process", () => {
+        it("junk-first: a flood that fills the cap first still lets a later valid copy process", async () => {
             // Byzantine peer floods the hash to the cap BEFORE any honest copy.
             let hash!: Hash;
             for (let i = 0; i < 300; i++) {
@@ -200,7 +200,7 @@ describe("QueueStorage", () => {
             expect(dequeued[0].block.hash).to.equal(mockBlock.hash);
         });
 
-        it("should overwrite on-chain timestamp when queueing same block again", () => {
+        it("should overwrite on-chain timestamp when queueing same block again", async () => {
             storage.queueBlock(mockBlock);
 
             storage.queueBlock(Block.fromSignedBlock(mockSignedBlock, 20));
@@ -211,7 +211,7 @@ describe("QueueStorage", () => {
             expect(dequeued[0].block.onChainTimestamp).to.equal(30);
         });
 
-        it("should not mutate queue when checking queued duplicate", () => {
+        it("should not mutate queue when checking queued duplicate", async () => {
             const onChainTimestamp = 1234567890;
             storage.queueBlock(mockBlock);
 
@@ -226,7 +226,7 @@ describe("QueueStorage", () => {
             expect(dequeued[0].block.onChainTimestamp).to.equal(undefined);
         });
 
-        it("should merge on-chain timestamp through storage proxy", () => {
+        it("should merge on-chain timestamp through storage proxy", async () => {
             const storageWithProxy = new Storage();
             const onChainTimestamp = 1234567890;
             storageWithProxy.queues.queueBlock(mockBlock);
@@ -249,7 +249,7 @@ describe("QueueStorage", () => {
     });
 
     describe("Dequeue Operations", () => {
-        it("should allow multiple dequeues on different coordinates", () => {
+        it("should allow multiple dequeues on different coordinates", async () => {
             const block1 = Block.fromSignedBlock(
                 factory.signedBlock({
                     encodedBlock: factory
@@ -292,7 +292,7 @@ describe("QueueStorage", () => {
             expect(dequeued2[0].block.equals(block2)).to.be.true;
         });
 
-        it("should dequeue the lowest eligible height by priority", () => {
+        it("should dequeue the lowest eligible height by priority", async () => {
             const block1 = Block.fromSignedBlock(
                 factory.signedBlock({
                     encodedBlock: factory
@@ -335,7 +335,7 @@ describe("QueueStorage", () => {
             expect(dequeued[0].block.equals(block1)).to.be.true;
         });
 
-        it("should track source peers and signature attribution", () => {
+        it("should track source peers and signature attribution", async () => {
             const peerAddress = ethers.Wallet.createRandom().address;
             const confirmationSignature = sig();
             const block = Block.fromBlockConfirmation({
@@ -355,7 +355,7 @@ describe("QueueStorage", () => {
             ).to.equal(true);
         });
 
-        it("should attribute only the signatures each sender's copy carried", () => {
+        it("should attribute only the signatures each sender's copy carried", async () => {
             const senderA = ethers.Wallet.createRandom().address;
             const senderB = ethers.Wallet.createRandom().address;
             const straySig = sig();
@@ -393,7 +393,7 @@ describe("QueueStorage", () => {
             );
         });
 
-        it("should return empty on subsequent dequeues", () => {
+        it("should return empty on subsequent dequeues", async () => {
             storage.queueBlock(mockBlock);
             expect(
                 storage.tryDequeueAt(mockForkId, mockHeight)
@@ -405,7 +405,7 @@ describe("QueueStorage", () => {
     });
 
     describe("Restore Entry", () => {
-        it("should restore a dequeued entry with its attribution intact", () => {
+        it("should restore a dequeued entry with its attribution intact", async () => {
             const senderAddress = ethers.Wallet.createRandom().address;
             const confirmationSignature = sig();
             const block = Block.fromBlockConfirmation({
@@ -433,7 +433,7 @@ describe("QueueStorage", () => {
             ).to.have.lengthOf(1);
         });
 
-        it("should merge a restored entry with a copy queued meanwhile", () => {
+        it("should merge a restored entry with a copy queued meanwhile", async () => {
             const senderA = ethers.Wallet.createRandom().address;
             const senderB = ethers.Wallet.createRandom().address;
             const sigA = sig();
@@ -481,7 +481,7 @@ describe("QueueStorage", () => {
             storageWithProxy = new Storage();
         });
 
-        it("should isolate modifications from outside objects", () => {
+        it("should isolate modifications from outside objects", async () => {
             const originalConfirmation = factory.blockConfirmation({
                 signedBlock: mockSignedBlock,
                 signatures: [sig(), sig()]
@@ -512,7 +512,7 @@ describe("QueueStorage", () => {
             ).to.be.greaterThan(originalCount);
         });
 
-        it("should isolate modifications to dequeued objects", () => {
+        it("should isolate modifications to dequeued objects", async () => {
             const confirmation = factory.blockConfirmation({
                 signedBlock: mockSignedBlock,
                 signatures: [sig()]

--- a/test/storage/StateMachineStateStorage.test.ts
+++ b/test/storage/StateMachineStateStorage.test.ts
@@ -19,7 +19,7 @@ describe("StateMachineStateStorage", () => {
     });
 
     describe("Basic operations", () => {
-        it("should store state with auto-computed hash", () => {
+        it("should store state with auto-computed hash", async () => {
             const hash = storage.storeStateMachineState(mockEncodedState);
             expect(hash).to.equal(mockStateHash);
 
@@ -27,7 +27,7 @@ describe("StateMachineStateStorage", () => {
             expect(stored).to.equal(mockEncodedState);
         });
 
-        it("should store state with provided hash", () => {
+        it("should store state with provided hash", async () => {
             const customHash = ethers.hexlify(ethers.randomBytes(32));
             const hash = storage.storeStateMachineState(mockEncodedState, {
                 hash: customHash
@@ -38,13 +38,13 @@ describe("StateMachineStateStorage", () => {
             expect(stored).to.equal(mockEncodedState);
         });
 
-        it("should get state by hash", () => {
+        it("should get state by hash", async () => {
             storage.storeStateMachineState(mockEncodedState);
             const result = storage.getStateMachineState(mockStateHash);
             expect(result).to.equal(mockEncodedState);
         });
 
-        it("should return undefined for non-existent hash", () => {
+        it("should return undefined for non-existent hash", async () => {
             const nonExistentHash = ethers.hexlify(ethers.randomBytes(32));
             expect(storage.getStateMachineState(nonExistentHash)).to.be
                 .undefined;
@@ -58,7 +58,7 @@ describe("StateMachineStateStorage", () => {
         let stateMachineStateHash: Hash;
         let encodedStateMachineState: Bytes;
 
-        beforeEach(() => {
+        beforeEach(async () => {
             mainStorage = new Storage();
 
             // Create encoded state machine state
@@ -79,20 +79,22 @@ describe("StateMachineStateStorage", () => {
             forkId = genesisSnapshot.forkID;
 
             // Store the genesis snapshot
-            mainStorage.stateSnapshots.storeStateSnapshot(genesisSnapshot);
+            await mainStorage.stateSnapshots.storeStateSnapshot(
+                genesisSnapshot
+            );
 
             // Store the encoded state machine state
-            mainStorage.stateMachineStates.storeStateMachineState(
+            await mainStorage.stateMachineStates.storeStateMachineState(
                 encodedStateMachineState
             );
         });
 
-        it("should return correct bytes for correct fork ID", () => {
+        it("should return correct bytes for correct fork ID", async () => {
             const result = mainStorage.getGenesisStateMachineState(forkId);
             expect(result).to.equal(encodedStateMachineState);
         });
 
-        it("should return undefined for incorrect fork ID", () => {
+        it("should return undefined for incorrect fork ID", async () => {
             const incorrectForkId = ethers.hexlify(ethers.randomBytes(32));
             const result =
                 mainStorage.getGenesisStateMachineState(incorrectForkId);
@@ -100,7 +102,7 @@ describe("StateMachineStateStorage", () => {
             expect(result).to.be.undefined;
         });
 
-        it("should return undefined when genesis snapshot exists but stateMachineStateHash is not in storage", () => {
+        it("should return undefined when genesis snapshot exists but stateMachineStateHash is not in storage", async () => {
             // Create a new genesis snapshot with a different stateMachineStateHash
             const baseSnapshot = factory.stateSnapshot();
             const orphanedSnapshotStruct = baseSnapshot.toStruct();

--- a/test/storage/StateSnapshotStorage.test.ts
+++ b/test/storage/StateSnapshotStorage.test.ts
@@ -24,7 +24,7 @@ describe("StateSnapshotStorage", () => {
 
     describe("CREATE - storeStateSnapshot()", () => {
         describe("Auto-computed hash", () => {
-            it("should store snapshot with computed hash", () => {
+            it("should store snapshot with computed hash", async () => {
                 const hash = storage.storeStateSnapshot(stateSnapshot);
                 expect(hash).to.equal(stateSnapshot.hash);
 
@@ -34,7 +34,7 @@ describe("StateSnapshotStorage", () => {
                 );
             });
 
-            it("should store genesis snapshot and auto-add to genesis mapping", () => {
+            it("should store genesis snapshot and auto-add to genesis mapping", async () => {
                 const hash = storage.storeStateSnapshot(genesisStateSnapshot);
                 expect(hash).to.equal(genesisStateSnapshot.hash);
 
@@ -55,7 +55,7 @@ describe("StateSnapshotStorage", () => {
         });
 
         describe("Provided hash", () => {
-            it("should store snapshot with provided hash", () => {
+            it("should store snapshot with provided hash", async () => {
                 const customHash = ethers.hexlify(ethers.randomBytes(32));
                 const hash = storage.storeStateSnapshot(stateSnapshot, {
                     hash: customHash
@@ -68,7 +68,7 @@ describe("StateSnapshotStorage", () => {
                 );
             });
 
-            it("should store genesis snapshot with provided hash and auto-add to genesis mapping", () => {
+            it("should store genesis snapshot with provided hash and auto-add to genesis mapping", async () => {
                 const customHash = ethers.hexlify(ethers.randomBytes(32));
                 const hash = storage.storeStateSnapshot(genesisStateSnapshot, {
                     hash: customHash
@@ -93,23 +93,27 @@ describe("StateSnapshotStorage", () => {
     });
 
     describe("READ operations", () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             storage.storeStateSnapshot(stateSnapshot);
             storage.storeStateSnapshot(genesisStateSnapshot);
         });
 
-        it("should get snapshot by hash", () => {
+        it("should get snapshot by hash", async () => {
             const result = storage.getStateSnapshotByHash(stateSnapshot.hash);
             expect(result?.toStruct()).to.deep.equal(stateSnapshot.toStruct());
         });
 
-        it("should return undefined for non-existent snapshot hash", () => {
+        it("should return the number of stored snapshots", async () => {
+            expect(storage.getSnapshotCount()).to.equal(2);
+        });
+
+        it("should return undefined for non-existent snapshot hash", async () => {
             const nonExistentHash = ethers.hexlify(ethers.randomBytes(32));
             expect(storage.getStateSnapshotByHash(nonExistentHash)).to.be
                 .undefined;
         });
 
-        it("should get genesis snapshot by forkId", () => {
+        it("should get genesis snapshot by forkId", async () => {
             const result = storage.getGenesisSnapshotByForkId(
                 genesisStateSnapshot.forkID
             );
@@ -118,7 +122,7 @@ describe("StateSnapshotStorage", () => {
             );
         });
 
-        it("should return undefined for non-existent genesis forkId", () => {
+        it("should return undefined for non-existent genesis forkId", async () => {
             const nonExistentForkId = ethers.hexlify(ethers.randomBytes(32));
             expect(storage.getGenesisSnapshotByForkId(nonExistentForkId)).to.be
                 .undefined;
@@ -126,12 +130,12 @@ describe("StateSnapshotStorage", () => {
     });
 
     describe("Genesis snapshot logic", () => {
-        it("should identify genesis snapshot correctly", () => {
+        it("should identify genesis snapshot correctly", async () => {
             expect(genesisStateSnapshot.isGenesis).to.be.true;
             expect(stateSnapshot.isGenesis).to.be.false;
         });
 
-        it("should not non-genesis snapshots in genesis mapping", () => {
+        it("should not non-genesis snapshots in genesis mapping", async () => {
             // Store non-genesis snapshot
             storage.storeStateSnapshot(stateSnapshot);
 

--- a/test/storage/Storage.test.ts
+++ b/test/storage/Storage.test.ts
@@ -49,7 +49,7 @@ describe("Storage", () => {
             });
         });
 
-        beforeEach(() => {
+        beforeEach(async () => {
             storage = new Storage();
 
             // Store genesis snapshot
@@ -64,7 +64,7 @@ describe("Storage", () => {
             );
         });
 
-        it("should return genesis state snapshot when height < 0", () => {
+        it("should return genesis state snapshot when height < 0", async () => {
             const coordinates: BlockCoordinates = {
                 forkId: forkId,
                 height: -1
@@ -78,7 +78,7 @@ describe("Storage", () => {
             );
         });
 
-        it("should return genesis state snapshot when height is any negative number", () => {
+        it("should return genesis state snapshot when height is any negative number", async () => {
             const coordinates: BlockCoordinates = {
                 forkId: forkId,
                 // Random height between -200 and -100
@@ -93,7 +93,7 @@ describe("Storage", () => {
             );
         });
 
-        it("should return state snapshot from block when height >= 0", () => {
+        it("should return state snapshot from block when height >= 0", async () => {
             const coordinates: BlockCoordinates = {
                 forkId: forkId,
                 height: 1
@@ -105,7 +105,7 @@ describe("Storage", () => {
             expect(result?.toStruct()).to.deep.equal(blockSnapshot.toStruct());
         });
 
-        it("genesis snapshot doesn't exist", () => {
+        it("genesis snapshot doesn't exist", async () => {
             const nonExistentForkId =
                 "0x9999999999999999999999999999999999999999999999999999999999999999";
 
@@ -117,7 +117,7 @@ describe("Storage", () => {
             ).to.be.undefined;
         });
 
-        it("block confirmation doesn't exist", () => {
+        it("block confirmation doesn't exist", async () => {
             expect(
                 storage.getStateSnapshot({
                     forkId: forkId,
@@ -126,7 +126,7 @@ describe("Storage", () => {
             ).to.be.undefined;
         });
 
-        it("correct block height, wrong forkId", () => {
+        it("correct block height, wrong forkId", async () => {
             const wrongForkId =
                 "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
             expect(
@@ -137,7 +137,7 @@ describe("Storage", () => {
             ).to.be.undefined;
         });
 
-        it("modifying retrieved snapshot doesn't affect stored snapshot", () => {
+        it("modifying retrieved snapshot doesn't affect stored snapshot", async () => {
             const coordinates: BlockCoordinates = {
                 forkId: forkId,
                 height: 1

--- a/test/storage/persistence/PersistenceController.test.ts
+++ b/test/storage/persistence/PersistenceController.test.ts
@@ -105,6 +105,7 @@ async function createSubject(
         maxBatchOperations?: number;
         flushIntervalMs?: number;
         maxRetries?: number;
+        commitDeadlineMs?: number;
     } = {}
 ) {
     const database = options.database ?? createDatabase();
@@ -112,7 +113,8 @@ async function createSubject(
         databaseHandle: createHandle(database),
         maxBatchOperations: options.maxBatchOperations,
         flushIntervalMs: options.flushIntervalMs,
-        maxRetries: options.maxRetries
+        maxRetries: options.maxRetries,
+        commitDeadlineMs: options.commitDeadlineMs
     });
     const values = new PersistentCollection<string, number>(
         "forceJoin",
@@ -475,6 +477,58 @@ describe("PersistenceController", function () {
         }
         expect(laterError).to.equal(firstError);
         expect(failureCount).to.equal(1);
+    });
+
+    it("poisons the controller when a commit hangs past its deadline", async () => {
+        // A rejecting batch poisons through the retry path; a batch that
+        // HANGS would otherwise keep every flush waiter (and thus every
+        // durability barrier) pending forever with no failure-handler
+        // teardown. The commit deadline converts the hang into the same
+        // poison flow.
+        const database = createDatabase();
+        const batches = new BatchControl(database);
+        const hungBatch = batches.holdNext();
+        const { controller, values } = await createSubject({
+            database,
+            maxBatchOperations: 1,
+            commitDeadlineMs: 100
+        });
+        let failureError: Error | undefined;
+        controller.setFailureHandler((error) => {
+            failureError = error;
+        });
+
+        values.set("value", 4);
+        await batches.waitForBatch(1);
+
+        let flushError: Error | undefined;
+        try {
+            await controller.flush();
+        } catch (error) {
+            flushError = error as Error;
+        }
+        expect(flushError?.message).to.include("deadline");
+        expect(failureError?.message).to.include("deadline");
+        // The cache-first write stays visible after the poison, matching the
+        // rejecting-batch behavior.
+        expect(values.get("value")).to.equal(4);
+        // Release the abandoned batch; its late settlement must be a no-op.
+        hungBatch.resolve();
+    });
+
+    it("leaves commits that settle within the deadline unaffected", async () => {
+        const { controller, database, values } = await createSubject({
+            maxBatchOperations: 1,
+            commitDeadlineMs: 1_000
+        });
+
+        values.set("value", 11);
+        await controller.flush();
+
+        expect(await database.get("records!v1!forceJoin!value")).to.not.equal(
+            undefined
+        );
+        await controller.close();
     });
 
     it("separates close from scoped failure-handler cache cleanup", async () => {

--- a/test/storage/persistence/PersistenceController.test.ts
+++ b/test/storage/persistence/PersistenceController.test.ts
@@ -1,0 +1,561 @@
+import type { AbstractBatchOperation } from "abstract-level";
+import { expect } from "chai";
+import { MemoryLevel } from "memory-level";
+import sinon from "sinon";
+
+import {
+    PersistenceController,
+    PersistentCollection,
+    type PersistenceDatabaseHandle
+} from "@/storage/persistence";
+import { createStorageRecordCodec } from "@/storage/persistence/storageCodecs";
+
+type Database = MemoryLevel<string, string>;
+type BatchOperation = AbstractBatchOperation<Database, string, string>;
+
+function deferred(): {
+    promise: Promise<void>;
+    resolve: () => void;
+    reject: (error: Error) => void;
+} {
+    let resolve!: () => void;
+    let reject!: (error: Error) => void;
+    const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}
+
+class BatchControl {
+    public readonly batches: BatchOperation[][] = [];
+    public maxActiveBatches = 0;
+    private readonly database: Database;
+    private readonly originalBatch: Database["batch"];
+    private readonly gates: ReturnType<typeof deferred>[] = [];
+    private readonly batchWaiters: Array<{
+        count: number;
+        resolve: () => void;
+    }> = [];
+    private activeBatches = 0;
+
+    constructor(database: Database) {
+        this.database = database;
+        this.originalBatch = database.batch.bind(database);
+        database.batch = ((operations: BatchOperation[]): Promise<void> =>
+            this.run(operations)) as Database["batch"];
+    }
+
+    public holdNext(): ReturnType<typeof deferred> {
+        const gate = deferred();
+        this.gates.push(gate);
+        return gate;
+    }
+
+    public waitForBatch(count: number): Promise<void> {
+        if (this.batches.length >= count) return Promise.resolve();
+        return new Promise((resolve) => {
+            this.batchWaiters.push({ count, resolve });
+        });
+    }
+
+    private async run(operations: BatchOperation[]): Promise<void> {
+        this.batches.push(operations);
+        this.activeBatches += 1;
+        this.maxActiveBatches = Math.max(
+            this.maxActiveBatches,
+            this.activeBatches
+        );
+        for (let index = this.batchWaiters.length - 1; index >= 0; index--) {
+            const waiter = this.batchWaiters[index];
+            if (this.batches.length < waiter.count) continue;
+            this.batchWaiters.splice(index, 1);
+            waiter.resolve();
+        }
+
+        try {
+            const gate = this.gates.shift();
+            if (gate) await gate.promise;
+            await this.originalBatch(operations);
+        } finally {
+            this.activeBatches -= 1;
+        }
+    }
+}
+
+function createDatabase(): Database {
+    return new MemoryLevel<string, string>({
+        keyEncoding: "utf8",
+        valueEncoding: "utf8"
+    });
+}
+
+function createHandle(database = createDatabase()): PersistenceDatabaseHandle {
+    return {
+        database,
+        location: "memory:persistence-controller",
+        close: () => database.close(),
+        destroy: () => database.clear()
+    };
+}
+
+async function createSubject(
+    options: {
+        database?: Database;
+        maxBatchOperations?: number;
+        flushIntervalMs?: number;
+        maxRetries?: number;
+    } = {}
+) {
+    const database = options.database ?? createDatabase();
+    const controller = new PersistenceController(createStorageRecordCodec(), {
+        databaseHandle: createHandle(database),
+        maxBatchOperations: options.maxBatchOperations,
+        flushIntervalMs: options.flushIntervalMs,
+        maxRetries: options.maxRetries
+    });
+    const values = new PersistentCollection<string, number>(
+        "forceJoin",
+        controller
+    );
+    await controller.bind();
+    return { controller, database, values };
+}
+
+describe("PersistenceController", function () {
+    it("makes a cache-first mutation visible before the backend settles", async () => {
+        const database = createDatabase();
+        const batches = new BatchControl(database);
+        const heldBatch = batches.holdNext();
+        const { controller, values } = await createSubject({
+            database,
+            maxBatchOperations: 1
+        });
+
+        expect(values.set("value", 7)).to.equal(7);
+        expect(values.get("value")).to.equal(7);
+        await batches.waitForBatch(1);
+        expect(await database.get("records!v1!forceJoin!value")).to.equal(
+            undefined
+        );
+
+        heldBatch.resolve();
+        await controller.flush();
+        expect(await database.get("records!v1!forceJoin!value")).to.equal(
+            "0x0000000000000000000000000000000000000000000000000000000000000007"
+        );
+        await controller.close();
+    });
+
+    it("batches rapid writes and persists their final value", async () => {
+        const database = createDatabase();
+        const batches = new BatchControl(database);
+        const { controller, values } = await createSubject({
+            database,
+            flushIntervalMs: 60_000
+        });
+
+        for (let value = 1; value <= 10; value++) {
+            values.set("value", value);
+        }
+        await controller.flush();
+
+        expect(batches.batches).to.have.length(1);
+        expect(batches.batches[0]).to.have.length(1);
+        expect(values.get("value")).to.equal(10);
+        expect(await database.get("records!v1!forceJoin!value")).to.equal(
+            "0x000000000000000000000000000000000000000000000000000000000000000a"
+        );
+        await controller.close();
+    });
+
+    it("applies rapid updates synchronously from the latest cache value", async () => {
+        const { controller, database, values } = await createSubject();
+
+        for (let index = 0; index < 20; index++) {
+            values.update("value", (current) => (current ?? 0) + 1);
+        }
+
+        expect(values.get("value")).to.equal(20);
+        await controller.flush();
+        expect(await database.get("records!v1!forceJoin!value")).to.equal(
+            "0x0000000000000000000000000000000000000000000000000000000000000014"
+        );
+        await controller.close();
+    });
+
+    it("uses a revision watermark for an explicit flush", async () => {
+        const database = createDatabase();
+        const batches = new BatchControl(database);
+        const firstBatch = batches.holdNext();
+        const secondBatch = batches.holdNext();
+        const { controller, values } = await createSubject({
+            database,
+            maxBatchOperations: 1
+        });
+
+        values.set("first", 1);
+        await batches.waitForBatch(1);
+        const firstFlush = controller.flush();
+        let firstResolved = false;
+        void firstFlush.then(() => {
+            firstResolved = true;
+        });
+        values.set("second", 2);
+
+        firstBatch.resolve();
+        await firstFlush;
+        expect(firstResolved).to.be.true;
+        await batches.waitForBatch(2);
+        expect(await database.get("records!v1!forceJoin!second")).to.equal(
+            undefined
+        );
+
+        secondBatch.resolve();
+        await controller.flush();
+        expect(await database.get("records!v1!forceJoin!second")).to.not.equal(
+            undefined
+        );
+        await controller.close();
+    });
+
+    it("settles concurrent barriers against their own target revisions", async () => {
+        const database = createDatabase();
+        const batches = new BatchControl(database);
+        const firstBatch = batches.holdNext();
+        const secondBatch = batches.holdNext();
+        const { controller, values } = await createSubject({
+            database,
+            maxBatchOperations: 1
+        });
+
+        values.set("first", 1);
+        await batches.waitForBatch(1);
+        const firstFlush = controller.flush();
+        values.set("second", 2);
+        const secondFlush = controller.flush();
+        let secondResolved = false;
+        void secondFlush.then(() => {
+            secondResolved = true;
+        });
+
+        firstBatch.resolve();
+        await firstFlush;
+        expect(secondResolved).to.be.false;
+        await batches.waitForBatch(2);
+        secondBatch.resolve();
+        await secondFlush;
+        expect(secondResolved).to.be.true;
+        await controller.close();
+    });
+
+    it("flushes on the configured interval", async () => {
+        const clock = sinon.useFakeTimers();
+        try {
+            const database = createDatabase();
+            const batches = new BatchControl(database);
+            const { controller, values } = await createSubject({
+                database,
+                flushIntervalMs: 50
+            });
+
+            values.set("value", 1);
+            expect(batches.batches).to.have.length(0);
+            await clock.tickAsync(49);
+            expect(batches.batches).to.have.length(0);
+            await clock.tickAsync(1);
+            await batches.waitForBatch(1);
+            expect(batches.batches).to.have.length(1);
+            await controller.close();
+        } finally {
+            clock.restore();
+        }
+    });
+
+    it("flushes at the size threshold without parallel batches", async () => {
+        const database = createDatabase();
+        const batches = new BatchControl(database);
+        const firstBatch = batches.holdNext();
+        const { controller, values } = await createSubject({
+            database,
+            maxBatchOperations: 2,
+            flushIntervalMs: 60_000
+        });
+
+        values.set("one", 1);
+        values.set("two", 2);
+        await batches.waitForBatch(1);
+        values.set("three", 3);
+        values.set("four", 4);
+        expect(batches.batches).to.have.length(1);
+
+        firstBatch.resolve();
+        await batches.waitForBatch(2);
+        await controller.flush();
+        expect(batches.maxActiveBatches).to.equal(1);
+        expect(batches.batches.map((batch) => batch.length)).to.deep.equal([
+            2, 2
+        ]);
+        await controller.close();
+    });
+
+    it("coalesces mutations for a blocked dirty record", async () => {
+        const database = createDatabase();
+        const batches = new BatchControl(database);
+        const firstBatch = batches.holdNext();
+        const { controller, values } = await createSubject({
+            database,
+            maxBatchOperations: 1
+        });
+
+        values.set("blocker", 1);
+        await batches.waitForBatch(1);
+        for (let value = 1; value <= 2_500; value++) {
+            values.set("dirty", value);
+        }
+
+        firstBatch.resolve();
+        await controller.flush();
+        expect(batches.batches).to.have.length(2);
+        expect(batches.batches[1]).to.have.length(1);
+        expect(values.get("dirty")).to.equal(2_500);
+        await controller.close();
+    });
+
+    for (const testCase of [
+        {
+            name: "put then put",
+            mutate(values: PersistentCollection<string, number>) {
+                values.set("value", 1);
+                values.set("value", 2);
+            },
+            expected: 2
+        },
+        {
+            name: "put then delete",
+            mutate(values: PersistentCollection<string, number>) {
+                values.set("value", 1);
+                values.delete("value");
+            },
+            expected: undefined
+        },
+        {
+            name: "delete then put",
+            mutate(values: PersistentCollection<string, number>) {
+                values.set("value", 1);
+                values.delete("value");
+                values.set("value", 3);
+            },
+            expected: 3
+        },
+        {
+            name: "clear then put",
+            mutate(values: PersistentCollection<string, number>) {
+                values.set("value", 1);
+                values.clear();
+                values.set("value", 4);
+            },
+            expected: 4
+        }
+    ]) {
+        it(`preserves ${testCase.name} ordering while coalescing`, async () => {
+            const database = createDatabase();
+            const batches = new BatchControl(database);
+            const { controller, values } = await createSubject({
+                database,
+                flushIntervalMs: 60_000
+            });
+
+            testCase.mutate(values);
+            await controller.flush();
+
+            expect(batches.batches).to.have.length(1);
+            expect(batches.batches[0]).to.have.length(1);
+            expect(values.get("value")).to.equal(testCase.expected);
+            expect(await database.get("records!v1!forceJoin!value")).to.equal(
+                testCase.expected === undefined
+                    ? undefined
+                    : `0x${testCase.expected.toString(16).padStart(64, "0")}`
+            );
+            await controller.close();
+        });
+    }
+
+    it("does not enqueue empty or missing deletes", async () => {
+        const database = createDatabase();
+        const batches = new BatchControl(database);
+        const { controller, values } = await createSubject({ database });
+
+        expect(values.delete("missing")).to.be.false;
+        expect(values.takeMany(["missing"])).to.deep.equal([]);
+        values.clear();
+        await controller.flush();
+
+        expect(batches.batches).to.have.length(0);
+        await controller.close();
+    });
+
+    it("deletes each key once in a multi-delete", async () => {
+        const database = createDatabase();
+        const batches = new BatchControl(database);
+        const { controller, values } = await createSubject({
+            database,
+            flushIntervalMs: 60_000
+        });
+        values.set("value", 1);
+        await controller.flush();
+
+        expect(values.takeMany(["value", "value"])).to.deep.equal([1]);
+        await controller.flush();
+
+        expect(batches.batches).to.have.length(2);
+        expect(batches.batches[1]).to.have.length(1);
+        expect(values.get("value")).to.equal(undefined);
+        await controller.close();
+    });
+
+    it("retries the same extracted batch", async () => {
+        const database = createDatabase();
+        const batches = new BatchControl(database);
+        const failedAttempt = batches.holdNext();
+        const { controller, values } = await createSubject({
+            database,
+            maxBatchOperations: 1,
+            maxRetries: 1
+        });
+
+        values.set("value", 7);
+        await batches.waitForBatch(1);
+        failedAttempt.reject(new Error("transient batch failure"));
+        await controller.flush();
+
+        expect(batches.batches).to.have.length(2);
+        expect(batches.batches[0]).to.deep.equal(batches.batches[1]);
+        expect(await database.get("records!v1!forceJoin!value")).to.not.equal(
+            undefined
+        );
+        await controller.close();
+    });
+
+    it("keeps failed cache writes visible and poisons barriers once", async () => {
+        const database = createDatabase();
+        const batches = new BatchControl(database);
+        const failedBatch = batches.holdNext();
+        const { controller, values } = await createSubject({
+            database,
+            maxBatchOperations: 1,
+            maxRetries: 0
+        });
+        let failureCount = 0;
+        controller.setFailureHandler(() => {
+            failureCount += 1;
+        });
+
+        values.set("value", 2);
+        expect(values.get("value")).to.equal(2);
+        await batches.waitForBatch(1);
+        failedBatch.reject(new Error("terminal batch failure"));
+
+        let firstError: Error | undefined;
+        try {
+            await controller.flush();
+        } catch (error) {
+            firstError = error as Error;
+        }
+        expect(firstError?.message).to.include("terminal batch failure");
+        expect(failureCount).to.equal(1);
+
+        values.set("value", 3);
+        expect(values.get("value")).to.equal(3);
+        let laterError: Error | undefined;
+        try {
+            await controller.flush();
+        } catch (error) {
+            laterError = error as Error;
+        }
+        expect(laterError).to.equal(firstError);
+        expect(failureCount).to.equal(1);
+    });
+
+    it("separates close from scoped failure-handler cache cleanup", async () => {
+        const database = createDatabase();
+        const batches = new BatchControl(database);
+        const failedBatch = batches.holdNext();
+        const { controller, values } = await createSubject({
+            database,
+            maxBatchOperations: 1,
+            maxRetries: 0
+        });
+        let cleanupResult: number | undefined;
+        controller.setFailureHandler(() => {
+            cleanupResult = values.set("cleanup", 9);
+        });
+
+        values.set("value", 1);
+        await batches.waitForBatch(1);
+        const close = controller.close();
+        expect(() => values.set("ordinary", 2)).to.throw(
+            "Persistence controller is closing"
+        );
+
+        failedBatch.reject(new Error("close batch failure"));
+        let closeError: Error | undefined;
+        try {
+            await close;
+        } catch (error) {
+            closeError = error as Error;
+        }
+        expect(closeError?.message).to.include("close batch failure");
+        expect(cleanupResult).to.equal(9);
+        expect(values.get("cleanup")).to.equal(9);
+        let repeatedCloseError: Error | undefined;
+        try {
+            await controller.close();
+        } catch (error) {
+            repeatedCloseError = error as Error;
+        }
+        expect(repeatedCloseError?.message).to.include("close batch failure");
+    });
+
+    it("keeps disabled persistence synchronous and flushes immediately", async () => {
+        const controller = new PersistenceController(
+            createStorageRecordCodec()
+        );
+        const values = new PersistentCollection<string, number>(
+            "forceJoin",
+            controller
+        );
+
+        expect(values.set("value", 1)).to.equal(1);
+        expect(values.get("value")).to.equal(1);
+        await controller.flush();
+        await controller.close();
+    });
+
+    it("includes the resolved location in hydration failures", async () => {
+        const database = createDatabase();
+        await database.open();
+        await database.put("records!v1!unknown!value", "corrupt");
+        const controller = new PersistenceController(
+            createStorageRecordCodec(),
+            {
+                databaseHandle: createHandle(database)
+            }
+        );
+        new PersistentCollection<string, number>("forceJoin", controller);
+
+        let bindError: Error | undefined;
+        try {
+            await controller.bind();
+        } catch (error) {
+            bindError = error as Error;
+        }
+
+        expect(bindError?.message).to.include(
+            "Unknown persistence collection unknown"
+        );
+        expect(bindError?.message).to.include(
+            "(persistence: memory:persistence-controller)"
+        );
+    });
+});

--- a/test/storage/persistence/PersistenceController.test.ts
+++ b/test/storage/persistence/PersistenceController.test.ts
@@ -479,6 +479,47 @@ describe("PersistenceController", function () {
         expect(failureCount).to.equal(1);
     });
 
+    it("serializes concurrent binds onto a single hydration run", async () => {
+        const database = createDatabase();
+        // Seed a durable record through a first controller lifetime.
+        const seed = new PersistenceController(createStorageRecordCodec(), {
+            databaseHandle: createHandle(database)
+        });
+        const seedValues = new PersistentCollection<string, number>(
+            "forceJoin",
+            seed
+        );
+        await seed.bind();
+        seedValues.set("value", 21);
+        await seed.close();
+
+        const controller = new PersistenceController(
+            createStorageRecordCodec(),
+            { databaseHandle: createHandle(database) }
+        );
+        const values = new PersistentCollection<string, number>(
+            "forceJoin",
+            controller
+        );
+        let iteratorCalls = 0;
+        const originalIterator = database.iterator.bind(database);
+        database.iterator = ((options: Parameters<Database["iterator"]>[0]) => {
+            iteratorCalls += 1;
+            return originalIterator(options);
+        }) as Database["iterator"];
+
+        // A resume-from-background hydrate racing the connect-path bind must
+        // join the same run, not hydrate twice.
+        await Promise.all([controller.bind(), controller.bind()]);
+        expect(iteratorCalls).to.equal(1);
+        expect(values.get("value")).to.equal(21);
+
+        // Once bound, further binds are no-ops.
+        await controller.bind();
+        expect(iteratorCalls).to.equal(1);
+        await controller.close();
+    });
+
     it("poisons the controller when a commit hangs past its deadline", async () => {
         // A rejecting batch poisons through the retry path; a batch that
         // HANGS would otherwise keep every flush waiter (and thus every

--- a/test/storage/persistence/StorageHydration.test.ts
+++ b/test/storage/persistence/StorageHydration.test.ts
@@ -50,6 +50,48 @@ describe("Storage hydration", function () {
         await storage.close();
     });
 
+    it("hydrate() is a safe resume entry point: no-op when unbound or bound, never rolls back a cache ahead of disk", async () => {
+        // Persistence disabled: hydrate resolves immediately.
+        const unbound = new Storage();
+        await unbound.hydrate();
+        await unbound.close();
+
+        const database = new MemoryLevel<string, string>({
+            keyEncoding: "utf8",
+            valueEncoding: "utf8"
+        });
+        const handle: PersistenceDatabaseHandle = {
+            database,
+            location: "memory:hydration-resume",
+            close: () => database.close(),
+            destroy: () => database.clear()
+        };
+        const storage = new Storage();
+        await storage.bind(handle);
+
+        const forkA = factory.hash() as ForkId;
+        const forkB = factory.hash() as ForkId;
+        const snapshotHash = factory.hash();
+        const stateHash = factory.hash();
+        storage.setRuntimeMetadata({
+            activeForkId: forkA,
+            snapshotHash,
+            stateHash
+        });
+        await storage.flush();
+
+        // Write-behind: memory is now AHEAD of disk. A resume-time hydrate
+        // must not re-read disk and roll the cache back to forkA.
+        storage.setRuntimeMetadata({
+            activeForkId: forkB,
+            snapshotHash,
+            stateHash
+        });
+        await storage.hydrate();
+        expect(storage.getRuntimeMetadata()?.activeForkId).to.equal(forkB);
+        await storage.close();
+    });
+
     it("fails closed for every inconsistent persisted-state shape", async () => {
         const location = "memory:hydration";
         const channelId = factory.hash() as ChannelId;

--- a/test/storage/persistence/StorageHydration.test.ts
+++ b/test/storage/persistence/StorageHydration.test.ts
@@ -1,0 +1,437 @@
+import { expect } from "chai";
+import { MemoryLevel } from "memory-level";
+
+import Storage from "@/storage";
+import type { PersistenceDatabaseHandle } from "@/storage/persistence";
+import { validatePersistedRuntimeState } from "@/storage/persistence/validatePersistedRuntimeState";
+import type { ChannelId, ForkId } from "@/types/types";
+import * as factory from "../../factory";
+
+describe("Storage hydration", function () {
+    it("accepts empty and complete runtime state", async () => {
+        const database = new MemoryLevel<string, string>({
+            keyEncoding: "utf8",
+            valueEncoding: "utf8"
+        });
+        const handle: PersistenceDatabaseHandle = {
+            database,
+            location: "memory:hydration",
+            close: () => database.close(),
+            destroy: () => database.clear()
+        };
+        const storage = new Storage();
+        await storage.bind(handle);
+        const channelId = factory.hash() as ChannelId;
+
+        expect(validatePersistedRuntimeState(storage, channelId)).to.equal(
+            undefined
+        );
+
+        const forkId = factory.hash() as ForkId;
+        const stateHash = factory.hash();
+        const encodedState = factory.hexString(64);
+        const snapshot = factory.stateSnapshot({
+            forkId,
+            snapshotData: { stateMachineStateHash: stateHash }
+        });
+        storage.stateMachineStates.storeStateMachineState(encodedState, {
+            hash: stateHash
+        });
+        storage.stateSnapshots.storeStateSnapshot(snapshot);
+        storage.setRuntimeMetadata({
+            activeForkId: forkId,
+            snapshotHash: snapshot.hash,
+            stateHash
+        });
+
+        const restored = validatePersistedRuntimeState(storage, channelId);
+        expect(restored?.metadata.activeForkId).to.equal(forkId);
+        expect(restored?.encodedState).to.equal(encodedState);
+        await storage.close();
+    });
+
+    it("fails closed for every inconsistent persisted-state shape", async () => {
+        const location = "memory:hydration";
+        const channelId = factory.hash() as ChannelId;
+        const cases: Array<{
+            expected: string;
+            seed: (storage: Storage) => void;
+        }> = [
+            {
+                expected: "Persisted runtime metadata is incomplete",
+                seed: (storage) => storage.setRuntimeMetadata({})
+            },
+            {
+                expected:
+                    "Persisted runtime metadata references missing snapshot",
+                seed: (storage) =>
+                    storage.setRuntimeMetadata({
+                        activeForkId: factory.hash() as ForkId,
+                        snapshotHash: factory.hash(),
+                        stateHash: factory.hash()
+                    })
+            },
+            {
+                expected: "Persisted runtime metadata references missing state",
+                seed: (storage) => {
+                    const snapshot = factory.stateSnapshot();
+                    storage.stateSnapshots.storeStateSnapshot(snapshot);
+                    storage.setRuntimeMetadata({
+                        activeForkId: snapshot.forkID,
+                        snapshotHash: snapshot.hash,
+                        stateHash: snapshot.stateMachineStateHash
+                    });
+                }
+            },
+            {
+                expected:
+                    "Persisted runtime metadata snapshot belongs to another fork",
+                seed: (storage) => {
+                    const snapshot = factory.stateSnapshot();
+                    const stateHash = snapshot.stateMachineStateHash;
+                    storage.stateSnapshots.storeStateSnapshot(snapshot);
+                    storage.stateMachineStates.storeStateMachineState(
+                        factory.hexString(64),
+                        { hash: stateHash }
+                    );
+                    storage.setRuntimeMetadata({
+                        activeForkId: factory.hash() as ForkId,
+                        snapshotHash: snapshot.hash,
+                        stateHash
+                    });
+                }
+            },
+            {
+                expected: "Persisted runtime metadata references missing head",
+                seed: (storage) => {
+                    const snapshot = factory.stateSnapshot();
+                    const stateHash = snapshot.stateMachineStateHash;
+                    storage.stateSnapshots.storeStateSnapshot(snapshot);
+                    storage.stateMachineStates.storeStateMachineState(
+                        factory.hexString(64),
+                        { hash: stateHash }
+                    );
+                    storage.setRuntimeMetadata({
+                        activeForkId: snapshot.forkID,
+                        snapshotHash: snapshot.hash,
+                        stateHash,
+                        headHash: factory.hash()
+                    });
+                }
+            },
+            {
+                expected:
+                    "Persisted runtime metadata head belongs to another fork",
+                seed: (storage) => {
+                    const snapshot = factory.stateSnapshot();
+                    const stateHash = snapshot.stateMachineStateHash;
+                    const head = factory.block({
+                        stateSnapshotHash: snapshot.hash
+                    });
+                    storage.stateSnapshots.storeStateSnapshot(snapshot);
+                    storage.stateMachineStates.storeStateMachineState(
+                        factory.hexString(64),
+                        { hash: stateHash }
+                    );
+                    storage.blocks.storeBlock(head);
+                    storage.setRuntimeMetadata({
+                        activeForkId: snapshot.forkID,
+                        snapshotHash: snapshot.hash,
+                        stateHash,
+                        headHash: head.hash
+                    });
+                }
+            },
+            {
+                expected:
+                    "Persisted runtime metadata head and snapshot disagree",
+                seed: (storage) => {
+                    const forkId = factory.hash() as ForkId;
+                    const snapshot = factory.stateSnapshot({ forkId });
+                    const stateHash = snapshot.stateMachineStateHash;
+                    const head = factory.block({
+                        transaction: {
+                            header: factory.transactionHeader({ forkId }),
+                            body: factory.transactionBody()
+                        }
+                    });
+                    storage.stateSnapshots.storeStateSnapshot(snapshot);
+                    storage.stateMachineStates.storeStateMachineState(
+                        factory.hexString(64),
+                        { hash: stateHash }
+                    );
+                    storage.blocks.storeBlock(head);
+                    storage.setRuntimeMetadata({
+                        activeForkId: forkId,
+                        snapshotHash: snapshot.hash,
+                        stateHash,
+                        headHash: head.hash
+                    });
+                }
+            },
+            {
+                expected:
+                    "Persisted runtime metadata snapshot and state disagree",
+                seed: (storage) => {
+                    const forkId = factory.hash() as ForkId;
+                    const snapshot = factory.stateSnapshot({ forkId });
+                    const otherStateHash = factory.hash();
+                    const head = factory.block({
+                        transaction: {
+                            header: factory.transactionHeader({
+                                forkId,
+                                transactionCnt: 0
+                            }),
+                            body: factory.transactionBody()
+                        },
+                        stateSnapshotHash: snapshot.hash
+                    });
+                    storage.stateSnapshots.storeStateSnapshot(snapshot);
+                    storage.stateMachineStates.storeStateMachineState(
+                        factory.hexString(64),
+                        { hash: otherStateHash }
+                    );
+                    storage.blocks.storeBlock(head);
+                    storage.setRuntimeMetadata({
+                        activeForkId: forkId,
+                        snapshotHash: snapshot.hash,
+                        stateHash: otherStateHash,
+                        headHash: head.hash
+                    });
+                }
+            },
+            {
+                expected: "Persisted canonical block missing at height 0",
+                seed: (storage) => {
+                    const forkId = factory.hash() as ForkId;
+                    const stateHash = factory.hash();
+                    const snapshot = factory.stateSnapshot({
+                        forkId,
+                        snapshotData: { stateMachineStateHash: stateHash }
+                    });
+                    const head = factory.block({
+                        transaction: {
+                            header: factory.transactionHeader({
+                                forkId,
+                                transactionCnt: 1
+                            }),
+                            body: factory.transactionBody()
+                        },
+                        stateSnapshotHash: snapshot.hash
+                    });
+                    storage.stateSnapshots.storeStateSnapshot(snapshot);
+                    storage.stateMachineStates.storeStateMachineState(
+                        factory.hexString(64),
+                        { hash: stateHash }
+                    );
+                    storage.blocks.storeBlock(head);
+                    storage.setRuntimeMetadata({
+                        activeForkId: forkId,
+                        snapshotHash: snapshot.hash,
+                        stateHash,
+                        headHash: head.hash
+                    });
+                }
+            },
+            {
+                expected:
+                    "Persisted canonical block linkage is broken at height 1",
+                seed: (storage) => {
+                    const forkId = factory.hash() as ForkId;
+                    const stateHash = factory.hash();
+                    const snapshot = factory.stateSnapshot({
+                        forkId,
+                        snapshotData: { stateMachineStateHash: stateHash }
+                    });
+                    const block0 = factory.block({
+                        transaction: {
+                            header: factory.transactionHeader({
+                                forkId,
+                                transactionCnt: 0
+                            }),
+                            body: factory.transactionBody()
+                        },
+                        stateSnapshotHash: snapshot.hash
+                    });
+                    const block1 = factory.block({
+                        transaction: {
+                            header: factory.transactionHeader({
+                                forkId,
+                                transactionCnt: 1
+                            }),
+                            body: factory.transactionBody()
+                        },
+                        previousBlockHash: factory.hash(),
+                        stateSnapshotHash: snapshot.hash
+                    });
+                    storage.stateSnapshots.storeStateSnapshot(snapshot);
+                    storage.stateMachineStates.storeStateMachineState(
+                        factory.hexString(64),
+                        { hash: stateHash }
+                    );
+                    storage.blocks.storeBlock(block0);
+                    storage.blocks.storeBlock(block1);
+                    storage.setRuntimeMetadata({
+                        activeForkId: forkId,
+                        snapshotHash: snapshot.hash,
+                        stateHash,
+                        headHash: block1.hash
+                    });
+                }
+            },
+            {
+                expected: "references a missing snapshot",
+                seed: (storage) => {
+                    const forkId = factory.hash() as ForkId;
+                    const stateHash = factory.hash();
+                    const headSnapshot = factory.stateSnapshot({
+                        forkId,
+                        snapshotData: { stateMachineStateHash: stateHash }
+                    });
+                    const block0 = factory.block({
+                        transaction: {
+                            header: factory.transactionHeader({
+                                forkId,
+                                transactionCnt: 0
+                            }),
+                            body: factory.transactionBody()
+                        },
+                        stateSnapshotHash: factory.hash()
+                    });
+                    const head = factory.block({
+                        transaction: {
+                            header: factory.transactionHeader({
+                                forkId,
+                                transactionCnt: 1
+                            }),
+                            body: factory.transactionBody()
+                        },
+                        previousBlockHash: block0.hash,
+                        stateSnapshotHash: headSnapshot.hash
+                    });
+                    storage.stateSnapshots.storeStateSnapshot(headSnapshot);
+                    storage.stateMachineStates.storeStateMachineState(
+                        factory.hexString(64),
+                        { hash: stateHash }
+                    );
+                    storage.blocks.storeBlock(block0);
+                    storage.blocks.storeBlock(head);
+                    storage.setRuntimeMetadata({
+                        activeForkId: forkId,
+                        snapshotHash: headSnapshot.hash,
+                        stateHash,
+                        headHash: head.hash
+                    });
+                }
+            },
+            {
+                expected: "references a missing state",
+                seed: (storage) => {
+                    const forkId = factory.hash() as ForkId;
+                    const headStateHash = factory.hash();
+                    const missingStateHash = factory.hash();
+                    const block0Snapshot = factory.stateSnapshot({
+                        forkId,
+                        snapshotData: {
+                            stateMachineStateHash: missingStateHash
+                        }
+                    });
+                    const headSnapshot = factory.stateSnapshot({
+                        forkId,
+                        snapshotData: {
+                            stateMachineStateHash: headStateHash
+                        }
+                    });
+                    const block0 = factory.block({
+                        transaction: {
+                            header: factory.transactionHeader({
+                                forkId,
+                                transactionCnt: 0
+                            }),
+                            body: factory.transactionBody()
+                        },
+                        stateSnapshotHash: block0Snapshot.hash
+                    });
+                    const head = factory.block({
+                        transaction: {
+                            header: factory.transactionHeader({
+                                forkId,
+                                transactionCnt: 1
+                            }),
+                            body: factory.transactionBody()
+                        },
+                        previousBlockHash: block0.hash,
+                        stateSnapshotHash: headSnapshot.hash
+                    });
+                    storage.stateSnapshots.storeStateSnapshot(block0Snapshot);
+                    storage.stateSnapshots.storeStateSnapshot(headSnapshot);
+                    storage.stateMachineStates.storeStateMachineState(
+                        factory.hexString(64),
+                        { hash: headStateHash }
+                    );
+                    storage.blocks.storeBlock(block0);
+                    storage.blocks.storeBlock(head);
+                    storage.setRuntimeMetadata({
+                        activeForkId: forkId,
+                        snapshotHash: headSnapshot.hash,
+                        stateHash: headStateHash,
+                        headHash: head.hash
+                    });
+                }
+            },
+            {
+                expected: "belongs to another channel",
+                seed: (storage) => {
+                    const forkId = factory.hash() as ForkId;
+                    const stateHash = factory.hash();
+                    const snapshot = factory.stateSnapshot({
+                        forkId,
+                        snapshotData: { stateMachineStateHash: stateHash }
+                    });
+                    const foreignBlock = factory.block();
+                    storage.stateSnapshots.storeStateSnapshot(snapshot);
+                    storage.stateMachineStates.storeStateMachineState(
+                        factory.hexString(64),
+                        { hash: stateHash }
+                    );
+                    storage.queues.restoreEntry({
+                        block: foreignBlock,
+                        firstSeenAt: 1,
+                        sourcePeers: new Set(),
+                        signatureSources: new Map()
+                    });
+                    storage.setRuntimeMetadata({
+                        activeForkId: forkId,
+                        snapshotHash: snapshot.hash,
+                        stateHash
+                    });
+                }
+            }
+        ];
+
+        for (const testCase of cases) {
+            const database = new MemoryLevel<string, string>({
+                keyEncoding: "utf8",
+                valueEncoding: "utf8"
+            });
+            const handle: PersistenceDatabaseHandle = {
+                database,
+                location,
+                close: () => database.close(),
+                destroy: () => database.clear()
+            };
+            const storage = new Storage();
+            await storage.bind(handle);
+            testCase.seed(storage);
+            await storage.flush();
+
+            expect(() =>
+                validatePersistedRuntimeState(storage, channelId)
+            ).to.throw(testCase.expected);
+            expect(() =>
+                validatePersistedRuntimeState(storage, channelId)
+            ).to.throw(`(persistence: ${location})`);
+            await storage.close();
+        }
+    });
+});

--- a/test/storage/persistence/StoragePersistence.test.ts
+++ b/test/storage/persistence/StoragePersistence.test.ts
@@ -1,0 +1,440 @@
+import { expect } from "chai";
+import { MemoryLevel } from "memory-level";
+
+import Storage from "@/storage";
+import type { PersistenceDatabaseHandle } from "@/storage/persistence";
+import { Codec, Type } from "@/utils";
+import * as factory from "../../factory";
+
+function createHandle(
+    database: MemoryLevel<string, string>,
+    closeDatabase = true
+): PersistenceDatabaseHandle {
+    return {
+        database,
+        location: "memory:test",
+        close: () =>
+            closeDatabase ? database.close() : Promise.resolve(undefined),
+        destroy: () => database.clear()
+    };
+}
+
+describe("Storage persistence", function () {
+    it("recovers primary records, derived indexes, and queue attribution", async () => {
+        const database = new MemoryLevel<string, string>({
+            keyEncoding: "utf8",
+            valueEncoding: "utf8"
+        });
+        const first = new Storage();
+        await first.bind(createHandle(database));
+
+        const snapshot = factory.stateSnapshot();
+        const encodedState = factory.hexString(128);
+        const block = factory.block({
+            stateSnapshotHash: snapshot.hash
+        });
+        const sender = factory.randomAddress();
+        first.stateSnapshots.storeStateSnapshot(snapshot);
+        first.stateMachineStates.storeStateMachineState(encodedState, {
+            hash: snapshot.stateMachineStateHash
+        });
+        first.blocks.storeBlock(block);
+        first.queues.restoreEntry({
+            block,
+            firstSeenAt: 1,
+            sourcePeers: new Set([sender]),
+            signatureSources: new Map([
+                [block.originalSignature, new Set([sender])]
+            ])
+        });
+        await first.flush();
+        await first.close();
+
+        const second = new Storage();
+        await second.bind(createHandle(database));
+
+        expect(second.blocks.getBlock(block.hash)?.equals(block)).to.be.true;
+        expect(second.blocks.getLatestBlock(block.forkId)?.hash).to.equal(
+            block.hash
+        );
+        expect(
+            second.stateSnapshots.getStateSnapshotByHash(snapshot.hash)?.hash
+        ).to.equal(snapshot.hash);
+        expect(
+            second.stateMachineStates.getStateMachineState(
+                snapshot.stateMachineStateHash
+            )
+        ).to.equal(encodedState);
+        const queued = second.queues.getQueuedEntry(block.hash);
+        expect(queued?.sourcePeers.has(sender)).to.be.true;
+        expect(queued?.signatureSources.size).to.be.greaterThan(0);
+        await second.close();
+    });
+
+    it("persists the final queue state after interleaved mutations", async () => {
+        const database = new MemoryLevel<string, string>({
+            keyEncoding: "utf8",
+            valueEncoding: "utf8"
+        });
+        const first = new Storage();
+        await first.bind(createHandle(database));
+        const block = factory.block();
+        first.queues.restoreEntry({
+            block,
+            firstSeenAt: 1,
+            sourcePeers: new Set(),
+            signatureSources: new Map()
+        });
+        const removed = first.queues.removeBlock(block.hash);
+        expect(removed).to.not.be.undefined;
+        expect(first.queues.getQueuedEntry(block.hash)).to.be.undefined;
+        first.queues.restoreEntry(removed!);
+        expect(first.queues.getQueuedEntry(block.hash)).to.not.be.undefined;
+        await first.flush();
+        await first.close();
+
+        const second = new Storage();
+        await second.bind(createHandle(database));
+        expect(second.queues.getQueuedEntry(block.hash)).to.not.be.undefined;
+        await second.close();
+    });
+
+    it("updates primary cache and derived indexes before disk settles", async () => {
+        const database = new MemoryLevel<string, string>({
+            keyEncoding: "utf8",
+            valueEncoding: "utf8"
+        });
+        const storage = new Storage(undefined, {
+            flushIntervalMs: 60_000
+        });
+        await storage.bind(createHandle(database));
+        const block = factory.block();
+
+        storage.blocks.storeBlock(block);
+
+        expect(storage.blocks.getBlock(block.hash)?.hash).to.equal(block.hash);
+        expect(storage.blocks.getLatestBlock(block.forkId)?.hash).to.equal(
+            block.hash
+        );
+        expect(await database.get(`records!v1!blocks!${block.hash}`)).to.equal(
+            undefined
+        );
+        await storage.flush();
+        expect(
+            await database.get(`records!v1!blocks!${block.hash}`)
+        ).to.not.equal(undefined);
+        await storage.close();
+    });
+
+    it("keeps cache-first mutations visible when their barrier fails", async () => {
+        const database = new MemoryLevel<string, string>({
+            keyEncoding: "utf8",
+            valueEncoding: "utf8"
+        });
+        const storage = new Storage();
+        await storage.bind(createHandle(database));
+        const firstBlock = factory.block();
+        const nextBlock = factory.block({
+            transaction: {
+                header: factory.transactionHeader({
+                    forkId: firstBlock.forkId,
+                    transactionCnt: 1
+                }),
+                body: factory.transactionBody()
+            }
+        });
+        storage.blocks.storeBlock(firstBlock);
+        await storage.flush();
+        await database.close();
+
+        storage.blocks.storeBlock(nextBlock);
+        expect(storage.blocks.getBlock(nextBlock.hash)?.hash).to.equal(
+            nextBlock.hash
+        );
+        expect(storage.blocks.getLatestBlock(firstBlock.forkId)?.hash).to.equal(
+            nextBlock.hash
+        );
+
+        let error: Error | undefined;
+        try {
+            await storage.flush();
+        } catch (caught) {
+            error = caught as Error;
+        }
+
+        expect(error).to.be.instanceOf(Error);
+        expect(storage.blocks.getBlock(nextBlock.hash)?.hash).to.equal(
+            nextBlock.hash
+        );
+    });
+
+    it("flushes pending writes during graceful close", async () => {
+        const database = new MemoryLevel<string, string>({
+            keyEncoding: "utf8",
+            valueEncoding: "utf8"
+        });
+        const first = new Storage(undefined, {
+            flushIntervalMs: 60_000
+        });
+        await first.bind(createHandle(database));
+        const block = factory.block();
+        first.blocks.storeBlock(block);
+
+        await first.close();
+
+        const second = new Storage();
+        await second.bind(createHandle(database));
+        expect(second.blocks.getBlock(block.hash)?.hash).to.equal(block.hash);
+        await second.close();
+    });
+
+    it("recovers a flushed canonical height and rejects conflicting bait after an abrupt reopen", async () => {
+        const database = new MemoryLevel<string, string>({
+            keyEncoding: "utf8",
+            valueEncoding: "utf8"
+        });
+        const first = new Storage(undefined, {
+            flushIntervalMs: 60_000
+        });
+        await first.bind(createHandle(database, false));
+        const canonical = factory.block();
+        const conflicting = factory.block({
+            transaction: {
+                header: factory.transactionHeader({
+                    forkId: canonical.forkId,
+                    transactionCnt: canonical.height
+                }),
+                body: factory.transactionBody()
+            }
+        });
+        first.blocks.storeBlock(canonical);
+        await first.flush();
+
+        const restarted = new Storage();
+        await restarted.bind(createHandle(database, false));
+        expect(restarted.blocks.getBlock(canonical.hash)?.hash).to.equal(
+            canonical.hash
+        );
+        expect(restarted.blocks.storeBlock(conflicting)).to.equal(undefined);
+        expect(
+            restarted.blocks.getBlock(canonical.forkId, canonical.height)?.hash
+        ).to.equal(canonical.hash);
+
+        await first.close();
+        await restarted.close();
+        await database.close();
+    });
+
+    it("recovers the flushed prefix but not a later cache-only tail", async () => {
+        const database = new MemoryLevel<string, string>({
+            keyEncoding: "utf8",
+            valueEncoding: "utf8"
+        });
+        const first = new Storage(undefined, {
+            flushIntervalMs: 60_000
+        });
+        await first.bind(createHandle(database, false));
+        const durableBlock = factory.block();
+        first.blocks.storeBlock(durableBlock);
+        await first.flush();
+        first.forceExit.setForceExit(true);
+
+        const restarted = new Storage();
+        await restarted.bind(createHandle(database, false));
+        expect(restarted.blocks.getBlock(durableBlock.hash)?.hash).to.equal(
+            durableBlock.hash
+        );
+        expect(restarted.forceExit.getForceExit()).to.equal(false);
+
+        await first.close();
+        await restarted.close();
+        await database.close();
+    });
+
+    it("re-arms an unflushed dequeue and consumes the resurrected entry once", async () => {
+        const database = new MemoryLevel<string, string>({
+            keyEncoding: "utf8",
+            valueEncoding: "utf8"
+        });
+        const first = new Storage(undefined, {
+            flushIntervalMs: 60_000
+        });
+        await first.bind(createHandle(database, false));
+        const block = factory.block();
+        first.queues.restoreEntry({
+            block,
+            firstSeenAt: 1,
+            sourcePeers: new Set(),
+            signatureSources: new Map()
+        });
+        await first.flush();
+        expect(first.queues.removeBlock(block.hash)?.block.hash).to.equal(
+            block.hash
+        );
+
+        const restarted = new Storage();
+        await restarted.bind(createHandle(database, false));
+        const resurrected = restarted.queues.removeBlock(block.hash);
+        expect(resurrected?.block.hash).to.equal(block.hash);
+        expect(restarted.queues.removeBlock(block.hash)).to.equal(undefined);
+        await restarted.flush();
+
+        const afterExecution = new Storage();
+        await afterExecution.bind(createHandle(database, false));
+        expect(afterExecution.queues.getQueuedEntry(block.hash)).to.equal(
+            undefined
+        );
+
+        await first.close();
+        await restarted.close();
+        await afterExecution.close();
+        await database.close();
+    });
+
+    it("round-trips every registered collection through public storage owners", async () => {
+        const database = new MemoryLevel<string, string>({
+            keyEncoding: "utf8",
+            valueEncoding: "utf8"
+        });
+        const first = new Storage(undefined, {
+            flushIntervalMs: 60_000
+        });
+        await first.bind(createHandle(database));
+
+        const snapshot = factory.stateSnapshot();
+        const encodedState = factory.hexString(64);
+        const block = factory.block({
+            stateSnapshotHash: snapshot.hash
+        });
+        const inboundMessage = factory.exitChannelBlock({ blockHeight: 3n });
+        const outboundMessage = factory.exitChannelBlock({ blockHeight: 4n });
+        const dispute = factory.dispute();
+        const signedDispute = factory.signedDispute({
+            encodedDispute: Codec.encode(dispute, Type.Dispute)
+        });
+        const participant = factory.randomAddress();
+        const fraudProof = {
+            proofType: 0,
+            participant,
+            encodedProof: factory.hexString(24)
+        };
+        const disputeFraudProof = {
+            proofType: 0,
+            participant,
+            dispute,
+            encodedProof: factory.hexString(24)
+        };
+        const timeout = {
+            participant,
+            blockHeight: 5n,
+            minTimeStamp: 6n,
+            isForced: false,
+            previousBlockProducer: factory.randomAddress(),
+            previousBlockProducerPostedCalldata: false,
+            participantSignatureOnPreviousBlock: factory.signature()
+        };
+        const blockCalldata = {
+            signedBlock: block.signedBlock,
+            onChainTimestamp: 7
+        };
+
+        first.blocks.storeBlock(block);
+        const inboundHash = first.inboundMessages.store(inboundMessage);
+        const outboundHash = first.outboundMessages.store(outboundMessage);
+        first.stateSnapshots.storeStateSnapshot(snapshot);
+        first.stateMachineStates.storeStateMachineState(encodedState, {
+            hash: snapshot.stateMachineStateHash
+        });
+        first.participantSetChanges.storeChangePoint(block.forkId, 8);
+        first.queues.restoreEntry({
+            block,
+            firstSeenAt: 1,
+            sourcePeers: new Set([participant]),
+            signatureSources: new Map([
+                [block.originalSignature, new Set([participant])]
+            ])
+        });
+        const disputeHash = first.disputes.storeDispute(signedDispute);
+        first.disputes.storeDisputedFork(block.forkId, true);
+        const fraudProofHash = first.fraudProofs.storeFraudProof(fraudProof);
+        first.disputeFraudProofs.storeFraudProof(disputeFraudProof);
+        first.timeout.storeTimeout(block.forkId, timeout);
+        first.forceExit.setForceExit(true);
+        first.forceJoin.setJoinSubmissionBlockHeight(-1);
+        first.blockCalldata.storeBlockCalldata(blockCalldata);
+        first.eventSync.storeLatestProcessedBlock(block.channelId, 10);
+        first.setRuntimeMetadata({
+            activeForkId: block.forkId,
+            headHash: block.hash,
+            snapshotHash: snapshot.hash,
+            stateHash: snapshot.stateMachineStateHash
+        });
+        await first.flush();
+        await first.close();
+
+        const second = new Storage();
+        await second.bind(createHandle(database));
+        expect(second.blocks.getBlock(block.hash)?.hash).to.equal(block.hash);
+        expect(
+            second.inboundMessages.getMessageBlock(inboundHash)
+        ).to.deep.equal(inboundMessage);
+        expect(
+            second.outboundMessages.getMessageBlock(outboundHash)
+        ).to.deep.equal(outboundMessage);
+        expect(
+            second.stateSnapshots.getStateSnapshotByHash(snapshot.hash)?.hash
+        ).to.equal(snapshot.hash);
+        expect(
+            second.stateMachineStates.getStateMachineState(
+                snapshot.stateMachineStateHash
+            )
+        ).to.equal(encodedState);
+        expect(
+            second.participantSetChanges.getChangePointsInRange(
+                block.forkId,
+                0,
+                10
+            )
+        ).to.deep.equal([8]);
+        expect(
+            second.queues
+                .getQueuedEntry(block.hash)
+                ?.sourcePeers.has(participant)
+        ).to.be.true;
+        expect(
+            second.disputes.getDisputeConfirmation(disputeHash)
+        ).to.not.equal(undefined);
+        expect(second.disputes.didIDispute(block.forkId)).to.be.true;
+        expect(
+            second.fraudProofs.getFraudProofByHash(fraudProofHash)?.participant
+        ).to.equal(participant);
+        expect(
+            second.disputeFraudProofs.getDisputeFraudProofForDispute(dispute)
+                ?.participant
+        ).to.equal(participant);
+        expect(second.timeout.getTimeout(block.forkId)?.blockHeight).to.equal(
+            5n
+        );
+        expect(second.forceExit.getForceExit()).to.be.true;
+        expect(second.forceJoin.getJoinSubmissionBlockHeight()).to.equal(-1);
+        expect(
+            second.blockCalldata.getMatchingBlockCalldata(block)
+                ?.onChainTimestamp
+        ).to.equal(7);
+        expect(
+            second.eventSync.getLatestProcessedBlock(block.channelId)
+        ).to.equal(10);
+        expect(second.getRuntimeMetadata()?.headHash).to.equal(block.hash);
+        await second.close();
+    });
+
+    it("makes flush immediate when persistence is disabled", async () => {
+        const storage = new Storage();
+        const block = factory.block();
+
+        storage.blocks.storeBlock(block);
+        expect(storage.blocks.getBlock(block.hash)?.hash).to.equal(block.hash);
+        await storage.flush();
+        await storage.close();
+    });
+});

--- a/test/storage/persistence/StoragePersistence.test.ts
+++ b/test/storage/persistence/StoragePersistence.test.ts
@@ -428,6 +428,88 @@ describe("Storage persistence", function () {
         await second.close();
     });
 
+    it("a justPersist merge cannot demote the tip, and a justPersist-only block stays off the tip across a restart", async () => {
+        const database = new MemoryLevel<string, string>({
+            keyEncoding: "utf8",
+            valueEncoding: "utf8"
+        });
+        const first = new Storage();
+        await first.bind(createHandle(database));
+
+        // Normal store, then a justPersist merge of the SAME block: the merge
+        // must not demote the already-advancing record off the tip.
+        const advancing = factory.block();
+        first.blocks.storeBlock(advancing);
+        expect(first.blocks.getLatestBlock(advancing.forkId)?.hash).to.equal(
+            advancing.hash
+        );
+        first.blocks.storeBlock(advancing, { justPersist: true });
+        expect(first.blocks.getLatestBlock(advancing.forkId)?.hash).to.equal(
+            advancing.hash
+        );
+
+        // A justPersist-only block at a greater height must not advance the
+        // tip (same fork by factory default).
+        const parked = factory.block({
+            transaction: factory.transaction({
+                header: factory.transactionHeader({ transactionCnt: 5 })
+            })
+        });
+        first.blocks.storeBlock(parked, { justPersist: true });
+        expect(first.blocks.getLatestBlock(advancing.forkId)?.hash).to.equal(
+            advancing.hash
+        );
+        await first.flush();
+        await first.close();
+
+        // The restart must agree: advancesTip is persisted, not re-inferred,
+        // so rehydration cannot resurrect the parked block as the tip.
+        const second = new Storage();
+        await second.bind(createHandle(database));
+        expect(second.blocks.getBlock(parked.hash)?.equals(parked)).to.be.true;
+        expect(second.blocks.getLatestBlock(advancing.forkId)?.hash).to.equal(
+            advancing.hash
+        );
+
+        // A later normal store of the parked block promotes it.
+        second.blocks.storeBlock(parked);
+        expect(second.blocks.getLatestBlock(advancing.forkId)?.hash).to.equal(
+            parked.hash
+        );
+        await second.close();
+    });
+
+    it("fails hydration closed on a corrupt record value in a known collection", async () => {
+        const database = new MemoryLevel<string, string>({
+            keyEncoding: "utf8",
+            valueEncoding: "utf8"
+        });
+        const first = new Storage();
+        await first.bind(createHandle(database));
+        const block = factory.block();
+        first.blocks.storeBlock(block);
+        await first.flush();
+        await first.close();
+
+        // Corrupt the persisted block record in place (a known-collection
+        // key, unlike the unknown-collection case the controller suite
+        // covers).
+        await database.open();
+        await database.put(`records!v1!blocks!${block.hash}`, "0xdeadbeef");
+
+        const second = new Storage();
+        let bindError: Error | undefined;
+        try {
+            await second.bind(createHandle(database));
+        } catch (error) {
+            bindError = error as Error;
+        }
+        expect(bindError, "hydration must fail closed on a corrupt record").to
+            .not.be.undefined;
+        // Fail-closed also means no partial state leaks into the caches.
+        expect(second.blocks.getBlock(block.hash)).to.be.undefined;
+    });
+
     it("makes flush immediate when persistence is disabled", async () => {
         const storage = new Storage();
         const block = factory.block();

--- a/test/storage/persistence/node/PersistencePartition.test.ts
+++ b/test/storage/persistence/node/PersistencePartition.test.ts
@@ -1,0 +1,303 @@
+import { expect } from "chai";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+    openPersistencePartition,
+    type PersistenceDatabaseHandle
+} from "@/storage/persistence";
+import Storage from "@/storage";
+import * as factory from "../../../factory";
+
+describe("Node persistence partition", function () {
+    let root: string;
+    const handles: PersistenceDatabaseHandle[] = [];
+
+    beforeEach(async () => {
+        root = await mkdtemp(
+            path.join(tmpdir(), "state-channels-plus-persistence-")
+        );
+    });
+
+    afterEach(async () => {
+        for (const handle of handles.splice(0)) {
+            await handle.close();
+        }
+        await rm(root, { recursive: true, force: true });
+    });
+
+    it("recovers the channel signer instead of a new candidate", async () => {
+        const identity = {
+            chainId: "31337",
+            stateChannelManagerAddress: String(factory.randomAddress()),
+            stateMachineAddress: String(factory.randomAddress()),
+            channelId: factory.hash()
+        };
+        const originalSigner = String(factory.hexString(32));
+        const first = await openPersistencePartition({
+            identity,
+            persistence: { location: root },
+            signerSecret: originalSigner,
+            existingPartition: "allow"
+        });
+        handles.push(first.databaseHandle);
+        await first.databaseHandle.close();
+        handles.splice(0);
+
+        const second = await openPersistencePartition({
+            identity,
+            persistence: { location: root },
+            signerSecret: String(factory.hexString(32)),
+            existingPartition: "allow"
+        });
+        handles.push(second.databaseHandle);
+
+        expect(second.signerSecret).to.equal(originalSigner);
+    });
+
+    it("rejects a second live writer for one channel partition", async () => {
+        const identity = {
+            chainId: "31337",
+            stateChannelManagerAddress: String(factory.randomAddress()),
+            stateMachineAddress: String(factory.randomAddress()),
+            channelId: factory.hash()
+        };
+        const first = await openPersistencePartition({
+            identity,
+            persistence: { location: root },
+            signerSecret: String(factory.hexString(32)),
+            existingPartition: "allow"
+        });
+        handles.push(first.databaseHandle);
+
+        let error: Error | undefined;
+        try {
+            await openPersistencePartition({
+                identity,
+                persistence: { location: root },
+                signerSecret: String(factory.hexString(32)),
+                existingPartition: "allow"
+            });
+        } catch (caught) {
+            error = caught as Error;
+        }
+        expect(error).to.be.instanceOf(Error);
+    });
+
+    it("rejects an unsupported schema without replacing the partition", async () => {
+        const identity = {
+            chainId: "31337",
+            stateChannelManagerAddress: String(factory.randomAddress()),
+            stateMachineAddress: String(factory.randomAddress()),
+            channelId: factory.hash()
+        };
+        const signerSecret = String(factory.hexString(32));
+        const first = await openPersistencePartition({
+            identity,
+            persistence: { location: root },
+            signerSecret,
+            existingPartition: "allow"
+        });
+        await first.databaseHandle.database.put("metadata!schemaVersion", "99");
+        await first.databaseHandle.close();
+
+        let error: Error | undefined;
+        try {
+            await openPersistencePartition({
+                identity,
+                persistence: { location: root },
+                signerSecret: String(factory.hexString(32)),
+                existingPartition: "allow"
+            });
+        } catch (caught) {
+            error = caught as Error;
+        }
+        expect(error?.message).to.include(
+            "Unsupported persistence schema version 99"
+        );
+    });
+
+    it("resumes a chunked schema migration and removes the old prefix", async () => {
+        const identity = {
+            chainId: "31337",
+            stateChannelManagerAddress: String(factory.randomAddress()),
+            stateMachineAddress: String(factory.randomAddress()),
+            channelId: factory.hash()
+        };
+        const signerSecret = String(factory.hexString(32));
+        const first = await openPersistencePartition({
+            identity,
+            persistence: { location: root },
+            signerSecret,
+            existingPartition: "allow"
+        });
+        await first.databaseHandle.database.batch([
+            {
+                type: "put",
+                key: "metadata!schemaVersion",
+                value: "0"
+            },
+            {
+                type: "put",
+                key: "records!v0!runtimeMetadata!active",
+                value: "first"
+            },
+            {
+                type: "put",
+                key: "records!v0!runtimeMetadata!head",
+                value: "second"
+            },
+            {
+                type: "put",
+                key: "records!v1!runtimeMetadata!active",
+                value: "first"
+            },
+            {
+                type: "put",
+                key: "metadata!migrationProgress",
+                value: JSON.stringify({
+                    fromVersion: 0,
+                    toVersion: 1,
+                    phase: "copy",
+                    cursor: "records!v0!runtimeMetadata!active"
+                })
+            }
+        ]);
+        await first.databaseHandle.close();
+
+        const second = await openPersistencePartition({
+            identity,
+            persistence: { location: root },
+            signerSecret: String(factory.hexString(32)),
+            existingPartition: "allow",
+            migrations: [
+                {
+                    fromVersion: 0,
+                    toVersion: 1,
+                    transformRecord: (record) => record
+                }
+            ]
+        });
+        handles.push(second.databaseHandle);
+
+        expect(
+            await second.databaseHandle.database.get(
+                "records!v1!runtimeMetadata!head"
+            )
+        ).to.equal("second");
+        expect(
+            await getOptional(
+                second.databaseHandle.database,
+                "records!v0!runtimeMetadata!active"
+            )
+        ).to.equal(undefined);
+        expect(
+            await getOptional(
+                second.databaseHandle.database,
+                "metadata!migrationProgress"
+            )
+        ).to.equal(undefined);
+    });
+
+    it("resets a partition only when explicitly requested", async () => {
+        const identity = {
+            chainId: "31337",
+            stateChannelManagerAddress: String(factory.randomAddress()),
+            stateMachineAddress: String(factory.randomAddress()),
+            channelId: factory.hash()
+        };
+        const originalSigner = String(factory.hexString(32));
+        const replacementSigner = String(factory.hexString(32));
+        const first = await openPersistencePartition({
+            identity,
+            persistence: { location: root },
+            signerSecret: originalSigner,
+            existingPartition: "allow"
+        });
+        await first.databaseHandle.database.put("test!stale", "value");
+        await first.databaseHandle.close();
+
+        const reset = await openPersistencePartition({
+            identity,
+            persistence: { location: root, reset: true },
+            signerSecret: replacementSigner,
+            existingPartition: "allow"
+        });
+        handles.push(reset.databaseHandle);
+
+        expect(reset.signerSecret).to.equal(replacementSigner);
+        expect(
+            await getOptional(reset.databaseHandle.database, "test!stale")
+        ).to.equal(undefined);
+    });
+
+    it("flushes many cache mutations to one ClassicLevel partition", async () => {
+        const identity = {
+            chainId: "31337",
+            stateChannelManagerAddress: String(factory.randomAddress()),
+            stateMachineAddress: String(factory.randomAddress()),
+            channelId: factory.hash()
+        };
+        const firstPartition = await openPersistencePartition({
+            identity,
+            persistence: { location: root },
+            signerSecret: String(factory.hexString(32)),
+            existingPartition: "allow"
+        });
+        const first = new Storage(undefined, {
+            flushIntervalMs: 60_000
+        });
+        await first.bind(firstPartition.databaseHandle);
+        const forkId = factory.transactionHeader().forkId;
+        const blocks = Array.from({ length: 20 }, (_, height) =>
+            factory.block({
+                transaction: {
+                    header: factory.transactionHeader({
+                        forkId,
+                        transactionCnt: height
+                    }),
+                    body: factory.transactionBody()
+                }
+            })
+        );
+
+        for (const block of blocks) first.blocks.storeBlock(block);
+        await first.flush();
+        await first.close();
+
+        const secondPartition = await openPersistencePartition({
+            identity,
+            persistence: { location: root },
+            signerSecret: String(factory.hexString(32)),
+            existingPartition: "allow"
+        });
+        const second = new Storage();
+        await second.bind(secondPartition.databaseHandle);
+        for (const block of blocks) {
+            expect(second.blocks.getBlock(block.hash)?.hash).to.equal(
+                block.hash
+            );
+        }
+        await second.close();
+    });
+});
+
+async function getOptional(
+    database: PersistenceDatabaseHandle["database"],
+    key: string
+): Promise<string | undefined> {
+    try {
+        return await database.get(key);
+    } catch (error) {
+        if (
+            typeof error === "object" &&
+            error !== null &&
+            "code" in error &&
+            error.code === "LEVEL_NOT_FOUND"
+        ) {
+            return undefined;
+        }
+        throw error;
+    }
+}

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -19,6 +19,9 @@
             "@platform/p2pRuntimeWorkerRuntime": [
                 "src/evm/p2pRuntime/browser/P2pRuntimeWorkerRuntime"
             ],
+            "@platform/persistenceDatabase": [
+                "src/storage/persistence/browser/createPersistenceDatabase"
+            ],
             "@platform/DeployUtils": ["src/utils/browser/DeployUtils"],
             "@platform/LocalDiscoveryServer": [
                 "src/utils/browser/LocalDiscoveryServer"
@@ -38,6 +41,8 @@
         "src/evm/node",
         "src/evm/contractExecutor/node",
         "src/evm/p2pRuntime/node",
+        "src/storage/persistence/node",
+        "test/storage/persistence/node",
         "src/utils/node",
         "src/utils/logging/node"
     ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,9 @@
             "@platform/p2pRuntimeWorkerRuntime": [
                 "src/evm/p2pRuntime/node/P2pRuntimeWorkerRuntime"
             ],
+            "@platform/persistenceDatabase": [
+                "src/storage/persistence/node/createPersistenceDatabase"
+            ],
             "@platform/DeployUtils": ["src/utils/node/DeployUtils"],
             "@platform/LocalDiscoveryServer": [
                 "src/utils/node/LocalDiscoveryServer"
@@ -42,6 +45,7 @@
         "src/evm/browser",
         "src/evm/contractExecutor/browser",
         "src/evm/p2pRuntime/browser",
+        "src/storage/persistence/browser",
         "src/utils/browser",
         "src/utils/logging/browser"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2728,6 +2728,18 @@ abortcontroller-polyfill@^1.7.3, abortcontroller-polyfill@^1.7.5:
   resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz#6738495f4e901fbb57b6c0611d0c75f76c485bed"
   integrity sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==
 
+abstract-level@^3, abstract-level@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/abstract-level/-/abstract-level-3.1.1.tgz#d61a7ae1a5cff15f315592a4cfa3259489ac2388"
+  integrity sha512-CW2gKbJFTuX1feMvOrvsVMmijAOgI9kg2Ie9Dq3gOcMt/dVVoVmqNlLcEUCT13NxHFMEajcUcVBIplbyDroDiw==
+  dependencies:
+    buffer "^6.0.3"
+    is-buffer "^2.0.5"
+    level-supports "^6.2.0"
+    level-transcoder "^1.0.1"
+    maybe-combine-errors "^1.0.0"
+    module-error "^1.0.1"
+
 abstract-leveldown@^6.2.1:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz#d25221d1e6612f820c35963ba4bd739928f6026a"
@@ -3382,6 +3394,13 @@ brorand@^1.0.1, brorand@^1.1.0:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
 
+browser-level@^3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/browser-level/-/browser-level-3.0.0.tgz#158287e21f44051cc06bf05abc235b385e66d264"
+  integrity sha512-kGXtLh29jMwqKaskz5xeDLtCtN1KBz/DbQSqmvH7QdJiyGRC7RAM8PPg6gvUiNMa+wVnaxS9eSmEtP/f5ajOVw==
+  dependencies:
+    abstract-level "^3.1.0"
+
 browser-stdout@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
@@ -3782,6 +3801,16 @@ class-is@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/class-is/-/class-is-1.1.0.tgz#9d3c0fba0440d211d843cec3dedfa48055005825"
   integrity sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==
+
+classic-level@^3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/classic-level/-/classic-level-3.0.0.tgz#2be00defbaf7d204ac33da77988993c6c337ba67"
+  integrity sha512-yGy8j8LjPbN0Bh3+ygmyYvrmskVita92pD/zCoalfcC9XxZj6iDtZTAnz+ot7GG8p9KLTG+MZ84tSA4AhkgVZQ==
+  dependencies:
+    abstract-level "^3.1.0"
+    module-error "^1.0.1"
+    napi-macros "^2.2.2"
+    node-gyp-build "^4.3.0"
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -7327,12 +7356,25 @@ level-supports@^2.0.1:
   resolved "https://registry.yarnpkg.com/level-supports/-/level-supports-2.1.0.tgz#9af908d853597ecd592293b2fad124375be79c5f"
   integrity sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==
 
+level-supports@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/level-supports/-/level-supports-6.2.0.tgz#e78b228973a24acdc5199c5f51e244e70f26c611"
+  integrity sha512-QNxVXP0IRnBmMsJIh+sb2kwNCYcKciQZJEt+L1hPCHrKNELllXhvrlClVHXBYZVT+a7aTSM6StgNXdAldoab3w==
+
 level-supports@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/level-supports/-/level-supports-1.0.1.tgz#2f530a596834c7301622521988e2c36bb77d122d"
   integrity sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==
   dependencies:
     xtend "^4.0.2"
+
+level-transcoder@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/level-transcoder/-/level-transcoder-1.0.1.tgz#f8cef5990c4f1283d4c86d949e73631b0bc8ba9c"
+  integrity sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==
+  dependencies:
+    buffer "^6.0.3"
+    module-error "^1.0.1"
 
 level-ws@^2.0.0:
   version "2.0.0"
@@ -7604,6 +7646,11 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
+maybe-combine-errors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/maybe-combine-errors/-/maybe-combine-errors-1.0.0.tgz#e9592832e61fc47643a92cff3c1f33e27211e5be"
+  integrity sha512-eefp6IduNPT6fVdwPp+1NgD0PML1NU5P6j1Mj5nz1nidX8/sWY7119WL8vTAHgqfsY74TzW0w1XPgdYEKkGZ5A==
+
 mcl-wasm@^0.7.1:
   version "0.7.9"
   resolved "https://registry.yarnpkg.com/mcl-wasm/-/mcl-wasm-0.7.9.tgz#c1588ce90042a8700c3b60e40efb339fc07ab87f"
@@ -7634,6 +7681,15 @@ memdown@^5.0.0:
     inherits "~2.0.1"
     ltgt "~2.2.0"
     safe-buffer "~5.2.0"
+
+memory-level@^3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/memory-level/-/memory-level-3.1.0.tgz#76d971f50072e3408ca7aacf3e97eeddea293517"
+  integrity sha512-mTqFVi5iReKcjue/pag0OY4VNU7dlagCyjjPwWGierpk1Bpl9WjOxgXIswymPW3Q9bj3Foay+Z16mPGnKzvTkQ==
+  dependencies:
+    abstract-level "^3.1.0"
+    functional-red-black-tree "^1.0.1"
+    module-error "^1.0.1"
 
 memorystream@^0.3.1:
   version "0.3.1"
@@ -7882,6 +7938,11 @@ mock-fs@^4.1.0:
   resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.14.0.tgz#ce5124d2c601421255985e6e94da80a7357b1b18"
   integrity sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw==
 
+module-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/module-error/-/module-error-1.0.2.tgz#8d1a48897ca883f47a45816d4fb3e3c6ba404d86"
+  integrity sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==
+
 mp4box@^0.5.2:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/mp4box/-/mp4box-0.5.4.tgz#f09d85482e9215927e6a617e4894c742f3f019f7"
@@ -7987,7 +8048,7 @@ nanoid@^3.3.12:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
   integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
 
-napi-macros@^2.0.0:
+napi-macros@^2.0.0, napi-macros@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/napi-macros/-/napi-macros-2.2.2.tgz#817fef20c3e0e40a963fbf7b37d1600bd0201044"
   integrity sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==


### PR DESCRIPTION
## Why

Part of the mobile background/reconnect work - [Issue on Trello](https://trello.com/c/PjDUGE4c). A player whose tab gets fully discarded while backgrounded loses all local channel state today, since `BlockStorage` is pure in-memory — recovery then depends entirely on peers/chain being reachable. This adds a persistence seam so a cold reload can rehydrate locally first.

## What changed

`BlockStorage` now takes an optional `IStoragePersistence` port (`persistBlock` / `deleteBlock` / `loadAll`). Every mutating method (`storeBlock`, `insertSignature`, `setOnChainTimestamp`, `deleteBlock`) drives it write-through with the post-mutation block state, and a new `hydrate()` rebuilds the in-memory maps from it on startup.

Reads stay fully synchronous — `getBlock`/`getNextBlockHeight`/`getLatestBlock`/`getIterator` are unchanged. This matters because callers in `StateManager`/`DisputeManager`/`SpectateService` read `BlockStorage` inside mutex-held sections; making reads async would have forced a much larger refactor across all of them.

Defaults to an in-memory-backed `InMemoryPersistence`, so this is behavior-preserving for every existing caller today. Real IndexedDB (browser) and Node-backed implementations are separate follow-up tickets — this one just establishes the seam.

Derived indexes (`forkIdToMaxHeightMap`) are rebuilt on `hydrate()`, never persisted directly, to avoid drift with the existing delete-decrement logic. A persistence call that throws invokes an error hook rather than surfacing into the synchronous caller that triggered it.

## A landmine found, not fixed here (flagging for the follow-up ticket)

`Storage` wraps every sub-store in `deepCopyProxy` (`src/utils/DeepCopyProxy.ts`), which runs `lodash.cloneDeep()` on every method's return value — including `Promise`s. `cloneDeep` has no special case for `Promise` (unlike the existing generator special-case right above it in the same file), so it silently strips the internal slots `.then()` needs.

`hydrate()` keeps an internal unproxied reference so it awaits correctly as implemented and tested here. But `Storage.hydrate()` invoked through a real proxied `Storage` instance will hit this the moment external callers are wired up in the follow-up ticket that extends persistence to sibling stores. The fix is small (mirror the existing generator special-case: `if (result instanceof Promise) return result;`) but is out of scope for this PR since `DeepCopyProxy.ts` isn't otherwise touched here.

## Test plan

- `yarn tsc --noEmit -p tsconfig.json` and `-p tsconfig.browser.json` — both clean.
- `test/storage/BlockStorage.test.ts` — 38/38 passing (32 pre-existing + 6 new persistence tests): default behavior unchanged when unhydrated, `hydrate()` correctly rebuilds all three maps, post-mutation state (signatures, on-chain timestamp) round-trips through persist→hydrate, `deleteBlock` drives the persistence delete, a throwing persistence implementation invokes the error hook without throwing into the caller, and a truncated/corrupt-tip store hydrates cleanly to the highest contiguous height.
- Note: running via `yarn mocha` directly currently fails for an unrelated, pre-existing reason — `.mocharc.json`'s config forces every `test/**/*.ts` file to load regardless of the path passed on the CLI, and an unrelated e2e file (`test/e2e/E2E-PingService.test.ts`) throws under Node's ESM loader when loaded that way. Reproduces identically on `dispute` with zero changes from this PR. Worked around for this validation via `npx mocha --no-config --require hardhat/register --timeout 40000 test/storage/BlockStorage.test.ts`.