### PR TITLE
fix(state-manager): handle dispute-storage race on reduction and snapshot-fork paths

### DIFF
--- a/src/agreementManager/AgreementManager.ts
+++ b/src/agreementManager/AgreementManager.ts
@@ -24,6 +24,22 @@ import { ReduceData } from "@/types";
 import { LoggerUtils } from "@/utils/LoggerUtils";
 
 /**
+ * Thrown when a dispute commitment is present on-chain in the window but its
+ * struct has not been stored locally yet — the commitment landed before our
+ * onDisputeCommitted handler ran. Callers treat this as a transient "nothing to
+ * reduce yet" condition (discard and retry once the struct lands), so it is a
+ * typed error rather than a matched message string.
+ */
+export class MissingDisputeInStorageError extends Error {
+    constructor(public readonly commitment: string) {
+        super(
+            `Missing Dispute in storage for dispute commitment ${commitment}`
+        );
+        this.name = "MissingDisputeInStorageError";
+    }
+}
+
+/**
  * AgreementManager acts as a higher logic layer over storage
  * It interprets storage data and provides convenience methods
  */
@@ -527,9 +543,7 @@ class AgreementManager {
         for (const commitment of disputeCommitments) {
             const dispute = this.storage.disputes.getDispute(commitment);
             if (!dispute) {
-                throw new Error(
-                    `Missing Dispute in storage for dispute commitment ${commitment}`
-                );
+                throw new MissingDisputeInStorageError(commitment);
             }
 
             currentWindowDisputes.push(dispute);

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -28,7 +28,9 @@ import {
 import { StateChannelManagerProxy } from "@typechain-types";
 
 // Core components
-import AgreementManager from "../agreementManager/AgreementManager";
+import AgreementManager, {
+    MissingDisputeInStorageError
+} from "../agreementManager/AgreementManager";
 import ADiamondStateMachine from "@/ADiamondStateMachine";
 import Clock from "@/Clock";
 import DisputeManager from "@/disputeManager";
@@ -509,21 +511,11 @@ class StateManager<
             );
         }
 
-        // Step 4: Perform reduction
-        try {
-            await this.performReduction(forkId);
-        } catch (error) {
-            if (
-                error instanceof Error &&
-                error.message.startsWith("Missing Dispute in storage")
-            ) {
-                this.logger.error(
-                    `Skipping reduction for fork ${forkId} because local dispute data is unavailable`,
-                    { error: error.message }
-                );
-            }
-            throw error;
-        }
+        // Step 4: Perform reduction. The "dispute struct not yet stored" race is
+        // handled at the source (reduceLocally discards), so performReduction
+        // returns without reducing rather than throwing an unhandled rejection
+        // out of this fire-and-forget path.
+        await this.performReduction(forkId);
     }
 
     /**
@@ -568,11 +560,27 @@ class StateManager<
         }
         const genesisTimestamp = Number(killPeriodEnd);
 
-        const disputes = await this.agreementManager.getForkDisputes(
-            this.channelId,
-            forkId,
-            this.stateChannelManagerContract
-        );
+        let disputes: DisputeStruct[];
+        try {
+            disputes = await this.agreementManager.getForkDisputes(
+                this.channelId,
+                forkId,
+                this.stateChannelManagerContract
+            );
+        } catch (error) {
+            // Race: a dispute commitment is already on-chain (in the window) but
+            // our onDisputeCommitted handler hasn't stored the struct yet.
+            // Nothing to reduce until it lands — discard; a later reduction
+            // attempt converges once the struct arrives.
+            if (error instanceof MissingDisputeInStorageError) {
+                this.logger.warn(
+                    `reduceLocally - dispute struct not yet stored for fork ${LoggerUtils.formatHash(forkId)}; discarding until it lands`,
+                    { error: error.message }
+                );
+                return undefined;
+            }
+            throw error;
+        }
 
         this.logger.debug(
             `Performing local reduction on disputes for fork ${LoggerUtils.formatHash(forkId)}`,
@@ -2174,9 +2182,7 @@ class StateManager<
                         const dispute =
                             this.storage.disputes.getDispute(commitment);
                         if (!dispute) {
-                            throw new Error(
-                                `Missing Dispute in storage for dispute commitment ${commitment}`
-                            );
+                            throw new MissingDisputeInStorageError(commitment);
                         }
                         return dispute;
                     }

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -2176,17 +2176,29 @@ class StateManager<
                     break;
                 }
 
-                // Build disputes from local storage confirmations
-                const disputes: DisputeStruct[] = disputeCommitments.map(
-                    (commitment) => {
-                        const dispute =
-                            this.storage.disputes.getDispute(commitment);
-                        if (!dispute) {
-                            throw new MissingDisputeInStorageError(commitment);
-                        }
-                        return dispute;
+                // Build disputes from local storage confirmations. A commitment
+                // can be on-chain before our onDisputeCommitted handler stored
+                // its struct; treat a missing struct like the no-commitments
+                // case above — stop traversal and wait for more data. A later
+                // attempt converges once the struct arrives.
+                const disputes: DisputeStruct[] = [];
+                let disputeStructNotYetStored = false;
+                for (const commitment of disputeCommitments) {
+                    const dispute =
+                        this.storage.disputes.getDispute(commitment);
+                    if (!dispute) {
+                        this.logger.warn(
+                            "prepareUpdateStateSnapshotFork - dispute struct not yet stored; stopping traversal (wait for more data)",
+                            { forkId: currentForkId, commitment }
+                        );
+                        disputeStructNotYetStored = true;
+                        break;
                     }
-                );
+                    disputes.push(dispute);
+                }
+                if (disputeStructNotYetStored) {
+                    break;
+                }
 
                 this.logger.verbose(
                     "prepareUpdateStateSnapshotFork - disputes built from storage",

--- a/test/e2e/E2E-AgreementManager.test.ts
+++ b/test/e2e/E2E-AgreementManager.test.ts
@@ -1,84 +1,98 @@
 import { MathTestSession as TestSession } from "@test/harness";
 
 /**
- * E2E Tests for the Agreement Manager
+ * E2E Tests for the dispute-storage race condition.
  *
  * Maps to: src/agreementManager/AgreementManager.ts (getForkDisputes)
  *          src/stateManager/StateManager.ts (reduceLocally / performLocalReduction,
- *                                            tryReduce)
+ *                                            tryReduce, prepareUpdateStateSnapshotFork)
  *
- * Dispute-storage race condition: a dispute commitment lands on-chain before our
- * onDisputeCommitted handler stores the struct locally. A reduction firing in
- * that gap sees the on-chain commitment but no local struct, so getForkDisputes
- * throws "Missing Dispute in storage". reduceLocally must treat this as "nothing
- * to reduce yet" and discard (return undefined) — not propagate the throw, which
- * on the fire-and-forget tryReduce path becomes an unhandled rejection.
+ * A dispute commitment lands on-chain before our onDisputeCommitted handler
+ * stores the struct locally. Any code reading the window then sees the on-chain
+ * commitment but no local struct ("Missing Dispute in storage"). Both readers
+ * must treat this as "nothing to do yet" and wait for the struct, not throw:
+ *  - reduceLocally (via getForkDisputes) discards — else the fire-and-forget
+ *    tryReduce path leaks an unhandled rejection.
+ *  - prepareUpdateStateSnapshotFork (via postStateSnapshot on the exit path)
+ *    stops traversal — else the exit snapshot post throws.
  */
+
+/**
+ * Drive four peers to a committed, kill-period-expired dispute in which no peer
+ * ever stored the dispute struct locally: no-op storeDisputeConfirmation (the
+ * only writer of the struct map) on every peer before the dispute, so the
+ * commitment lands on-chain but the struct never does — and, since no struct
+ * means no reduction, every peer stays on the disputed fork (deterministic).
+ * Returns an honest observer to exercise the window readers on.
+ */
+async function setupPartialDisputeWindow() {
+    const h = TestSession.getHarness();
+
+    // Short evidence window so the on-chain kill period expires quickly.
+    await h.scenario.preDisputeSetup({
+        peerCount: 4,
+        timeConfig: { evidenceTime: 6 }
+    });
+
+    // Reproduce the race on every peer: no-op the ONLY writer of the
+    // dispute-struct map (EventHandler.onDisputeCommitted ->
+    // storage.disputes.storeDisputeConfirmation). The on-chain commitment still
+    // lands, but no peer ever stores the struct — so no peer reduces and there
+    // is no reduced fork to adopt (keeps the scenario deterministic).
+    await Promise.all(
+        h.peers.map((peer) =>
+            h.execOnHost(peer, (sm) => {
+                sm.storage.disputes.storeDisputeConfirmation = () =>
+                    "0x0000000000000000000000000000000000000000000000000000000000000000";
+                return true;
+            })
+        )
+    );
+
+    // Malicious peer authors an invalid block; the honest peers dispute it and
+    // commit on-chain.
+    const malicious = await h.query.getNextPeerToWrite();
+    await h.byzantine.submitInvalidStateTransitionBlock(malicious.index);
+
+    // An honest observer processes the on-chain commitment (its struct write is
+    // a no-op), so its dispute window holds a commitment with no local struct.
+    const observer = h.peers.find((p) => p.index !== malicious.index)!;
+    await h.event.waitForPeers("onDisputeCommitted", [observer.index], 1, {
+        mode: "atLeast",
+        timeoutMs: 20000
+    });
+
+    // Wait for the on-chain kill period to expire. Poll at the test level with
+    // fast host calls — a single scenario.exec RPC must stay under its 2s
+    // timeout, so the wait can't live inside one exec body.
+    const killDeadline = Date.now() + 60000;
+    let killExpired = false;
+    while (Date.now() < killDeadline) {
+        killExpired = await h.execOnHost(observer, async (sm) => {
+            const { isExpired } =
+                await sm.stateChannelManagerContract.isKillPeriodExpired(
+                    sm.channelId,
+                    sm.forkId
+                );
+            return isExpired;
+        });
+        if (killExpired) break;
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+    if (!killExpired) {
+        throw new Error("kill period did not expire within timeout");
+    }
+
+    return { h, observer };
+}
+
 describe("E2E: Agreement Manager", function () {
     it("partial dispute window (commitment on-chain, struct not yet stored) → reduceLocally discards, not throws", async function () {
         this.timeout(90000);
-        const h = TestSession.getHarness();
+        const { h, observer } = await setupPartialDisputeWindow();
 
-        // Short evidence window so the on-chain kill period expires quickly.
-        await h.scenario.preDisputeSetup({
-            peerCount: 4,
-            timeConfig: { evidenceTime: 6 }
-        });
-
-        // Reproduce the race on every peer: no-op the ONLY writer of the
-        // dispute-struct map (EventHandler.onDisputeCommitted ->
-        // storage.disputes.storeDisputeConfirmation). The on-chain commitment
-        // still lands, but no peer ever stores the struct — so no peer reduces
-        // and there is no reduced fork to adopt (keeps the scenario
-        // deterministic: everyone stays on the disputed fork).
-        await Promise.all(
-            h.peers.map((peer) =>
-                h.execOnHost(peer, (sm) => {
-                    sm.storage.disputes.storeDisputeConfirmation = () =>
-                        "0x0000000000000000000000000000000000000000000000000000000000000000";
-                    return true;
-                })
-            )
-        );
-
-        // Malicious peer authors an invalid block; the honest peers dispute it
-        // and commit on-chain.
-        const malicious = await h.query.getNextPeerToWrite();
-        await h.byzantine.submitInvalidStateTransitionBlock(malicious.index);
-
-        // An honest observer processes the on-chain commitment (its struct write
-        // is a no-op), so its dispute window now holds a commitment with no local
-        // struct.
-        const observer = h.peers.find((p) => p.index !== malicious.index)!;
-        await h.event.waitForPeers("onDisputeCommitted", [observer.index], 1, {
-            mode: "atLeast",
-            timeoutMs: 20000
-        });
-
-        // Wait for the on-chain kill period to expire so reduceLocally gets past
-        // its isKillPeriodExpired guard and reaches getForkDisputes. Poll at the
-        // test level with fast host calls — a single scenario.exec RPC must stay
-        // under its 2s timeout, so the wait can't live inside one exec body.
-        const killDeadline = Date.now() + 60000;
-        let killExpired = false;
-        while (Date.now() < killDeadline) {
-            killExpired = await h.execOnHost(observer, async (sm) => {
-                const { isExpired } =
-                    await sm.stateChannelManagerContract.isKillPeriodExpired(
-                        sm.channelId,
-                        sm.forkId
-                    );
-                return isExpired;
-            });
-            if (killExpired) break;
-            await new Promise((resolve) => setTimeout(resolve, 2000));
-        }
-        if (!killExpired) {
-            throw new Error("kill period did not expire within timeout");
-        }
-
-        // reduceLocally now reaches getForkDisputes -> "Missing Dispute in
-        // storage" and must discard (return undefined), not throw.
+        // reduceLocally reaches getForkDisputes -> "Missing Dispute in storage"
+        // and must discard (return undefined), not throw.
         const result = await h.execOnHost(observer, async (sm) => {
             const forkId = sm.forkId;
 
@@ -138,6 +152,80 @@ describe("E2E: Agreement Manager", function () {
         if (!result.discarded) {
             throw new Error(
                 "reduceLocally did not discard (expected undefined return)"
+            );
+        }
+    });
+
+    it("partial dispute window (commitment on-chain, struct not yet stored) → prepareUpdateStateSnapshotFork stops traversal, not throws", async function () {
+        this.timeout(90000);
+        const { h, observer } = await setupPartialDisputeWindow();
+
+        // prepareUpdateStateSnapshotFork (reached via postStateSnapshot on the
+        // exit path) traverses the disputed fork and reads the same window. With
+        // a commitment on-chain but no local struct it must stop traversal and
+        // wait for more data, not throw. The observer stayed on the disputed
+        // fork (no reduction happened), so sm.forkId is the on-chain fork the
+        // traversal starts from.
+        const result = await h.execOnHost(observer, async (sm) => {
+            const forkId = sm.forkId;
+            const isDisputed =
+                await sm.stateChannelManagerContract.isForkDisputed(
+                    sm.channelId,
+                    forkId
+                );
+            const commitments = Array.from(
+                await sm.stateChannelManagerContract.getWindowCommitments(
+                    sm.channelId,
+                    forkId
+                )
+            );
+            const anyStructPresent = commitments.some(
+                (commitment) =>
+                    sm.storage.disputes.getDispute(commitment) !== undefined
+            );
+
+            let threw = false;
+            let message = "";
+            try {
+                await sm.prepareUpdateStateSnapshotFork();
+            } catch (error) {
+                threw = true;
+                message =
+                    error instanceof Error ? error.message : String(error);
+            }
+
+            return {
+                isDisputed,
+                commitmentCount: commitments.length,
+                anyStructPresent,
+                threw,
+                message
+            };
+        });
+
+        // The reproduction must be genuine: the fork is disputed with a
+        // commitment whose struct is absent locally (else the traversal never
+        // reaches the struct read).
+        if (!result.isDisputed) {
+            throw new Error("expected the fork to be disputed on-chain");
+        }
+        if (result.commitmentCount === 0) {
+            throw new Error(
+                "expected at least one on-chain dispute commitment"
+            );
+        }
+        if (result.anyStructPresent) {
+            throw new Error(
+                "expected the dispute struct to be absent from local storage"
+            );
+        }
+
+        // The fix: prepareUpdateStateSnapshotFork must stop traversal on the
+        // not-yet-stored dispute rather than throwing "Missing Dispute in
+        // storage" out of the exit-path postStateSnapshot caller.
+        if (result.threw) {
+            throw new Error(
+                `prepareUpdateStateSnapshotFork threw instead of stopping traversal: ${result.message}`
             );
         }
     });

--- a/test/e2e/E2E-AgreementManager.test.ts
+++ b/test/e2e/E2E-AgreementManager.test.ts
@@ -1,0 +1,144 @@
+import { MathTestSession as TestSession } from "@test/harness";
+
+/**
+ * E2E Tests for the Agreement Manager
+ *
+ * Maps to: src/agreementManager/AgreementManager.ts (getForkDisputes)
+ *          src/stateManager/StateManager.ts (reduceLocally / performLocalReduction,
+ *                                            tryReduce)
+ *
+ * Dispute-storage race condition: a dispute commitment lands on-chain before our
+ * onDisputeCommitted handler stores the struct locally. A reduction firing in
+ * that gap sees the on-chain commitment but no local struct, so getForkDisputes
+ * throws "Missing Dispute in storage". reduceLocally must treat this as "nothing
+ * to reduce yet" and discard (return undefined) — not propagate the throw, which
+ * on the fire-and-forget tryReduce path becomes an unhandled rejection.
+ */
+describe("E2E: Agreement Manager", function () {
+    it("partial dispute window (commitment on-chain, struct not yet stored) → reduceLocally discards, not throws", async function () {
+        this.timeout(90000);
+        const h = TestSession.getHarness();
+
+        // Short evidence window so the on-chain kill period expires quickly.
+        await h.scenario.preDisputeSetup({
+            peerCount: 4,
+            timeConfig: { evidenceTime: 6 }
+        });
+
+        // Reproduce the race on every peer: no-op the ONLY writer of the
+        // dispute-struct map (EventHandler.onDisputeCommitted ->
+        // storage.disputes.storeDisputeConfirmation). The on-chain commitment
+        // still lands, but no peer ever stores the struct — so no peer reduces
+        // and there is no reduced fork to adopt (keeps the scenario
+        // deterministic: everyone stays on the disputed fork).
+        await Promise.all(
+            h.peers.map((peer) =>
+                h.execOnHost(peer, (sm) => {
+                    sm.storage.disputes.storeDisputeConfirmation = () =>
+                        "0x0000000000000000000000000000000000000000000000000000000000000000";
+                    return true;
+                })
+            )
+        );
+
+        // Malicious peer authors an invalid block; the honest peers dispute it
+        // and commit on-chain.
+        const malicious = await h.query.getNextPeerToWrite();
+        await h.byzantine.submitInvalidStateTransitionBlock(malicious.index);
+
+        // An honest observer processes the on-chain commitment (its struct write
+        // is a no-op), so its dispute window now holds a commitment with no local
+        // struct.
+        const observer = h.peers.find((p) => p.index !== malicious.index)!;
+        await h.event.waitForPeers("onDisputeCommitted", [observer.index], 1, {
+            mode: "atLeast",
+            timeoutMs: 20000
+        });
+
+        // Wait for the on-chain kill period to expire so reduceLocally gets past
+        // its isKillPeriodExpired guard and reaches getForkDisputes. Poll at the
+        // test level with fast host calls — a single scenario.exec RPC must stay
+        // under its 2s timeout, so the wait can't live inside one exec body.
+        const killDeadline = Date.now() + 60000;
+        let killExpired = false;
+        while (Date.now() < killDeadline) {
+            killExpired = await h.execOnHost(observer, async (sm) => {
+                const { isExpired } =
+                    await sm.stateChannelManagerContract.isKillPeriodExpired(
+                        sm.channelId,
+                        sm.forkId
+                    );
+                return isExpired;
+            });
+            if (killExpired) break;
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+        }
+        if (!killExpired) {
+            throw new Error("kill period did not expire within timeout");
+        }
+
+        // reduceLocally now reaches getForkDisputes -> "Missing Dispute in
+        // storage" and must discard (return undefined), not throw.
+        const result = await h.execOnHost(observer, async (sm) => {
+            const forkId = sm.forkId;
+
+            // Confirm the scenario is genuine: an on-chain commitment exists but
+            // its struct is absent locally (getForkDisputes would throw).
+            const commitments = Array.from(
+                await sm.stateChannelManagerContract.getWindowCommitments(
+                    sm.channelId,
+                    forkId
+                )
+            );
+            const anyStructPresent = commitments.some(
+                (commitment) =>
+                    sm.storage.disputes.getDispute(commitment) !== undefined
+            );
+
+            let threw = false;
+            let discarded = false;
+            let message = "";
+            try {
+                const reduction = await sm.reduceLocally(forkId);
+                discarded = reduction === undefined;
+            } catch (error) {
+                threw = true;
+                message =
+                    error instanceof Error ? error.message : String(error);
+            }
+
+            return {
+                commitmentCount: commitments.length,
+                anyStructPresent,
+                threw,
+                discarded,
+                message
+            };
+        });
+
+        // The reproduction must be genuine, or the assertion below is vacuous.
+        if (result.commitmentCount === 0) {
+            throw new Error(
+                "expected at least one on-chain dispute commitment"
+            );
+        }
+        if (result.anyStructPresent) {
+            throw new Error(
+                "expected the dispute struct to be absent from local storage"
+            );
+        }
+
+        // The fix: reduceLocally must discard the not-yet-stored dispute rather
+        // than throwing (which the fire-and-forget tryReduce path would leak).
+        if (result.threw) {
+            throw new Error(
+                `reduceLocally threw instead of discarding: ${result.message}`
+            );
+        }
+        if (!result.discarded) {
+            throw new Error(
+                "reduceLocally did not discard (expected undefined return)"
+            );
+        }
+    });
+});


### PR DESCRIPTION
## Summary

A dispute commitment can land on-chain before our `onDisputeCommitted` handler
stores the dispute struct locally. Any code that reads the window in that gap
sees the on-chain commitment but no local struct, so `getForkDisputes` (and the
equivalent inline read) throws `"Missing Dispute in storage"`. This surfaced on
two paths:

- **Reduction path** (`reduceLocally` → `performLocalReduction` → `getForkDisputes`).
  `reduceLocally` did not catch it, and `tryReduce` is fire-and-forget, so the
  throw became an **unhandled rejection**.
- **Snapshot-fork path** (`prepareUpdateStateSnapshotFork`, reached via
  `postStateSnapshot` on the leaver exit path). It threw while building the
  window's disputes. The throw was caught and logged at the single caller, so no
  crash — but a transient race became a skipped, un-retried snapshot post.

### Changes

- `performLocalReduction` treats the missing struct as a transient "nothing to
  reduce yet" condition and **discards** (returns `undefined`); this fulfills the
  method's already-documented "no local dispute data → undefined" contract, and a
  later attempt converges once the struct lands.
- Removed the `tryReduce` catch that logged and re-threw — the source of the
  unhandled rejection.
- `prepareUpdateStateSnapshotFork` **stops traversal and waits for more data** on
  a missing struct, mirroring the existing no-commitments handling directly above
  it (partial reduction progress accumulated so far is preserved and posted).
- Introduced a typed `MissingDisputeInStorageError` so the discard decision is
  `instanceof`-checked instead of matched on an error-message string, and
  collapsed the duplicated literal onto one type.

## Test Plan

- New e2e suite `test/e2e/E2E-AgreementManager.test.ts` with two regressions that
  reproduce the race (no-op the sole struct writer on every peer, so the
  commitment lands on-chain but the struct never does), asserting:
  - `reduceLocally` discards rather than throwing.
  - `prepareUpdateStateSnapshotFork` stops traversal rather than throwing.
  - Both include genuineness guards (kill period expired, ≥1 on-chain commitment,
    struct absent) so the assertions aren't vacuous.
- Both tests pass; each was verified with a prove-it (reverting the fix makes the
  matching test fail with the exact `Missing Dispute in storage` error, then
  restored).
- `yarn tsc --noEmit -p tsconfig.json` and `-p tsconfig.browser.json`: clean.
- Regression: `E2E-DisputeManager` reduction tests pass (the one failing entry is
  a pre-existing WebSocket teardown flake in `MathPeerTestHarness.cleanup`,
  unrelated to these changes).
