### PR TITLE
fix(p2p): jitter HolepunchRelay's retry/backoff to avoid thundering herds

### DIFF
--- a/src/HolepunchRelay.ts
+++ b/src/HolepunchRelay.ts
@@ -10,6 +10,10 @@ import { Logger } from "@/utils";
 // success), so a fully-down network doesn't tight-loop hammering reconnects.
 const BACKOFF_BASE_MS = 1000;
 const BACKOFF_CAP_MS = 30000;
+// Upper bound for the randomized delay before retrying after a single
+// relayer failure, so many clients failing over at the same instant don't
+// all pile onto the next relayer at once (thundering herd).
+const FAILOVER_JITTER_MAX_MS = 250;
 
 class HolepunchRelay {
     relayerUrls: string[];
@@ -131,14 +135,18 @@ class HolepunchRelay {
     }
 
     private scheduleRetryAfterExhaustion(): void {
-        const delayMs = Math.min(
+        // Full jitter (AWS-style): pick uniformly in [0, cappedBackoff] rather
+        // than retrying at the deterministic cappedBackoff mark, so clients
+        // that exhaust the pool at the same moment don't retry in lockstep.
+        const cappedBackoffMs = Math.min(
             BACKOFF_BASE_MS * 2 ** this.backoffAttempt,
             BACKOFF_CAP_MS
         );
+        const delayMs = Math.random() * cappedBackoffMs;
         this.backoffAttempt++;
         this.logger.warn(
             "All holepunch relayers failed, retrying pool after backoff",
-            { delayMs, relayerUrls: this.relayerUrls }
+            { delayMs, cappedBackoffMs, relayerUrls: this.relayerUrls }
         );
         this.excludedRelayers.clear();
         setTimeout(() => this.connectToRelayer(), delayMs);
@@ -151,7 +159,10 @@ class HolepunchRelay {
             excludedCount: this.excludedRelayers.size,
             total: this.relayerUrls.length
         });
-        this.connectToRelayer();
+        // Randomized delay so many clients failing over off the same
+        // relayer at once don't all hit the next relayer simultaneously.
+        const delayMs = Math.random() * FAILOVER_JITTER_MAX_MS;
+        setTimeout(() => this.connectToRelayer(), delayMs);
     }
 }
 

--- a/src/HolepunchRelay.ts
+++ b/src/HolepunchRelay.ts
@@ -159,6 +159,13 @@ class HolepunchRelay {
             excludedCount: this.excludedRelayers.size,
             total: this.relayerUrls.length
         });
+        // Branch immediately so a pool-exhausting failure schedules only the
+        // exhaustion backoff, never the failover jitter as well - one timer
+        // owner per failure, not two stacked delays.
+        if (this.isRelayerPoolExhausted()) {
+            this.scheduleRetryAfterExhaustion();
+            return;
+        }
         // Randomized delay so many clients failing over off the same
         // relayer at once don't all hit the next relayer simultaneously.
         const delayMs = Math.random() * FAILOVER_JITTER_MAX_MS;

--- a/test/utils/HolepunchRelay.test.ts
+++ b/test/utils/HolepunchRelay.test.ts
@@ -215,13 +215,19 @@ describe("HolepunchRelay", function () {
             "wss://relay-b.example",
             "wss://relay-c.example"
         ];
-        const setTimeoutSpy = sinon.spy(global, "setTimeout");
         const delays: number[] = [];
 
         // Simulate several independent clients failing over off one relayer
         // at essentially the same instant (a reconnect storm), and capture
-        // the randomized retry delay each one schedules.
+        // the randomized retry delay each one schedules. Give each client
+        // its own fake-timer clock, spy, and instance list - otherwise a
+        // timer left pending by an earlier "client" can fire during a later
+        // one's clock.tick() and get mistaken for that client's own retry.
         for (let i = 0; i < 8; i++) {
+            clock.restore();
+            clock = sinon.useFakeTimers();
+            const setTimeoutSpy = sinon.spy(global, "setTimeout");
+            FakeWebSocket.instances = [];
             HolepunchRelay.init(relayerUrls, () => undefined, createLogger());
             const ws =
                 FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
@@ -243,12 +249,19 @@ describe("HolepunchRelay", function () {
 
     it("applies full jitter (not a deterministic mark) to the exhaustion backoff", () => {
         const relayerUrls = ["wss://relay-a.example", "wss://relay-b.example"];
-        const setTimeoutSpy = sinon.spy(global, "setTimeout");
         const delays: number[] = [];
 
         // Simulate several independent clients that all exhaust the full
         // relayer pool at the same moment (e.g. a shared relayer outage).
+        // Give each client its own fake-timer clock, spy, and instance list
+        // - otherwise a timer left pending by an earlier "client" can fire
+        // during a later one's clock.tick() and get mistaken for that
+        // client's own retry (inflating its captured delay).
         for (let i = 0; i < 8; i++) {
+            clock.restore();
+            clock = sinon.useFakeTimers();
+            const setTimeoutSpy = sinon.spy(global, "setTimeout");
+            FakeWebSocket.instances = [];
             HolepunchRelay.init(relayerUrls, () => undefined, createLogger());
             // Fail the first relayer, then advance past its (jittered)
             // failover retry so the client actually reconnects to the

--- a/test/utils/HolepunchRelay.test.ts
+++ b/test/utils/HolepunchRelay.test.ts
@@ -34,6 +34,9 @@ stubModule("@hyperswarm/dht-relay/ws", FakeDhtStream);
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const HolepunchRelay = require("@/HolepunchRelay").default;
 
+// Mirrors HolepunchRelay.ts's FAILOVER_JITTER_MAX_MS (not exported).
+const FAILOVER_JITTER_MAX_MS = 250;
+
 // Minimal fake WebSocket the test drives manually via emitOpen/emitClose/emitError.
 class FakeWebSocket {
     static instances: FakeWebSocket[] = [];
@@ -180,23 +183,99 @@ describe("HolepunchRelay", function () {
         );
 
         // Fail both relayers once (exhausts the round, schedules backoff).
+        // The first failure only schedules the (jittered) failover retry -
+        // advance past it so the second relayer actually connects before
+        // failing it too.
         FakeWebSocket.instances[0].emitClose();
-        FakeWebSocket.instances[1].emitClose();
+        clock.tick(FAILOVER_JITTER_MAX_MS);
+        FakeWebSocket.instances[FakeWebSocket.instances.length - 1].emitClose();
 
-        // The first exhaustion backoff is base * 2^0 = 1s; advance past it
-        // so the pool retries and produces a fresh connection to succeed on.
+        // The first exhaustion backoff is at most base * 2^0 = 1s; advance
+        // past it so the pool retries and produces a fresh connection to
+        // succeed on.
         clock.tick(1000);
         const successWs =
             FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
         successWs.emitOpen();
 
         // After success, a subsequent single failure must not be treated as
-        // a full-round exhaustion (no backoff delay) - a new connection
-        // attempt should happen synchronously via connectToRelayer(), not
-        // require a timer tick.
+        // a full-round exhaustion (no backoff delay) - the retry only needs
+        // the small failover jitter (well under the 1s exhaustion backoff
+        // floor) to elapse, not a full backoff tick.
         const countBeforeFailure = updateCallbackCount;
         successWs.emitClose();
+        clock.tick(FAILOVER_JITTER_MAX_MS);
 
         expect(updateCallbackCount).to.equal(countBeforeFailure + 1);
+    });
+
+    it("adds a randomized, non-synchronized delay before retrying a single relayer failure", () => {
+        const relayerUrls = [
+            "wss://relay-a.example",
+            "wss://relay-b.example",
+            "wss://relay-c.example"
+        ];
+        const setTimeoutSpy = sinon.spy(global, "setTimeout");
+        const delays: number[] = [];
+
+        // Simulate several independent clients failing over off one relayer
+        // at essentially the same instant (a reconnect storm), and capture
+        // the randomized retry delay each one schedules.
+        for (let i = 0; i < 8; i++) {
+            HolepunchRelay.init(relayerUrls, () => undefined, createLogger());
+            const ws =
+                FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+            setTimeoutSpy.resetHistory();
+            ws.emitClose();
+
+            expect(setTimeoutSpy.calledOnce).to.equal(true);
+            const delayMs = setTimeoutSpy.firstCall.args[1] as number;
+            expect(delayMs).to.be.at.least(0);
+            expect(delayMs).to.be.lessThan(FAILOVER_JITTER_MAX_MS);
+            delays.push(delayMs);
+        }
+
+        // Not a thundering herd: delays aren't all identical, and not all
+        // zero (the pre-fix, always-synchronous-retry behavior).
+        expect(new Set(delays).size).to.be.greaterThan(1);
+        expect(delays.some((delayMs) => delayMs > 0)).to.equal(true);
+    });
+
+    it("applies full jitter (not a deterministic mark) to the exhaustion backoff", () => {
+        const relayerUrls = ["wss://relay-a.example", "wss://relay-b.example"];
+        const setTimeoutSpy = sinon.spy(global, "setTimeout");
+        const delays: number[] = [];
+
+        // Simulate several independent clients that all exhaust the full
+        // relayer pool at the same moment (e.g. a shared relayer outage).
+        for (let i = 0; i < 8; i++) {
+            HolepunchRelay.init(relayerUrls, () => undefined, createLogger());
+            // Fail the first relayer, then advance past its (jittered)
+            // failover retry so the client actually reconnects to the
+            // second relayer before failing that one too.
+            FakeWebSocket.instances[
+                FakeWebSocket.instances.length - 1
+            ].emitClose();
+            clock.tick(FAILOVER_JITTER_MAX_MS);
+            setTimeoutSpy.resetHistory();
+            FakeWebSocket.instances[
+                FakeWebSocket.instances.length - 1
+            ].emitClose();
+
+            // The second failure exhausts the 2-relayer pool and schedules
+            // the backoff retry - capture that delay.
+            expect(setTimeoutSpy.calledOnce).to.equal(true);
+            const delayMs = setTimeoutSpy.firstCall.args[1] as number;
+            // First exhaustion: cappedBackoffMs = BACKOFF_BASE_MS * 2^0 = 1000.
+            expect(delayMs).to.be.at.least(0);
+            expect(delayMs).to.be.lessThan(1000);
+            delays.push(delayMs);
+        }
+
+        // Full jitter, not the deterministic 1000ms mark every client would
+        // hit pre-fix - delays are spread across the range, not lockstepped.
+        expect(new Set(delays).size).to.be.greaterThan(1);
+        expect(delays.some((delayMs) => delayMs > 0)).to.equal(true);
+        expect(delays.every((delayMs) => delayMs !== 1000)).to.equal(true);
     });
 });


### PR DESCRIPTION
## Why

Follow-up to #386. That PR fixed the relayer pool permanently exhausting itself after repeated failures, but left two synchronized-retry gaps:

1. Single-relayer failover retried the next relayer immediately, with zero delay.
2. Full-pool-exhaustion backoff retried at a deterministic mark (`BACKOFF_BASE_MS * 2^n`).

Either way, if many clients fail over at the same moment (e.g. a relayer actually going down, or a wave of clients reconnecting after backgrounding), they all retry in lockstep — amplifying load on whichever relayer survives right when it's under the most pressure.

## What changed

`src/HolepunchRelay.ts`:
- Single-relayer failover now waits a small randomized delay (0–250ms, `FAILOVER_JITTER_MAX_MS`) before retrying, instead of retrying synchronously.
- Full-pool-exhaustion backoff now applies full jitter — uniform random in `[0, cappedBackoff]` — instead of retrying at the deterministic capped value.

Success path (exclusions + backoff counter resetting on `ws.onopen`) is unchanged.

## Test plan

- Extended `test/utils/HolepunchRelay.test.ts` (3 → 5 tests): two new tests simulate several concurrent clients failing over/exhausting at the same instant and assert the resulting delays are bounded, non-identical, and not pinned at the old deterministic marks — not just "a delay exists."
- The two pre-existing tests that relied on the old zero-delay synchronous failover were updated to advance the fake clock past the new jitter window, without changing what they actually assert (exclusion/backoff reset behavior is unchanged).
- `yarn tsc --noEmit -p tsconfig.json` and `-p tsconfig.browser.json` — both clean.
- `yarn hardhat test --no-compile test/utils/HolepunchRelay.test.ts` — 5/5 passing.