### PR TITLE
fix first-block calldata grace, spectate junk-block abort, event-sync retry

### DIFF
--- a/contracts/V1/StateChannelDiamondProxy/DisputeFraudProofFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeFraudProofFacet.sol
@@ -607,9 +607,10 @@ contract DisputeFraudProofFacet is StateChannelCommon {
                 }
             }
         }
+        uint256 firstBlockGrace = hasBlock ? 0 : getEvidenceTime();
         //TODO think >= or >
         (bool ok, uint256 maxValidTimestamp) =
-            Math.tryAdd(previousTimestamp, getP2pTime() + getAgreementTime() + getChainFallbackTime());
+            Math.tryAdd(previousTimestamp, firstBlockGrace + getP2pTime() + getAgreementTime() + getChainFallbackTime());
         if (ok && timeoutCalldataPostedProof.onChainTimestamp > maxValidTimestamp) {
             return false;
         }

--- a/contracts/V1/StateChannelDiamondProxy/DisputeFraudProofFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeFraudProofFacet.sol
@@ -96,6 +96,16 @@ contract DisputeFraudProofFacet is StateChannelCommon {
         return address(0);
     }
 
+    function _timeoutDeadline(uint256 previousTimestamp, bool hasBlock)
+        internal
+        view
+        returns (bool ok, uint256 deadline)
+    {
+        uint256 firstBlockGrace = hasBlock ? 0 : getEvidenceTime();
+        return
+            Math.tryAdd(previousTimestamp, firstBlockGrace + getP2pTime() + getAgreementTime() + getChainFallbackTime());
+    }
+
     function _handleInvalidDisputeFraudProofType(bytes memory, Dispute memory) internal pure returns (address) {
         return _invalid();
     }
@@ -495,9 +505,7 @@ contract DisputeFraudProofFacet is StateChannelCommon {
                 }
             }
         }
-        uint256 firstBlockGrace = hasBlock ? 0 : getEvidenceTime();
-        (bool ok, uint256 minValidTimestamp) =
-            Math.tryAdd(previousTimestamp, firstBlockGrace + getP2pTime() + getAgreementTime() + getChainFallbackTime());
+        (bool ok, uint256 minValidTimestamp) = _timeoutDeadline(previousTimestamp, hasBlock);
         if (!ok || timeoutTimestamp < minValidTimestamp) {
             return _valid(dispute.input.disputer);
         }
@@ -607,10 +615,8 @@ contract DisputeFraudProofFacet is StateChannelCommon {
                 }
             }
         }
-        uint256 firstBlockGrace = hasBlock ? 0 : getEvidenceTime();
         //TODO think >= or >
-        (bool ok, uint256 maxValidTimestamp) =
-            Math.tryAdd(previousTimestamp, firstBlockGrace + getP2pTime() + getAgreementTime() + getChainFallbackTime());
+        (bool ok, uint256 maxValidTimestamp) = _timeoutDeadline(previousTimestamp, hasBlock);
         if (ok && timeoutCalldataPostedProof.onChainTimestamp > maxValidTimestamp) {
             return false;
         }

--- a/src/P2PManager.ts
+++ b/src/P2PManager.ts
@@ -308,6 +308,12 @@ class P2PManager<TCustomRpc extends MainRpcService = MainRpcService>
         this.disconnectConnection(transport);
     }
 
+    public disconnectAndBlacklistPeers(peers: Iterable<Address>) {
+        for (const peer of peers) {
+            this.disconnectAndBlacklistPeerByEvmAddress(peer);
+        }
+    }
+
     public isBlacklisted(evmAddress: Address): boolean {
         return (
             this.profileManager.getProfileByEvmAddress(evmAddress)

--- a/src/stateManager/BlockQueueManager.ts
+++ b/src/stateManager/BlockQueueManager.ts
@@ -392,11 +392,9 @@ export default class BlockQueueManager {
     }
 
     private disconnectEntrySources(entry: QueuedBlockEntry): void {
-        for (const peer of entry.sourcePeers) {
-            this.stateManager.p2pManager.disconnectAndBlacklistPeerByEvmAddress(
-                peer
-            );
-        }
+        this.stateManager.p2pManager.disconnectAndBlacklistPeers(
+            entry.sourcePeers
+        );
     }
 
     public scheduleStoredBlockConfirmationMerge(
@@ -546,7 +544,6 @@ export default class BlockQueueManager {
                     sourcePeers: Array.from(entry.sourcePeers)
                 }
             );
-            this.disconnectEntrySources(entry);
         }
     }
 

--- a/src/stateManager/BlockQueueManager.ts
+++ b/src/stateManager/BlockQueueManager.ts
@@ -391,6 +391,14 @@ export default class BlockQueueManager {
         }
     }
 
+    private disconnectEntrySources(entry: QueuedBlockEntry): void {
+        for (const peer of entry.sourcePeers) {
+            this.stateManager.p2pManager.disconnectAndBlacklistPeerByEvmAddress(
+                peer
+            );
+        }
+    }
+
     public scheduleStoredBlockConfirmationMerge(
         entry: QueuedBlockEntry,
         strategy: AValidationStrategy
@@ -502,11 +510,7 @@ export default class BlockQueueManager {
             await strategy.interpretFinalValidationResult(validationResult);
 
         if (!shouldKeepConnection) {
-            for (const peer of entry.sourcePeers) {
-                this.stateManager.p2pManager.disconnectAndBlacklistPeerByEvmAddress(
-                    peer
-                );
-            }
+            this.disconnectEntrySources(entry);
         }
         P2pEventHooksUtils.notifyBlockConfirmationProcessed({
             blockHash: entry.block.hash,
@@ -542,6 +546,7 @@ export default class BlockQueueManager {
                     sourcePeers: Array.from(entry.sourcePeers)
                 }
             );
+            this.disconnectEntrySources(entry);
         }
     }
 

--- a/src/stateManager/EventSyncService.ts
+++ b/src/stateManager/EventSyncService.ts
@@ -15,14 +15,7 @@ import {
 } from "@/types/types";
 import { convertEthersValue, DetachedPromises, hash, Logger } from "@/utils";
 
-type BlockState = {
-    pending: number;
-    complete: boolean;
-    // Keys of logs in this block whose handler currently failed. A block only
-    // completes once every failure has cleared, so a successful retry (which
-    // removes its key on reschedule) lets the watermark advance past it.
-    failedEventKeys: Set<EventKey>;
-};
+type BlockState = { pending: number; complete: boolean; failed: boolean };
 type OnChainBlockValidationKey = string;
 type EventKey = string;
 type ChannelKey = string;
@@ -124,20 +117,18 @@ export default class EventSyncService {
         const state = states.get(log.blockNumber) ?? {
             pending: 0,
             complete: false,
-            failedEventKeys: new Set<EventKey>()
+            failed: false
         };
-        // Rescheduling this log clears its prior failure so a successful retry
-        // can complete the block; a still-failing retry re-adds it below.
-        state.failedEventKeys.delete(eventKey);
         state.pending += 1;
         state.complete = false;
         states.set(log.blockNumber, state);
 
+        // A log executes atomically: it either completes or throws. A throw is
+        // fatal - the rejected promise stays cached so the log is never
+        // re-dispatched, and its block never completes so the watermark holds.
         const promise = this.dispatchLog(log, scheduledChannelId)
             .catch((error) => {
-                this.eventPromises.delete(eventKey);
-                this.eventBlockNumbers.delete(eventKey);
-                state.failedEventKeys.add(eventKey);
+                state.failed = true;
                 this.logger.error("Contract event pipeline failed", {
                     blockNumber: log.blockNumber,
                     logIndex: log.index,
@@ -148,8 +139,7 @@ export default class EventSyncService {
             })
             .finally(() => {
                 state.pending -= 1;
-                state.complete =
-                    state.pending === 0 && state.failedEventKeys.size === 0;
+                state.complete = state.pending === 0 && !state.failed;
                 this.publishCompletedBlocks(scheduledChannelId, channelKey);
             });
         this.eventPromises.set(eventKey, promise);

--- a/src/stateManager/EventSyncService.ts
+++ b/src/stateManager/EventSyncService.ts
@@ -15,7 +15,14 @@ import {
 } from "@/types/types";
 import { convertEthersValue, DetachedPromises, hash, Logger } from "@/utils";
 
-type BlockState = { pending: number; complete: boolean; failed: boolean };
+type BlockState = {
+    pending: number;
+    complete: boolean;
+    // Keys of logs in this block whose handler currently failed. A block only
+    // completes once every failure has cleared, so a successful retry (which
+    // removes its key on reschedule) lets the watermark advance past it.
+    failedEventKeys: Set<EventKey>;
+};
 type OnChainBlockValidationKey = string;
 type EventKey = string;
 type ChannelKey = string;
@@ -117,15 +124,20 @@ export default class EventSyncService {
         const state = states.get(log.blockNumber) ?? {
             pending: 0,
             complete: false,
-            failed: false
+            failedEventKeys: new Set<EventKey>()
         };
+        // Rescheduling this log clears its prior failure so a successful retry
+        // can complete the block; a still-failing retry re-adds it below.
+        state.failedEventKeys.delete(eventKey);
         state.pending += 1;
         state.complete = false;
         states.set(log.blockNumber, state);
 
         const promise = this.dispatchLog(log, scheduledChannelId)
             .catch((error) => {
-                state.failed = true;
+                this.eventPromises.delete(eventKey);
+                this.eventBlockNumbers.delete(eventKey);
+                state.failedEventKeys.add(eventKey);
                 this.logger.error("Contract event pipeline failed", {
                     blockNumber: log.blockNumber,
                     logIndex: log.index,
@@ -136,7 +148,8 @@ export default class EventSyncService {
             })
             .finally(() => {
                 state.pending -= 1;
-                state.complete = state.pending === 0 && !state.failed;
+                state.complete =
+                    state.pending === 0 && state.failedEventKeys.size === 0;
                 this.publishCompletedBlocks(scheduledChannelId, channelKey);
             });
         this.eventPromises.set(eventKey, promise);

--- a/src/stateManager/ValidationService.ts
+++ b/src/stateManager/ValidationService.ts
@@ -150,7 +150,7 @@ export default class ValidationService {
                 block: LoggerUtils.getBlockMetadata(block, this.storage)
             });
             // TODO -> here for the dispute strategy we can kill the dispute, since the stateProof comitted to the whole structure
-            return await strategy.blockIsNotLinkedAndIsNotFirstBlock(block);
+            return await strategy.blockIsNotLinkedAndIsNotFirstBlock(entry);
         }
 
         // isNextLeader
@@ -288,7 +288,7 @@ export default class ValidationService {
             return await strategy.wrongGenesisDetected(entry);
         }
 
-        return await strategy.conflictingButNotLinkedBlockDetected(block);
+        return await strategy.conflictingButNotLinkedBlockDetected(entry);
     }
 
     public async isDisputedFork(

--- a/src/stateManager/ValidationService.ts
+++ b/src/stateManager/ValidationService.ts
@@ -87,7 +87,7 @@ export default class ValidationService {
                     block: LoggerUtils.getBlockMetadata(block, this.storage)
                 }
             );
-            return await strategy.blockAuthorIsNotParticipant(block);
+            return await strategy.blockAuthorIsNotParticipant(entry);
         }
 
         // Check conflicting block

--- a/src/stateManager/validationStrategy/AValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/AValidationStrategy.ts
@@ -54,7 +54,7 @@ export default abstract class AValidationStrategy {
     ): Promise<BlockValidationResult>;
 
     public abstract blockAuthorIsNotParticipant(
-        block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult>;
 
     public abstract doubleSignDetected(

--- a/src/stateManager/validationStrategy/AValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/AValidationStrategy.ts
@@ -82,7 +82,7 @@ export default abstract class AValidationStrategy {
     ): Promise<BlockValidationResult>;
 
     public abstract conflictingButNotLinkedBlockDetected(
-        block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult>;
 
     public abstract blockForkIsDisputed(
@@ -94,7 +94,7 @@ export default abstract class AValidationStrategy {
     ): Promise<BlockValidationResult>;
 
     public abstract blockIsNotLinkedAndIsNotFirstBlock(
-        block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult>;
 
     public abstract objectiveInvalidTimestampDetected(

--- a/src/stateManager/validationStrategy/BlockValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/BlockValidationStrategy.ts
@@ -205,8 +205,10 @@ export default class BlockValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.DISPUTE;
     }
     public async conflictingButNotLinkedBlockDetected(
-        _block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
+        // Malformed linkage, not a provable fraud proof - drop the sender.
+        this.p2pManager.disconnectAndBlacklistPeers(entry.sourcePeers);
         return BlockValidationResult.DISCONNECT;
     }
     public async blockForkIsDisputed(
@@ -249,8 +251,10 @@ export default class BlockValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.NOT_READY;
     }
     public async blockIsNotLinkedAndIsNotFirstBlock(
-        _block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
+        // Malformed linkage, not a provable fraud proof - drop the sender.
+        this.p2pManager.disconnectAndBlacklistPeers(entry.sourcePeers);
         return BlockValidationResult.DISCONNECT;
     }
     public async objectiveInvalidTimestampDetected(

--- a/src/stateManager/validationStrategy/BlockValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/BlockValidationStrategy.ts
@@ -119,8 +119,11 @@ export default class BlockValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.BROADCAST;
     }
     public async blockAuthorIsNotParticipant(
-        _block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
+        const culprits = new Set(entry.sourcePeers);
+        culprits.add(entry.block.author);
+        this.p2pManager.disconnectAndBlacklistPeers(culprits);
         return BlockValidationResult.DISCONNECT;
     }
     public async doubleSignDetected(
@@ -175,9 +178,7 @@ export default class BlockValidationStrategy extends AValidationStrategy {
             // here - covered by the no-false-positive e2e.
             const culprits = new Set(entry.sourcePeers);
             culprits.add(block.author);
-            for (const peer of culprits) {
-                this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(peer);
-            }
+            this.p2pManager.disconnectAndBlacklistPeers(culprits);
             return BlockValidationResult.DISCONNECT;
         }
         this.logger.warn("Wrong genesis detected", {

--- a/src/stateManager/validationStrategy/CalldataCommittedStrategy.ts
+++ b/src/stateManager/validationStrategy/CalldataCommittedStrategy.ts
@@ -108,10 +108,10 @@ export default class CalldataCommittedStrategy extends AValidationStrategy {
         );
     }
     public async conflictingButNotLinkedBlockDetected(
-        _block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         return this.blockValidationStrategy.conflictingButNotLinkedBlockDetected(
-            _block
+            entry
         );
     }
     public async blockForkIsDisputed(
@@ -127,13 +127,13 @@ export default class CalldataCommittedStrategy extends AValidationStrategy {
         );
     }
     public async blockIsNotLinkedAndIsNotFirstBlock(
-        _block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         // TODO - this one is anyoing since we have to treat this as `junk` even though peers are maybe colluding to perform a double sign or invalid state transition - we don't have the data for that
         // We have to FORCE TIMEOUT this - the force timeout challenge HAS TO require that presenting this calldata on-chain is linked to the dispute.StateProof for the disputeFraudProof to be accepted,
         // otherwise our dispute.StateProof will reveal information for the timeout peer to do a dispute containing a double sign or invalid state transition fraud proof, which when reduce will cancel the timeout
         return this.blockValidationStrategy.blockIsNotLinkedAndIsNotFirstBlock(
-            _block
+            entry
         );
     }
     public async objectiveInvalidTimestampDetected(

--- a/src/stateManager/validationStrategy/CalldataCommittedStrategy.ts
+++ b/src/stateManager/validationStrategy/CalldataCommittedStrategy.ts
@@ -70,7 +70,7 @@ export default class CalldataCommittedStrategy extends AValidationStrategy {
         );
     }
     public async blockAuthorIsNotParticipant(
-        _block: Block
+        _entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         throw new Error(
             "CalldataCommittedStrategy - blockAuthorIsNotParticipant should not be collected"

--- a/src/stateManager/validationStrategy/DisputeValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/DisputeValidationStrategy.ts
@@ -169,8 +169,9 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.DUPLICATE;
     }
     public async blockAuthorIsNotParticipant(
-        block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
+        const block = entry.block;
         const previousStateSnapshot = this.storage.getPreviousStateSnapshot(
             block.coordinates
         );

--- a/src/stateManager/validationStrategy/DisputeValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/DisputeValidationStrategy.ts
@@ -255,7 +255,7 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.DISPUTE;
     }
     public async conflictingButNotLinkedBlockDetected(
-        _block: Block
+        _entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         return this.handleInvalidBlockStructure();
     }
@@ -274,7 +274,7 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
         );
     }
     public async blockIsNotLinkedAndIsNotFirstBlock(
-        _block: Block
+        _entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         return this.handleInvalidBlockStructure();
     }

--- a/src/stateManager/validationStrategy/SpectatingValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/SpectatingValidationStrategy.ts
@@ -171,9 +171,10 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.DISPUTE;
     }
     public async conflictingButNotLinkedBlockDetected(
-        _block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
-        // Malformed linkage, not a provable fraud proof - drop the sender.
+        // Malformed linkage, not a provable fraud proof - drop the sender
+        this.p2pManager.disconnectAndBlacklistPeers(entry.sourcePeers);
         return BlockValidationResult.DISCONNECT;
     }
     public async blockForkIsDisputed(
@@ -192,9 +193,10 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.NOT_READY;
     }
     public async blockIsNotLinkedAndIsNotFirstBlock(
-        _block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
-        // Malformed linkage, not a provable fraud proof - drop the sender.
+        // Malformed linkage, not a provable fraud proof - drop the sender
+        this.p2pManager.disconnectAndBlacklistPeers(entry.sourcePeers);
         return BlockValidationResult.DISCONNECT;
     }
     public async objectiveInvalidTimestampDetected(

--- a/src/stateManager/validationStrategy/SpectatingValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/SpectatingValidationStrategy.ts
@@ -57,15 +57,10 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
                 return true;
         }
     }
-    // Two classes of deviation, split by who caused it. A non-participant fault
-    // (unauthenticated junk, outsider author, wrong channel, stray signatures)
-    // is dropped + blacklisted while we keep spectating - author membership is
-    // checked before any linkage/timestamp check, so a non-participant only ever
-    // reaches these DISCONNECT hooks and must never be able to take us offline.
-    // A *provable* fraud by an actual channel participant (double-sign, invalid
-    // transition, wrong genesis, forged inbound, invalid timestamp) is the
-    // opposite: a peer in the channel lied to us, so we abort() - stop following
-    // the feed and lose interest in joining a channel with a proven liar.
+    // Deviations split by whether the fault is provable, not by who caused it.
+    // No fraud proof possible (junk, outsider author, wrong channel, stray
+    // signatures, malformed linkage, missing genesis) -> drop the sender and keep
+    // spectating. Provable fraud by a participant -> abort() and stop following.
     public async authenticateBlockFailed(
         _block: BlockConfirmationStruct
     ): Promise<BlockValidationResult> {
@@ -124,11 +119,14 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.BROADCAST;
     }
     public async blockAuthorIsNotParticipant(
-        _block: Block
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         // Non-participant author: authentication passed (they signed with their
         // own key) but they are not in the channel. Drop + blacklist the sender,
         // keep spectating - this is the DoS vector, never an abort.
+        const culprits = new Set(entry.sourcePeers);
+        culprits.add(entry.block.author);
+        this.p2pManager.disconnectAndBlacklistPeers(culprits);
         return BlockValidationResult.DISCONNECT;
     }
     public async doubleSignDetected(
@@ -146,8 +144,22 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.DISPUTE;
     }
     public async wrongGenesisDetected(
-        _entry: QueuedBlockEntry
+        entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
+        const block = entry.block;
+        if (
+            !this.storage.stateSnapshots.getGenesisSnapshotByForkId(
+                block.forkId
+            )
+        ) {
+            // No genesis snapshot means no fraud proof to build - nothing is
+            // proven against a participant, so cut the suppliers and the author
+            // and keep spectating rather than abort.
+            const culprits = new Set(entry.sourcePeers);
+            culprits.add(block.author);
+            this.p2pManager.disconnectAndBlacklistPeers(culprits);
+            return BlockValidationResult.DISCONNECT;
+        }
         this.abort();
         return BlockValidationResult.DISPUTE;
     }

--- a/src/stateManager/validationStrategy/SpectatingValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/SpectatingValidationStrategy.ts
@@ -57,14 +57,21 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
                 return true;
         }
     }
+    // Two classes of deviation, split by who caused it. A non-participant fault
+    // (unauthenticated junk, outsider author, wrong channel, stray signatures)
+    // is dropped + blacklisted while we keep spectating - author membership is
+    // checked before any linkage/timestamp check, so a non-participant only ever
+    // reaches these DISCONNECT hooks and must never be able to take us offline.
+    // A *provable* fraud by an actual channel participant (double-sign, invalid
+    // transition, wrong genesis, forged inbound, invalid timestamp) is the
+    // opposite: a peer in the channel lied to us, so we abort() - stop following
+    // the feed and lose interest in joining a channel with a proven liar.
     public async authenticateBlockFailed(
         _block: BlockConfirmationStruct
     ): Promise<BlockValidationResult> {
-        this.abort();
         return BlockValidationResult.DISCONNECT;
     }
     public async wrongChannel(_block: Block): Promise<BlockValidationResult> {
-        this.abort();
         return BlockValidationResult.DISCONNECT;
     }
     public async channelNotOpened(
@@ -87,8 +94,14 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
             unexpectedSignatures
         );
         if (unexpectedSignatures.has(block.originalSignature)) {
-            // Garbage author — stop spectating this feed.
-            this.abort();
+            // Garbage author outside the participant union - not a channel
+            // member, so nobody to slash and no dispute. Blacklist the signers
+            // of the junk block and drop it; keep spectating.
+            for (const signature of unexpectedSignatures) {
+                this.p2pManager.disconnectAndBlacklistPeerByEvmAddress(
+                    block.signatureToAddress(signature)
+                );
+            }
             return BlockValidationResult.DISCONNECT;
         }
         // Stray confirmation signatures don't invalidate an otherwise valid block.
@@ -113,18 +126,21 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
     public async blockAuthorIsNotParticipant(
         _block: Block
     ): Promise<BlockValidationResult> {
-        this.abort();
+        // Non-participant author: authentication passed (they signed with their
+        // own key) but they are not in the channel. Drop + blacklist the sender,
+        // keep spectating - this is the DoS vector, never an abort.
         return BlockValidationResult.DISCONNECT;
     }
     public async doubleSignDetected(
         _conflictingBlock: Block,
-        block: Block
+        _block: Block
     ): Promise<BlockValidationResult> {
+        // Provable fraud by a channel participant - stop following this channel.
         this.abort();
         return BlockValidationResult.DISPUTE;
     }
     public async invalidStateTransitionDetected(
-        block: Block
+        _block: Block
     ): Promise<BlockValidationResult> {
         this.abort();
         return BlockValidationResult.DISPUTE;
@@ -136,7 +152,7 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
         return BlockValidationResult.DISPUTE;
     }
     public async forgedInboundMessageBlockDetected(
-        block: Block,
+        _block: Block,
         _messageBlock: MessageBlockStruct
     ): Promise<BlockValidationResult> {
         this.abort();
@@ -145,7 +161,7 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
     public async conflictingButNotLinkedBlockDetected(
         _block: Block
     ): Promise<BlockValidationResult> {
-        this.abort();
+        // Malformed linkage, not a provable fraud proof - drop the sender.
         return BlockValidationResult.DISCONNECT;
     }
     public async blockForkIsDisputed(
@@ -166,11 +182,11 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
     public async blockIsNotLinkedAndIsNotFirstBlock(
         _block: Block
     ): Promise<BlockValidationResult> {
-        this.abort();
+        // Malformed linkage, not a provable fraud proof - drop the sender.
         return BlockValidationResult.DISCONNECT;
     }
     public async objectiveInvalidTimestampDetected(
-        block: Block
+        _block: Block
     ): Promise<BlockValidationResult> {
         this.abort();
         return BlockValidationResult.DISPUTE;

--- a/test/V1/StateChannelDiamondProxy/DisputeVerificationFacet.t.sol
+++ b/test/V1/StateChannelDiamondProxy/DisputeVerificationFacet.t.sol
@@ -289,6 +289,34 @@ contract DisputeVerificationFacetTest is DiamondHarness {
         assertFalse(diamond.validateTimeoutCalldataPostedProof(proof, dispute));
     }
 
+    // A height-0 author gets an extra evidenceTime of grace on the calldata-posted
+    // defense. graceWindow = p2p+agreement+chainFallback + evidenceTime; a post at
+    // this edge is beyond the no-grace window and only validates because of the
+    // +evidenceTime first-block grace. (Separate tests: each opens the channel once.)
+    function _firstBlockGraceWindow() internal view returns (uint256) {
+        return diamond.getEvidenceTime() + diamond.getP2pTime() + diamond.getAgreementTime()
+            + diamond.getChainFallbackTime();
+    }
+
+    function test_validateTimeoutCalldataPostedProof_firstBlockGraceEdge_valid() public {
+        require(diamond.getEvidenceTime() > 0, "evidenceTime is 0 - grace not observable");
+        (Dispute memory dispute, TimeoutCalldataPosted memory proof) =
+            _timeoutCalldataPostedProofPostedAfter(_firstBlockGraceWindow());
+        assertTrue(
+            diamond.validateTimeoutCalldataPostedProof(proof, dispute), "first-block grace edge rejected"
+        );
+    }
+
+    function test_validateTimeoutCalldataPostedProof_pastFirstBlockGrace_invalid() public {
+        require(diamond.getEvidenceTime() > 0, "evidenceTime is 0 - grace not observable");
+        (Dispute memory dispute, TimeoutCalldataPosted memory proof) =
+            _timeoutCalldataPostedProofPostedAfter(_firstBlockGraceWindow() + 1);
+        assertFalse(
+            diamond.validateTimeoutCalldataPostedProof(proof, dispute),
+            "calldata posted past the grace window accepted"
+        );
+    }
+
     function test_disputeBlockAuthorNotParticipant_validOutsiderBlock_killsDisputer() public {
         DisputeExpiryGuardHarness harness = new DisputeExpiryGuardHarness();
         (Dispute memory dispute, DisputeBlockAuthorNotParticipant memory proof,) =
@@ -418,10 +446,21 @@ contract DisputeVerificationFacetTest is DiamondHarness {
         internal
         returns (Dispute memory dispute, TimeoutCalldataPosted memory proof)
     {
+        return _timeoutCalldataPostedProofPostedAfter(0);
+    }
+
+    function _timeoutCalldataPostedProofPostedAfter(uint256 postDelay)
+        internal
+        returns (Dispute memory dispute, TimeoutCalldataPosted memory proof)
+    {
         address[] memory participants = new address[](2);
         participants[0] = vm.addr(1);
         participants[1] = vm.addr(2);
         _openChannel(participants);
+        // genesis timestamp is fixed at channel open; warp forward so the calldata
+        // is posted `postDelay` seconds after genesis - exercises the first-block
+        // grace band on the timeout-calldata-posted defense.
+        vm.warp(block.timestamp + postDelay);
         (, StateSnapshot memory latestSnapshot) = diamond.isChannelOpen(CHANNEL_ID);
 
         MathState memory latestState;

--- a/test/e2e/E2E-BlockQueueManager.test.ts
+++ b/test/e2e/E2E-BlockQueueManager.test.ts
@@ -473,6 +473,11 @@ describe("E2E: BlockQueueManager", function () {
                 .query.getForkId()
                 .request();
 
+            const observerStatus = await h
+                .control(observer)
+                .query.getStatus()
+                .request();
+
             // Record (and forward) sync requests + reduction attempts.
             const restoreSync = await h.rpcStub.recordSpectateSync(0, {
                 forward: true
@@ -512,32 +517,29 @@ describe("E2E: BlockQueueManager", function () {
                     .request()
             ).to.be.null;
 
-            // Evicted at the queue deadline.
-            await waitFor(
-                async () =>
-                    !(await h
-                        .control(observer)
-                        .query.isBlockQueued(bogusBlock.hash)
-                        .request()),
-                (timeConfig.agreementTime + 5) * 1000
-            );
+            // Punishment arrives through the sync flow, not the queue: the
+            // supplier cannot prove the fork, so the failed sync blacklists them.
+            // `queueTimeout` removes the block before it issues that sync probe,
+            // so once the blacklist lands the eviction has already happened -
+            // asserted synchronously below.
+            await h.assert.rpc.peerBlacklistedAndDisconnected({
+                observer,
+                target: author,
+                expectedStatus: observerStatus
+            });
+            expect(
+                await h
+                    .control(observer)
+                    .query.isBlockQueued(bogusBlock.hash)
+                    .request(),
+                "bogus block still queued after the deadline"
+            ).to.equal(false);
             expect(
                 await h
                     .control(observer)
                     .query.getBlockByHash(bogusBlock.hash)
                     .request()
             ).to.be.null;
-            // The punishment arrives through the sync flow, not the queue:
-            // the supplier cannot prove the fork, so the failed sync
-            // blacklists them.
-            await waitFor(
-                async () =>
-                    await h
-                        .control(observer)
-                        .query.isBlacklisted(author.address)
-                        .request(),
-                15000
-            );
             expect(
                 await h.control(observer).query.getForkId().request()
             ).to.equal(originalForkId);

--- a/test/e2e/E2E-FirstBlockTimestampGrace.test.ts
+++ b/test/e2e/E2E-FirstBlockTimestampGrace.test.ts
@@ -278,8 +278,7 @@ describe("E2E: First block timestamp grace", function () {
         await h.assert.dispute.didNotInitiate({ peers: [0, 1, 2] });
 
         await h.assert.dispute.initiatedWait({
-            peersIndices: [1, 2],
-            timeoutMs: 15000
+            peersIndices: [1, 2]
         });
         await h.assert.dispute.didNotInitiate({ peers: [0] });
     });

--- a/test/e2e/E2E-SpectatingAbortDoS.test.ts
+++ b/test/e2e/E2E-SpectatingAbortDoS.test.ts
@@ -3,8 +3,13 @@ import { expect } from "chai";
 import { Status } from "@/types";
 import { MathTestSession as TestSession } from "@test/harness";
 
+// A non-participant that sends a spectator a block it must reject should be
+// dropped + blacklisted, never able to take the spectator offline. Covers both
+// rejection paths: unauthenticated junk (rejected synchronously in ingest) and
+// an authenticated outsider-authored block (queued, then rejected when
+// executeQueuedEntry runs onBlockConfirmation).
 describe("E2E: spectating strategy junk-block handling", function () {
-    it("blacklists the sender but keeps a SYNCED spectator running on a junk block from a non-participant", async function () {
+    it("cuts the sender of an unauthenticated junk block and keeps a SYNCED spectator running", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(3, 1);
         const forkId = h.activeForkId!;
@@ -22,9 +27,6 @@ describe("E2E: spectating strategy junk-block handling", function () {
                 timeoutMessage: "attacker never connected to victim"
             }
         );
-        expect(
-            await h.control(victim).query.getStatus().request()
-        ).to.equal(Status.SYNCED);
 
         const { encodedBlockConfirmation } =
             await h.byzantine.craftJunkBlockConfirmation(0, forkId);
@@ -36,32 +38,22 @@ describe("E2E: spectating strategy junk-block handling", function () {
             )
             .request();
 
-        await h.disconnectionBarrier.waitFor(
-            async () =>
-                await h
-                    .control(victim)
-                    .query.isBlacklisted(attacker.address)
-                    .request(),
-            {
-                timeoutMs: h.event.protocolEventTimeoutMs(1),
-                timeoutMessage: "victim never blacklisted attacker"
-            }
-        );
-        expect(
-            await h.control(victim).query.getStatus().request()
-        ).to.equal(Status.SYNCED);
+        await h.assert.rpc.peerBlacklistedAndDisconnected({
+            observer: victim,
+            target: attacker
+        });
     });
 
-    it("keeps a PENDING_PARTICIPANT running on a junk block from a non-participant", async function () {
+    it("cuts the sender of an unauthenticated junk block and keeps a PENDING_PARTICIPANT running", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(3, 1);
         const forkId = h.activeForkId!;
 
         const victim = await h.join.addSpectatorWait();
         await h.join.joinChannelWait({ joiner: victim });
-        expect(
-            await h.control(victim).query.getStatus().request()
-        ).to.equal(Status.PENDING_PARTICIPANT);
+        expect(await h.control(victim).query.getStatus().request()).to.equal(
+            Status.PENDING_PARTICIPANT
+        );
 
         const attacker = await h.join.addSpectator();
         await h.connectionBarrier.waitFor(
@@ -86,43 +78,54 @@ describe("E2E: spectating strategy junk-block handling", function () {
             )
             .request();
 
-        await h.disconnectionBarrier.waitFor(
-            async () =>
-                await h
-                    .control(victim)
-                    .query.isBlacklisted(attacker.address)
-                    .request(),
-            {
-                timeoutMs: h.event.protocolEventTimeoutMs(1),
-                timeoutMessage: "victim never blacklisted attacker"
-            }
-        );
-        expect(
-            await h.control(victim).query.getStatus().request()
-        ).to.equal(Status.PENDING_PARTICIPANT);
+        await h.assert.rpc.peerBlacklistedAndDisconnected({
+            observer: victim,
+            target: attacker
+        });
     });
 
-    it("does not abort a SYNCED spectator validating an authenticated block from a non-participant author", async function () {
+    it("cuts the sender of an authenticated outsider-authored block over the live queue and keeps a SYNCED spectator running", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(3, 1);
         const forkId = h.activeForkId!;
 
         const victim = await h.join.addSpectatorWait();
-        expect(
-            await h.control(victim).query.getStatus().request()
-        ).to.equal(Status.SYNCED);
+        const attacker = await h.join.addSpectator();
+        await h.connectionBarrier.waitFor(
+            async () =>
+                await h
+                    .control(attacker)
+                    .query.isConnectedTo(victim.address)
+                    .request(),
+            {
+                timeoutMs: h.event.protocolEventTimeoutMs(1),
+                timeoutMessage: "attacker never connected to victim"
+            }
+        );
 
+        // the attacker is connected to the channel's p2p network but is not a
+        // channel participant. it authors + signs a well-formed next block with
+        // its own key: authentication passes, so it is queued and validated fresh
+        // -> reaches blockAuthorIsNotParticipant on the live queue, not the inline
+        // authenticate-failed path the junk cases hit. this is the vector that
+        // used to abort the spectator.
         const { encodedBlockConfirmation } =
-            await h.byzantine.craftOutsiderAuthoredBlockConfirmation(0, forkId);
-        const { aborted, result } = await h
-            .control(victim)
-            .stub.probeSpectateBlockNoAbort(encodedBlockConfirmation)
+            await h.byzantine.craftOutsiderAuthoredBlockConfirmation(
+                0,
+                forkId,
+                attacker.signer
+            );
+        await h
+            .control(attacker)
+            .byzantine.sendBlockConfirmation(
+                encodedBlockConfirmation,
+                victim.address
+            )
             .request();
 
-        expect(result).to.equal("DISCONNECT");
-        expect(aborted).to.equal(false);
-        expect(
-            await h.control(victim).query.getStatus().request()
-        ).to.equal(Status.SYNCED);
+        await h.assert.rpc.peerBlacklistedAndDisconnected({
+            observer: victim,
+            target: attacker
+        });
     });
 });

--- a/test/e2e/E2E-SpectatingAbortDoS.test.ts
+++ b/test/e2e/E2E-SpectatingAbortDoS.test.ts
@@ -1,0 +1,128 @@
+import { expect } from "chai";
+
+import { Status } from "@/types";
+import { MathTestSession as TestSession } from "@test/harness";
+
+describe("E2E: spectating strategy junk-block handling", function () {
+    it("blacklists the sender but keeps a SYNCED spectator running on a junk block from a non-participant", async function () {
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(3, 1);
+        const forkId = h.activeForkId!;
+
+        const victim = await h.join.addSpectatorWait();
+        const attacker = await h.join.addSpectator();
+        await h.connectionBarrier.waitFor(
+            async () =>
+                await h
+                    .control(attacker)
+                    .query.isConnectedTo(victim.address)
+                    .request(),
+            {
+                timeoutMs: h.event.protocolEventTimeoutMs(1),
+                timeoutMessage: "attacker never connected to victim"
+            }
+        );
+        expect(
+            await h.control(victim).query.getStatus().request()
+        ).to.equal(Status.SYNCED);
+
+        const { encodedBlockConfirmation } =
+            await h.byzantine.craftJunkBlockConfirmation(0, forkId);
+        await h
+            .control(attacker)
+            .byzantine.sendBlockConfirmation(
+                encodedBlockConfirmation,
+                victim.address
+            )
+            .request();
+
+        await h.disconnectionBarrier.waitFor(
+            async () =>
+                await h
+                    .control(victim)
+                    .query.isBlacklisted(attacker.address)
+                    .request(),
+            {
+                timeoutMs: h.event.protocolEventTimeoutMs(1),
+                timeoutMessage: "victim never blacklisted attacker"
+            }
+        );
+        expect(
+            await h.control(victim).query.getStatus().request()
+        ).to.equal(Status.SYNCED);
+    });
+
+    it("keeps a PENDING_PARTICIPANT running on a junk block from a non-participant", async function () {
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(3, 1);
+        const forkId = h.activeForkId!;
+
+        const victim = await h.join.addSpectatorWait();
+        await h.join.joinChannelWait({ joiner: victim });
+        expect(
+            await h.control(victim).query.getStatus().request()
+        ).to.equal(Status.PENDING_PARTICIPANT);
+
+        const attacker = await h.join.addSpectator();
+        await h.connectionBarrier.waitFor(
+            async () =>
+                await h
+                    .control(attacker)
+                    .query.isConnectedTo(victim.address)
+                    .request(),
+            {
+                timeoutMs: h.event.protocolEventTimeoutMs(1),
+                timeoutMessage: "attacker never connected to victim"
+            }
+        );
+
+        const { encodedBlockConfirmation } =
+            await h.byzantine.craftJunkBlockConfirmation(0, forkId);
+        await h
+            .control(attacker)
+            .byzantine.sendBlockConfirmation(
+                encodedBlockConfirmation,
+                victim.address
+            )
+            .request();
+
+        await h.disconnectionBarrier.waitFor(
+            async () =>
+                await h
+                    .control(victim)
+                    .query.isBlacklisted(attacker.address)
+                    .request(),
+            {
+                timeoutMs: h.event.protocolEventTimeoutMs(1),
+                timeoutMessage: "victim never blacklisted attacker"
+            }
+        );
+        expect(
+            await h.control(victim).query.getStatus().request()
+        ).to.equal(Status.PENDING_PARTICIPANT);
+    });
+
+    it("does not abort a SYNCED spectator validating an authenticated block from a non-participant author", async function () {
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(3, 1);
+        const forkId = h.activeForkId!;
+
+        const victim = await h.join.addSpectatorWait();
+        expect(
+            await h.control(victim).query.getStatus().request()
+        ).to.equal(Status.SYNCED);
+
+        const { encodedBlockConfirmation } =
+            await h.byzantine.craftOutsiderAuthoredBlockConfirmation(0, forkId);
+        const { aborted, result } = await h
+            .control(victim)
+            .stub.probeSpectateBlockNoAbort(encodedBlockConfirmation)
+            .request();
+
+        expect(result).to.equal("DISCONNECT");
+        expect(aborted).to.equal(false);
+        expect(
+            await h.control(victim).query.getStatus().request()
+        ).to.equal(Status.SYNCED);
+    });
+});

--- a/test/e2e/E2E-SpectatingAbortDoS.test.ts
+++ b/test/e2e/E2E-SpectatingAbortDoS.test.ts
@@ -1,17 +1,26 @@
 import { expect } from "chai";
 
 import { Status } from "@/types";
-import { MathTestSession as TestSession } from "@test/harness";
+import {
+    MathTestSession as TestSession,
+    MIN_TEST_TIME_CONFIG
+} from "@test/harness";
 
 // A non-participant that sends a spectator a block it must reject should be
 // dropped + blacklisted, never able to take the spectator offline. Covers both
 // rejection paths: unauthenticated junk (rejected synchronously in ingest) and
 // an authenticated outsider-authored block (queued, then rejected when
 // executeQueuedEntry runs onBlockConfirmation).
+
+const LIVE_FORK_TIME = {
+    ...MIN_TEST_TIME_CONFIG,
+    chainFallbackTime: 12
+};
+
 describe("E2E: spectating strategy junk-block handling", function () {
     it("cuts the sender of an unauthenticated junk block and keeps a SYNCED spectator running", async function () {
         const h = TestSession.getHarness();
-        await h.lifecycle.start(3, 1);
+        await h.lifecycle.start(3, 1, { timeConfig: LIVE_FORK_TIME });
         const forkId = h.activeForkId!;
 
         const victim = await h.join.addSpectatorWait();
@@ -40,13 +49,14 @@ describe("E2E: spectating strategy junk-block handling", function () {
 
         await h.assert.rpc.peerBlacklistedAndDisconnected({
             observer: victim,
-            target: attacker
+            target: attacker,
+            expectedStatus: Status.SYNCED
         });
     });
 
     it("cuts the sender of an unauthenticated junk block and keeps a PENDING_PARTICIPANT running", async function () {
         const h = TestSession.getHarness();
-        await h.lifecycle.start(3, 1);
+        await h.lifecycle.start(3, 1, { timeConfig: LIVE_FORK_TIME });
         const forkId = h.activeForkId!;
 
         const victim = await h.join.addSpectatorWait();
@@ -80,13 +90,14 @@ describe("E2E: spectating strategy junk-block handling", function () {
 
         await h.assert.rpc.peerBlacklistedAndDisconnected({
             observer: victim,
-            target: attacker
+            target: attacker,
+            expectedStatus: Status.PENDING_PARTICIPANT
         });
     });
 
     it("cuts the sender of an authenticated outsider-authored block over the live queue and keeps a SYNCED spectator running", async function () {
         const h = TestSession.getHarness();
-        await h.lifecycle.start(3, 1);
+        await h.lifecycle.start(3, 1, { timeConfig: LIVE_FORK_TIME });
         const forkId = h.activeForkId!;
 
         const victim = await h.join.addSpectatorWait();
@@ -125,7 +136,64 @@ describe("E2E: spectating strategy junk-block handling", function () {
 
         await h.assert.rpc.peerBlacklistedAndDisconnected({
             observer: victim,
-            target: attacker
+            target: attacker,
+            expectedStatus: Status.SYNCED
+        });
+    });
+
+    // supplier != author. every other case here has the attacker author the
+    // block it sends, so they cannot tell "cut the supplier" from "cut the
+    // author" - this one separates them and asserts that both are cut.
+    it("cuts both the relayer and the author when an outsider-authored block arrives via a different peer", async function () {
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(3, 1, { timeConfig: LIVE_FORK_TIME });
+        const forkId = h.activeForkId!;
+
+        const victim = await h.join.addSpectatorWait();
+        // two distinct non-participants: one signs the block, the other hands it
+        // to the victim. neither is in the channel.
+        const author = await h.join.addSpectator();
+        const relayer = await h.join.addSpectator();
+        await h.connectionBarrier.waitFor(
+            async () =>
+                (await h
+                    .control(relayer)
+                    .query.isConnectedTo(victim.address)
+                    .request()) &&
+                (await h
+                    .control(author)
+                    .query.isConnectedTo(victim.address)
+                    .request()),
+            {
+                timeoutMs: h.event.protocolEventTimeoutMs(1),
+                timeoutMessage: "relayer/author never both connected to victim"
+            }
+        );
+
+        const { encodedBlockConfirmation } =
+            await h.byzantine.craftOutsiderAuthoredBlockConfirmation(
+                0,
+                forkId,
+                author.signer
+            );
+        // the relayer never authored anything - it only supplied the transport
+        await h
+            .control(relayer)
+            .byzantine.sendBlockConfirmation(
+                encodedBlockConfirmation,
+                victim.address
+            )
+            .request();
+
+        await h.assert.rpc.peerBlacklistedAndDisconnected({
+            observer: victim,
+            target: relayer,
+            expectedStatus: Status.SYNCED
+        });
+        await h.assert.rpc.peerBlacklistedAndDisconnected({
+            observer: victim,
+            target: author,
+            expectedStatus: Status.SYNCED
         });
     });
 });

--- a/test/e2e/disputeValidation/invalidStateProofGenesisLinkage.test.ts
+++ b/test/e2e/disputeValidation/invalidStateProofGenesisLinkage.test.ts
@@ -18,8 +18,7 @@ describe("E2E: dispute validation / DisputeInvalidStateProof genesis linkage", f
         await h.lifecycle.timeoutSetup(4);
 
         await h.assert.dispute.initiatedWait({
-            peersIndices: [honestDisputerIndex],
-            timeoutMs: 15000
+            peersIndices: [honestDisputerIndex]
         });
         // peers 1,2,3 dispute the timed-out peer 0 -> 3 commitments (peer 0 is the defendant)
         await h.assert.dispute.committedWait({

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -15,6 +15,7 @@ import type { ForkId, Hash, Timestamp } from "@/types/types";
 import type { HarnessControlRpc } from "../../HarnessControlRpc";
 import type {
     EventSyncFailureProbe,
+    EventSyncRetryProbe,
     PausedReductionStatus,
     ReductionSimulationErrorName,
     ConcurrentCalldataRecoveryProbe,
@@ -635,6 +636,16 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
 
     public async probeRejectedEventSyncLog(): Promise<EventSyncFailureProbe> {
         return this.service.probeRejectedEventSyncLog();
+    }
+
+    public async probeRetriedEventSyncLog(): Promise<EventSyncRetryProbe> {
+        return this.service.probeRetriedEventSyncLog();
+    }
+
+    public async probeSpectateBlockNoAbort(
+        encodedBlockConfirmation: string
+    ): Promise<{ aborted: boolean; result: string }> {
+        return this.service.probeSpectateBlockNoAbort(encodedBlockConfirmation);
     }
 
     public async probeConcurrentCalldataRecovery(): Promise<ConcurrentCalldataRecoveryProbe> {

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -15,7 +15,6 @@ import type { ForkId, Hash, Timestamp } from "@/types/types";
 import type { HarnessControlRpc } from "../../HarnessControlRpc";
 import type {
     EventSyncFailureProbe,
-    EventSyncRetryProbe,
     PausedReductionStatus,
     ReductionSimulationErrorName,
     ConcurrentCalldataRecoveryProbe,
@@ -636,10 +635,6 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
 
     public async probeRejectedEventSyncLog(): Promise<EventSyncFailureProbe> {
         return this.service.probeRejectedEventSyncLog();
-    }
-
-    public async probeRetriedEventSyncLog(): Promise<EventSyncRetryProbe> {
-        return this.service.probeRetriedEventSyncLog();
     }
 
     public async probeSpectateBlockNoAbort(

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -637,12 +637,6 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
         return this.service.probeRejectedEventSyncLog();
     }
 
-    public async probeSpectateBlockNoAbort(
-        encodedBlockConfirmation: string
-    ): Promise<{ aborted: boolean; result: string }> {
-        return this.service.probeSpectateBlockNoAbort(encodedBlockConfirmation);
-    }
-
     public async probeConcurrentCalldataRecovery(): Promise<ConcurrentCalldataRecoveryProbe> {
         return this.service.probeConcurrentCalldataRecovery();
     }

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -346,8 +346,9 @@ export class StubService extends ARpcService<
             this.sm.diamondStateMachine.localDiamondContract,
             this.sm.logger
         );
-        const result =
-            await strategy.blockIsNotLinkedAndIsNotFirstBlock(latestBlock);
+        const result = await strategy.blockIsNotLinkedAndIsNotFirstBlock(
+            this.sm.storage.queues.createEntry(latestBlock)
+        );
         return {
             result: BlockValidationResult[result],
             proofStored:

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -5,7 +5,7 @@ import type { ForkId } from "@/types/types";
 import type { HarnessControlRpc } from "../../HarnessControlRpc";
 import StubRpcMethods from "./StubRpcMethods";
 import { id, Log } from "ethers";
-import { DetachedPromises } from "@/utils";
+import { Codec, DetachedPromises, Type } from "@/utils";
 import DisputeValidationStrategy from "@/stateManager/validationStrategy/DisputeValidationStrategy";
 import { BlockValidationResult } from "@/types";
 import { Block } from "@/models";
@@ -68,6 +68,15 @@ export type EventSyncFailureProbe = {
     cursorBefore: number | null;
     cursorAfter: number | null;
     detachedError: string | null;
+};
+
+export type EventSyncRetryProbe = {
+    handlerCallCount: number;
+    firstError: string | null;
+    cursorBefore: number | null;
+    cursorAfterFailure: number | null;
+    cursorAfterRetry: number | null;
+    blockNumber: number;
 };
 
 export type ConcurrentCalldataRecoveryProbe = {
@@ -228,6 +237,109 @@ export class StubService extends ARpcService<
             };
         } finally {
             eventHandler.onStateSnapshotUpdated = original;
+        }
+    }
+
+    /** Fail a log once, then reschedule with the handler fixed - the watermark must advance. */
+    public async probeRetriedEventSyncLog(): Promise<EventSyncRetryProbe> {
+        const sm = this.sm;
+        const contract = sm.stateChannelManagerContract;
+        const provider = contract.runner?.provider;
+        if (!provider) throw new Error("Expected a provider for event sync");
+        const latestBlock = await provider.getBlock("latest");
+        if (!latestBlock?.hash) throw new Error("Expected a latest block");
+        const stateSnapshot = await contract.getStateSnapshot(sm.channelId);
+        const event = contract.interface.getEvent("StateSnapshotUpdated");
+        const encodedEvent = contract.interface.encodeEventLog(event, [
+            sm.channelId,
+            stateSnapshot
+        ]);
+        const blockNumber = latestBlock.number + 1;
+        const log = new Log(
+            {
+                address: String(contract.target),
+                blockHash: latestBlock.hash,
+                blockNumber,
+                data: encodedEvent.data,
+                index: 0,
+                removed: false,
+                topics: encodedEvent.topics,
+                transactionHash: id(`event-sync-retry-${Date.now()}`),
+                transactionIndex: 0
+            },
+            provider
+        );
+        const eventHandler = sm.eventHandler;
+        const original = eventHandler.onStateSnapshotUpdated.bind(eventHandler);
+        let handlerCallCount = 0;
+        eventHandler.onStateSnapshotUpdated = async () => {
+            handlerCallCount += 1;
+            if (handlerCallCount === 1) {
+                throw new Error("Expected event-sync rejection");
+            }
+            // Retry: handler now succeeds so the block can complete.
+        };
+        const cursorBefore =
+            sm.storage.eventSync.getLatestProcessedBlock(sm.channelId) ?? null;
+        try {
+            const firstError = await sm.eventSyncService
+                .scheduleLog(log, sm.channelId)
+                .then(
+                    () => null,
+                    (error: unknown) =>
+                        error instanceof Error ? error.message : String(error)
+                );
+            const cursorAfterFailure =
+                sm.storage.eventSync.getLatestProcessedBlock(sm.channelId) ??
+                null;
+            // Same log, handler fixed: the failed key clears and the block
+            // completes, advancing the processed-block watermark past it.
+            await sm.eventSyncService.scheduleLog(log, sm.channelId);
+            const cursorAfterRetry =
+                sm.storage.eventSync.getLatestProcessedBlock(sm.channelId) ??
+                null;
+            return {
+                handlerCallCount,
+                firstError,
+                cursorBefore,
+                cursorAfterFailure,
+                cursorAfterRetry,
+                blockNumber
+            };
+        } finally {
+            eventHandler.onStateSnapshotUpdated = original;
+        }
+    }
+
+    /**
+     * Run the real spectator block validation on an outsider-authored block and
+     * report whether it aborted. Author membership is checked before linkage, so
+     * this reaches blockAuthorIsNotParticipant; the fix must drop the sender
+     * (DISCONNECT) without tearing the spectator down.
+     */
+    public async probeSpectateBlockNoAbort(
+        encodedBlockConfirmation: string
+    ): Promise<{ aborted: boolean; result: string }> {
+        const sm = this.sm;
+        const block = Block.fromBlockConfirmation(
+            Codec.decode(encodedBlockConfirmation, Type.BlockConfirmation)
+        );
+        const entry = sm.storage.queues.createEntry(block);
+        const strategy = sm.getActiveValidationStrategy();
+        let aborted = false;
+        const realAbort = sm.abort.bind(sm);
+        sm.abort = () => {
+            aborted = true;
+        };
+        try {
+            const result =
+                await sm.validationService.validateBlockConfirmation(
+                    entry,
+                    strategy
+                );
+            return { aborted, result: BlockValidationResult[result] };
+        } finally {
+            sm.abort = realAbort;
         }
     }
 

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -65,18 +65,10 @@ export type EventSyncFailureProbe = {
     handlerCallCount: number;
     firstError: string | null;
     secondError: string | null;
+    rescheduledError: string | null;
     cursorBefore: number | null;
     cursorAfter: number | null;
     detachedError: string | null;
-};
-
-export type EventSyncRetryProbe = {
-    handlerCallCount: number;
-    firstError: string | null;
-    cursorBefore: number | null;
-    cursorAfterFailure: number | null;
-    cursorAfterRetry: number | null;
-    blockNumber: number;
 };
 
 export type ConcurrentCalldataRecoveryProbe = {
@@ -223,88 +215,35 @@ export class StubService extends ARpcService<
                     ? rejected.reason.message
                     : String(rejected.reason)
                 : null;
+
+            // A failed log is fatal - rescheduling it returns the cached
+            // rejection and never re-enters the handler, even once the handler
+            // would succeed.
+            eventHandler.onStateSnapshotUpdated = async () => {
+                handlerCallCount += 1;
+            };
+            const rescheduled = sm.eventSyncService.scheduleLog(
+                log,
+                sm.channelId
+            );
+            const rescheduledError = await rescheduled.then(
+                () => null,
+                (error: unknown) =>
+                    error instanceof Error ? error.message : String(error)
+            );
+
             return {
                 samePromise: first === second,
                 handlerCallCount,
                 firstError,
                 secondError,
+                rescheduledError,
                 cursorBefore,
                 cursorAfter:
                     sm.storage.eventSync.getLatestProcessedBlock(
                         sm.channelId
                     ) ?? null,
                 detachedError
-            };
-        } finally {
-            eventHandler.onStateSnapshotUpdated = original;
-        }
-    }
-
-    /** Fail a log once, then reschedule with the handler fixed - the watermark must advance. */
-    public async probeRetriedEventSyncLog(): Promise<EventSyncRetryProbe> {
-        const sm = this.sm;
-        const contract = sm.stateChannelManagerContract;
-        const provider = contract.runner?.provider;
-        if (!provider) throw new Error("Expected a provider for event sync");
-        const latestBlock = await provider.getBlock("latest");
-        if (!latestBlock?.hash) throw new Error("Expected a latest block");
-        const stateSnapshot = await contract.getStateSnapshot(sm.channelId);
-        const event = contract.interface.getEvent("StateSnapshotUpdated");
-        const encodedEvent = contract.interface.encodeEventLog(event, [
-            sm.channelId,
-            stateSnapshot
-        ]);
-        const blockNumber = latestBlock.number + 1;
-        const log = new Log(
-            {
-                address: String(contract.target),
-                blockHash: latestBlock.hash,
-                blockNumber,
-                data: encodedEvent.data,
-                index: 0,
-                removed: false,
-                topics: encodedEvent.topics,
-                transactionHash: id(`event-sync-retry-${Date.now()}`),
-                transactionIndex: 0
-            },
-            provider
-        );
-        const eventHandler = sm.eventHandler;
-        const original = eventHandler.onStateSnapshotUpdated.bind(eventHandler);
-        let handlerCallCount = 0;
-        eventHandler.onStateSnapshotUpdated = async () => {
-            handlerCallCount += 1;
-            if (handlerCallCount === 1) {
-                throw new Error("Expected event-sync rejection");
-            }
-            // Retry: handler now succeeds so the block can complete.
-        };
-        const cursorBefore =
-            sm.storage.eventSync.getLatestProcessedBlock(sm.channelId) ?? null;
-        try {
-            const firstError = await sm.eventSyncService
-                .scheduleLog(log, sm.channelId)
-                .then(
-                    () => null,
-                    (error: unknown) =>
-                        error instanceof Error ? error.message : String(error)
-                );
-            const cursorAfterFailure =
-                sm.storage.eventSync.getLatestProcessedBlock(sm.channelId) ??
-                null;
-            // Same log, handler fixed: the failed key clears and the block
-            // completes, advancing the processed-block watermark past it.
-            await sm.eventSyncService.scheduleLog(log, sm.channelId);
-            const cursorAfterRetry =
-                sm.storage.eventSync.getLatestProcessedBlock(sm.channelId) ??
-                null;
-            return {
-                handlerCallCount,
-                firstError,
-                cursorBefore,
-                cursorAfterFailure,
-                cursorAfterRetry,
-                blockNumber
             };
         } finally {
             eventHandler.onStateSnapshotUpdated = original;
@@ -332,11 +271,10 @@ export class StubService extends ARpcService<
             aborted = true;
         };
         try {
-            const result =
-                await sm.validationService.validateBlockConfirmation(
-                    entry,
-                    strategy
-                );
+            const result = await sm.validationService.validateBlockConfirmation(
+                entry,
+                strategy
+            );
             return { aborted, result: BlockValidationResult[result] };
         } finally {
             sm.abort = realAbort;

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -5,7 +5,7 @@ import type { ForkId } from "@/types/types";
 import type { HarnessControlRpc } from "../../HarnessControlRpc";
 import StubRpcMethods from "./StubRpcMethods";
 import { id, Log } from "ethers";
-import { Codec, DetachedPromises, Type } from "@/utils";
+import { DetachedPromises } from "@/utils";
 import DisputeValidationStrategy from "@/stateManager/validationStrategy/DisputeValidationStrategy";
 import { BlockValidationResult } from "@/types";
 import { Block } from "@/models";
@@ -247,37 +247,6 @@ export class StubService extends ARpcService<
             };
         } finally {
             eventHandler.onStateSnapshotUpdated = original;
-        }
-    }
-
-    /**
-     * Run the real spectator block validation on an outsider-authored block and
-     * report whether it aborted. Author membership is checked before linkage, so
-     * this reaches blockAuthorIsNotParticipant; the fix must drop the sender
-     * (DISCONNECT) without tearing the spectator down.
-     */
-    public async probeSpectateBlockNoAbort(
-        encodedBlockConfirmation: string
-    ): Promise<{ aborted: boolean; result: string }> {
-        const sm = this.sm;
-        const block = Block.fromBlockConfirmation(
-            Codec.decode(encodedBlockConfirmation, Type.BlockConfirmation)
-        );
-        const entry = sm.storage.queues.createEntry(block);
-        const strategy = sm.getActiveValidationStrategy();
-        let aborted = false;
-        const realAbort = sm.abort.bind(sm);
-        sm.abort = () => {
-            aborted = true;
-        };
-        try {
-            const result = await sm.validationService.validateBlockConfirmation(
-                entry,
-                strategy
-            );
-            return { aborted, result: BlockValidationResult[result] };
-        } finally {
-            sm.abort = realAbort;
         }
     }
 

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -379,11 +379,12 @@ export class StubService extends ARpcService<
             this.sm.diamondStateMachine.localDiamondContract,
             this.sm.logger
         );
+        const entry = this.sm.storage.queues.createEntry(block);
         const earlyAuthorResult =
-            await strategy.blockAuthorIsNotParticipant(block);
+            await strategy.blockAuthorIsNotParticipant(entry);
         const signatureUnionResult =
             await strategy.notAllSingersAreParticipants(
-                this.sm.storage.queues.createEntry(block),
+                entry,
                 new Set([block.originalSignature])
             );
         return {

--- a/test/harness/actions/ByzantineActions.ts
+++ b/test/harness/actions/ByzantineActions.ts
@@ -229,4 +229,77 @@ export class ByzantineActions<
             }
         };
     }
+
+    /**
+     * Take a source peer's real latest block and re-sign it with a throwaway
+     * outsider key: the block body is authentic, only the author signature is
+     * forged, so authentication fails on the signature alone.
+     */
+    async craftJunkBlockConfirmation(
+        sourcePeerIndex: number,
+        forkId: ForkId
+    ): Promise<{ encodedBlockConfirmation: string }> {
+        const bundle = await this.harness
+            .control(this.harness.getPeer(sourcePeerIndex))
+            .query.getLatestBlockBundle(forkId)
+            .request();
+        const signedBlock = Codec.decode(
+            bundle!.encodedSignedBlock,
+            Type.SignedBlock
+        );
+        const outsider = ethers.Wallet.createRandom();
+        const forgedSignature = await outsider.signMessage(
+            ethers.getBytes(bundle!.hash)
+        );
+        return {
+            encodedBlockConfirmation: Codec.encode(
+                {
+                    signedBlock: {
+                        encodedBlock: signedBlock.encodedBlock,
+                        signature: forgedSignature
+                    },
+                    signatures: []
+                },
+                Type.BlockConfirmation
+            ) as string
+        };
+    }
+
+    /**
+     * Craft the next block (head height + 1) authored + signed by a throwaway
+     * outsider key: a new block position, so it is validated fresh rather than
+     * CRDT-merged into the head. Authentication passes (signature matches the
+     * author) but the author is not a channel participant, and membership is
+     * checked before linkage -> reaches blockAuthorIsNotParticipant (the
+     * handshaken-outsider DoS vector).
+     */
+    async craftOutsiderAuthoredBlockConfirmation(
+        sourcePeerIndex: number,
+        forkId: ForkId
+    ): Promise<{ encodedBlockConfirmation: string }> {
+        const bundle = await this.harness
+            .control(this.harness.getPeer(sourcePeerIndex))
+            .query.getLatestBlockBundle(forkId)
+            .request();
+        const head = Block.fromSignedBlock(
+            Codec.decode(bundle!.encodedSignedBlock, Type.SignedBlock)
+        );
+        const outsider = ethers.Wallet.createRandom();
+        const nextBlockStruct = {
+            ...factory.blockStructWithTransactionHeader(head.blockStruct, {
+                participant: outsider.address as Address,
+                transactionCnt: Number(head.height) + 1
+            }),
+            previousBlockHash: bundle!.hash
+        };
+        const outsiderSignedBlock = (
+            await Block.fromBlockStruct(nextBlockStruct, outsider)
+        ).signedBlock;
+        return {
+            encodedBlockConfirmation: Codec.encode(
+                { signedBlock: outsiderSignedBlock, signatures: [] },
+                Type.BlockConfirmation
+            ) as string
+        };
+    }
 }

--- a/test/harness/actions/ByzantineActions.ts
+++ b/test/harness/actions/ByzantineActions.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { ethers, Signer } from "ethers";
 import { PeerTestHarness } from "@test/fixtures/PeerTestHarness";
 import * as factory from "@test/factory";
 import { Block } from "@/models";
@@ -266,16 +266,18 @@ export class ByzantineActions<
     }
 
     /**
-     * Craft the next block (head height + 1) authored + signed by a throwaway
-     * outsider key: a new block position, so it is validated fresh rather than
-     * CRDT-merged into the head. Authentication passes (signature matches the
-     * author) but the author is not a channel participant, and membership is
-     * checked before linkage -> reaches blockAuthorIsNotParticipant (the
-     * handshaken-outsider DoS vector).
+     * Craft the next block (head height + 1) authored + signed by `author` - a
+     * peer connected to the channel's p2p network but not a channel participant
+     * (a spectator that never joined). A new block position, so it is validated
+     * fresh rather than CRDT-merged into the head. Authentication passes (the
+     * signature matches the declared author) but the author is not a participant,
+     * and membership is checked before linkage -> reaches
+     * blockAuthorIsNotParticipant (the connected-outsider DoS vector).
      */
     async craftOutsiderAuthoredBlockConfirmation(
         sourcePeerIndex: number,
-        forkId: ForkId
+        forkId: ForkId,
+        author: Signer
     ): Promise<{ encodedBlockConfirmation: string }> {
         const bundle = await this.harness
             .control(this.harness.getPeer(sourcePeerIndex))
@@ -284,16 +286,16 @@ export class ByzantineActions<
         const head = Block.fromSignedBlock(
             Codec.decode(bundle!.encodedSignedBlock, Type.SignedBlock)
         );
-        const outsider = ethers.Wallet.createRandom();
+        const authorAddress = (await author.getAddress()) as Address;
         const nextBlockStruct = {
             ...factory.blockStructWithTransactionHeader(head.blockStruct, {
-                participant: outsider.address as Address,
+                participant: authorAddress,
                 transactionCnt: Number(head.height) + 1
             }),
             previousBlockHash: bundle!.hash
         };
         const outsiderSignedBlock = (
-            await Block.fromBlockStruct(nextBlockStruct, outsider)
+            await Block.fromBlockStruct(nextBlockStruct, author)
         ).signedBlock;
         return {
             encodedBlockConfirmation: Codec.encode(

--- a/test/harness/actions/assert/AssertRPCActions.ts
+++ b/test/harness/actions/assert/AssertRPCActions.ts
@@ -11,13 +11,11 @@ export class AssertRPCActions<
     constructor(private readonly harness: PeerTestHarness<TCustomRpc>) {}
 
     // The observer blacklists and disconnects the target (a byzantine sender it
-    // rejected) without going offline. Snapshots the observer's status first,
-    // then asserts it still holds after the drop; pass `expectedStatus` to
-    // assert a different status instead of no-change.
+    // rejected) without going offline
     async peerBlacklistedAndDisconnected(options: {
         observer: TestPeer<TCustomRpc>;
         target: TestPeer<TCustomRpc>;
-        expectedStatus?: Status;
+        expectedStatus: Status;
         timeoutMs?: number;
     }): Promise<void> {
         const {
@@ -26,12 +24,6 @@ export class AssertRPCActions<
             expectedStatus,
             timeoutMs = this.harness.event.protocolEventTimeoutMs(1)
         } = options;
-
-        // defaults to the status the observer holds right now - assert the drop
-        // leaves it there
-        const requiredStatus =
-            expectedStatus ??
-            (await this.harness.control(observer).query.getStatus().request());
 
         await this.harness.disconnectionBarrier.waitFor(
             async () =>
@@ -54,7 +46,7 @@ export class AssertRPCActions<
         expect(
             await this.harness.control(observer).query.getStatus().request(),
             `peer ${observer.index} status changed while dropping peer ${target.index}`
-        ).to.equal(requiredStatus);
+        ).to.equal(expectedStatus);
     }
 
     async peerDisconnectedFrom(options: {

--- a/test/harness/actions/assert/AssertRPCActions.ts
+++ b/test/harness/actions/assert/AssertRPCActions.ts
@@ -1,11 +1,61 @@
 import type { ForkId } from "@/types/types";
+import type { Status } from "@/types";
 import { PeerTestHarness } from "@test/fixtures/PeerTestHarness";
 import type { HarnessControlRpc } from "@test/fixtures/customRpc/harnessControl/HarnessControlRpc";
+import type { TestPeer } from "@test/harness/core/types";
+import { expect } from "chai";
 
 export class AssertRPCActions<
     TCustomRpc extends HarnessControlRpc = HarnessControlRpc
 > {
     constructor(private readonly harness: PeerTestHarness<TCustomRpc>) {}
+
+    // The observer blacklists and disconnects the target (a byzantine sender it
+    // rejected) without going offline. Snapshots the observer's status first,
+    // then asserts it still holds after the drop; pass `expectedStatus` to
+    // assert a different status instead of no-change.
+    async peerBlacklistedAndDisconnected(options: {
+        observer: TestPeer<TCustomRpc>;
+        target: TestPeer<TCustomRpc>;
+        expectedStatus?: Status;
+        timeoutMs?: number;
+    }): Promise<void> {
+        const {
+            observer,
+            target,
+            expectedStatus,
+            timeoutMs = this.harness.event.protocolEventTimeoutMs(1)
+        } = options;
+
+        // defaults to the status the observer holds right now - assert the drop
+        // leaves it there
+        const requiredStatus =
+            expectedStatus ??
+            (await this.harness.control(observer).query.getStatus().request());
+
+        await this.harness.disconnectionBarrier.waitFor(
+            async () =>
+                await this.harness
+                    .control(observer)
+                    .query.isBlacklisted(target.address)
+                    .request(),
+            {
+                timeoutMs,
+                timeoutMessage: `Expected peer ${observer.index} to blacklist peer ${target.index} within ${timeoutMs}ms`
+            }
+        );
+        expect(
+            await this.harness
+                .control(observer)
+                .query.isConnectedTo(target.address)
+                .request(),
+            `peer ${observer.index} stayed connected to blacklisted peer ${target.index}`
+        ).to.equal(false);
+        expect(
+            await this.harness.control(observer).query.getStatus().request(),
+            `peer ${observer.index} status changed while dropping peer ${target.index}`
+        ).to.equal(requiredStatus);
+    }
 
     async peerDisconnectedFrom(options: {
         peerIndex: number;

--- a/test/stateManager/EventSyncService.test.ts
+++ b/test/stateManager/EventSyncService.test.ts
@@ -20,6 +20,20 @@ describe("EventSyncService", function () {
         expect(result.detachedError).to.equal("Expected event-sync rejection");
     });
 
+    it("advances the processed-block cursor after a failed log is retried successfully", async function () {
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(4, 0);
+        const result = await h
+            .control(h.getPeer(0))
+            .stub.probeRetriedEventSyncLog()
+            .request();
+
+        expect(result.handlerCallCount).to.equal(2);
+        expect(result.firstError).to.equal("Expected event-sync rejection");
+        expect(result.cursorAfterFailure).to.equal(result.cursorBefore);
+        expect(result.cursorAfterRetry).to.equal(result.blockNumber);
+    });
+
     it("joins concurrent calldata recovery onto one chain query", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(4, 0);

--- a/test/stateManager/EventSyncService.test.ts
+++ b/test/stateManager/EventSyncService.test.ts
@@ -3,8 +3,7 @@ import { expect } from "chai";
 import { MathTestSession as TestSession } from "@test/harness";
 
 describe("EventSyncService", function () {
-    it("retains a rejected log promise and holds the processed-block cursor", async function () {
-        this.timeout(90000);
+    it("treats a failed log as fatal - never re-dispatched, cursor holds", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(4, 0);
         const result = await h
@@ -16,22 +15,13 @@ describe("EventSyncService", function () {
         expect(result.handlerCallCount).to.equal(1);
         expect(result.firstError).to.equal("Expected event-sync rejection");
         expect(result.secondError).to.equal("Expected event-sync rejection");
-        expect(result.cursorAfter).to.equal(result.cursorBefore);
+        // the failure bubbles out of the detached promise
         expect(result.detachedError).to.equal("Expected event-sync rejection");
-    });
-
-    it("advances the processed-block cursor after a failed log is retried successfully", async function () {
-        const h = TestSession.getHarness();
-        await h.lifecycle.start(4, 0);
-        const result = await h
-            .control(h.getPeer(0))
-            .stub.probeRetriedEventSyncLog()
-            .request();
-
-        expect(result.handlerCallCount).to.equal(2);
-        expect(result.firstError).to.equal("Expected event-sync rejection");
-        expect(result.cursorAfterFailure).to.equal(result.cursorBefore);
-        expect(result.cursorAfterRetry).to.equal(result.blockNumber);
+        // rescheduling after the failure replays the rejection, it does not retry
+        expect(result.rescheduledError).to.equal(
+            "Expected event-sync rejection"
+        );
+        expect(result.cursorAfter).to.equal(result.cursorBefore);
     });
 
     it("joins concurrent calldata recovery onto one chain query", async function () {


### PR DESCRIPTION
review fixes for #397.

1. first-block calldata grace - `_validateTimeoutCalldataPostedProof` was missing the height-0 grace the other timeout paths already have
2. spectate junk-block abort - a non-participant sending an unauthenticated block could force a spectator offline; now it drops the sender and keeps running (E2E-SpectatingAbortDoS)

