### PR TITLE
Fix/Remove-polling (`waitFor`)

### DIFF
--- a/test/e2e/E2E-BlockQueueManager.test.ts
+++ b/test/e2e/E2E-BlockQueueManager.test.ts
@@ -123,14 +123,11 @@ describe("E2E: BlockQueueManager", function () {
             )
             .request();
 
-        await waitFor(
-            async () =>
-                await h
-                    .control(observer)
-                    .query.isBlacklisted(sender.address)
-                    .request(),
-            5000
-        );
+        await h.assert.sync.peerBlacklistedWait({
+            peerIndex: observer.index,
+            targetAddress: sender.address,
+            timeoutMs: 5000
+        });
         expect(
             await h
                 .control(observer)
@@ -287,14 +284,11 @@ describe("E2E: BlockQueueManager", function () {
             .transition.storeBlock(block1!.encodedBlockConfirmation)
             .request();
 
-        await waitFor(
-            async () =>
-                await h
-                    .control(observer)
-                    .query.isBlacklisted(h.getPeer(1).address)
-                    .request(),
-            (timeConfig.agreementTime + 5) * 1000
-        );
+        await h.assert.sync.peerBlacklistedWait({
+            peerIndex: observer.index,
+            targetAddress: h.getPeer(1).address,
+            timeoutMs: (timeConfig.agreementTime + 5) * 1000
+        });
         const storedBlock = await h
             .control(observer)
             .query.getBlockByHash(block1!.hash)
@@ -380,13 +374,19 @@ describe("E2E: BlockQueueManager", function () {
 
             await writerPeer!.p2pInstance.p2pContractInstance.add(1);
 
-            await waitFor(async () => {
-                const block = await h
-                    .control(sourcePeer)
-                    .query.getBlockByHeight(newForkId, 0)
-                    .request();
-                return Boolean(block?.encodedBlockConfirmation);
-            }, 10000);
+            await h.eventCountsBarrier.waitFor(
+                async () => {
+                    const block = await h
+                        .control(sourcePeer)
+                        .query.getBlockByHeight(newForkId, 0)
+                        .request();
+                    return Boolean(block?.encodedBlockConfirmation);
+                },
+                {
+                    timeoutMs: 10000,
+                    timeoutMessage: `sourcePeer did not observe the first reduced-fork block within 10000ms`
+                }
+            );
 
             const firstBlock = await h
                 .control(sourcePeer)
@@ -410,14 +410,12 @@ describe("E2E: BlockQueueManager", function () {
                 timeoutMs: 20000
             });
 
-            await waitFor(
-                async () =>
-                    (await h
-                        .control(targetPeer)
-                        .query.getForkId()
-                        .request()) === newForkId,
-                10000
-            );
+            await h.assert.sync.forkChangedWait({
+                originalForkId,
+                expectedForkId: newForkId,
+                honestPeerIndices: [targetPeerIndex],
+                timeoutMs: 10000
+            });
             expect(
                 h.event.getEventCallCount(targetPeerIndex, "onSetState")
             ).to.equal(1, "ingest-time local reduction should set state once");
@@ -530,14 +528,11 @@ describe("E2E: BlockQueueManager", function () {
             // The punishment arrives through the sync flow, not the queue:
             // the supplier cannot prove the fork, so the failed sync
             // blacklists them.
-            await waitFor(
-                async () =>
-                    await h
-                        .control(observer)
-                        .query.isBlacklisted(author.address)
-                        .request(),
-                15000
-            );
+            await h.assert.sync.peerBlacklistedWait({
+                peerIndex: observer.index,
+                targetAddress: author.address,
+                timeoutMs: 15000
+            });
             expect(
                 await h.control(observer).query.getForkId().request()
             ).to.equal(originalForkId);
@@ -640,14 +635,11 @@ describe("E2E: BlockQueueManager", function () {
             ).to.be.null;
             // The supplier cannot prove the bogus fork - the failed sync
             // blacklists them.
-            await waitFor(
-                async () =>
-                    await h
-                        .control(targetPeer)
-                        .query.isBlacklisted(author.address)
-                        .request(),
-                15000
-            );
+            await h.assert.sync.peerBlacklistedWait({
+                peerIndex: targetPeerIndex,
+                targetAddress: author.address,
+                timeoutMs: 15000
+            });
 
             await race.release();
             await h.event.waitWhileEventCountsStayAtMost(
@@ -714,13 +706,19 @@ describe("E2E: BlockQueueManager", function () {
 
             await writerPeer!.p2pInstance.p2pContractInstance.add(1);
 
-            await waitFor(async () => {
-                const block = await h
-                    .control(sourcePeer)
-                    .query.getBlockByHeight(newForkId, 0)
-                    .request();
-                return Boolean(block?.encodedBlockConfirmation);
-            }, 10000);
+            await h.eventCountsBarrier.waitFor(
+                async () => {
+                    const block = await h
+                        .control(sourcePeer)
+                        .query.getBlockByHeight(newForkId, 0)
+                        .request();
+                    return Boolean(block?.encodedBlockConfirmation);
+                },
+                {
+                    timeoutMs: 10000,
+                    timeoutMessage: `sourcePeer did not observe the first reduced-fork block within 10000ms`
+                }
+            );
             const firstBlock = await h
                 .control(sourcePeer)
                 .query.getBlockByHeight(newForkId, 0)
@@ -770,21 +768,22 @@ describe("E2E: BlockQueueManager", function () {
             await restoreReduce();
             await race.release();
 
-            await waitFor(
-                async () =>
-                    (await h
-                        .control(targetPeer)
-                        .query.getForkId()
-                        .request()) === newForkId,
-                15000
-            );
-            await waitFor(
+            await h.assert.sync.forkChangedWait({
+                originalForkId,
+                expectedForkId: newForkId,
+                honestPeerIndices: [targetPeerIndex],
+                timeoutMs: 15000
+            });
+            await h.eventCountsBarrier.waitFor(
                 async () =>
                     (await h
                         .control(targetPeer)
                         .query.getBlockByHeight(newForkId, 0)
                         .request()) !== null,
-                15000
+                {
+                    timeoutMs: 15000,
+                    timeoutMessage: `targetPeer did not observe the drained block at fork ${newForkId} height 0 within 15000ms`
+                }
             );
             expect(
                 h.event.getEventCallCount(targetPeerIndex, "onSetState")

--- a/test/e2e/E2E-CustomRpcRequestResponse.test.ts
+++ b/test/e2e/E2E-CustomRpcRequestResponse.test.ts
@@ -154,14 +154,20 @@ describe("E2E: custom RPC request/response over the runtime port", function () {
 
         // Track connection completion via client-side p2p event hooks (these
         // cross the port from the host). No host/state-manager access is used.
-        const connectedTo = new Map<string, Set<string>>([
-            [peer0Address, new Set<string>()],
-            [peer1Address, new Set<string>()]
-        ]);
+        // Each listener resolves its own deferred promise on arrival — no
+        // polling needed.
+        let resolveConnectedPeer0ToPeer1: () => void;
+        const connectedPeer0ToPeer1 = new Promise<void>((resolve) => {
+            resolveConnectedPeer0ToPeer1 = resolve;
+        });
+        let resolveConnectedPeer1ToPeer0: () => void;
+        const connectedPeer1ToPeer0 = new Promise<void>((resolve) => {
+            resolveConnectedPeer1ToPeer0 = resolve;
+        });
 
         const makePeer = async (
             runtimeWallet: ethers.HDNodeWallet,
-            selfAddress: string
+            onConnectedTo: (address: string) => void
         ): Promise<PingPeer> => {
             const runtimeSigner = runtimeWallet;
             const scm = StateChannelManagerProxy__factory.connect(
@@ -191,17 +197,23 @@ describe("E2E: custom RPC request/response over the runtime port", function () {
             // Track connection completion via a client-side p2p event listener
             // (forwarded over the port from the host).
             instance.on("onConnection", (address) => {
-                connectedTo
-                    .get(selfAddress)
-                    ?.add(String(address).toLowerCase());
+                onConnectedTo(String(address).toLowerCase());
             });
 
             return instance;
         };
 
-        const peer0 = await makePeer(peer0Wallet, peer0Address);
+        const peer0 = await makePeer(peer0Wallet, (address) => {
+            if (address === peer1Address.toLowerCase()) {
+                resolveConnectedPeer0ToPeer1();
+            }
+        });
         peers.push(peer0);
-        const peer1 = await makePeer(peer1Wallet, peer1Address);
+        const peer1 = await makePeer(peer1Wallet, (address) => {
+            if (address === peer0Address.toLowerCase()) {
+                resolveConnectedPeer1ToPeer0();
+            }
+        });
         peers.push(peer1);
 
         // Open a channel with both participants, driven entirely from the
@@ -234,16 +246,20 @@ describe("E2E: custom RPC request/response over the runtime port", function () {
         await openTx.wait();
 
         // Wait until both peers report a completed handshake to each other.
-        await waitFor(
-            () =>
-                connectedTo
-                    .get(peer0Address)
-                    ?.has(peer1Address.toLowerCase()) === true &&
-                connectedTo
-                    .get(peer1Address)
-                    ?.has(peer0Address.toLowerCase()) === true,
-            20_000
-        );
+        await Promise.race([
+            Promise.all([connectedPeer0ToPeer1, connectedPeer1ToPeer0]),
+            new Promise<never>((_, reject) =>
+                setTimeout(
+                    () =>
+                        reject(
+                            new Error(
+                                "timed out waiting for mutual handshake completion"
+                            )
+                        ),
+                    20_000
+                )
+            )
+        ]);
 
         // --- Self-call (no target): runs on the peer's own host (loopback) ---
         const sumSelf: SumResponse = await peer0.hostRpc.pingService

--- a/test/e2e/E2E-FraudProofsBlockConfirmation.test.ts
+++ b/test/e2e/E2E-FraudProofsBlockConfirmation.test.ts
@@ -4,7 +4,6 @@ import Clock from "@/Clock";
 import { FraudProofType } from "@/types/sol-enums";
 import { Codec, Type } from "@/utils";
 import { MathTestSession as TestSession, sleep } from "@test/harness";
-import { waitFor } from "@test/utils/waitFor";
 import type { BlockBundle } from "@test/fixtures/customRpc/harnessControl/services/query/QueryRpcMethods";
 
 /**
@@ -130,13 +129,16 @@ describe("E2E: Block Fraud Proofs", function () {
         // maybePostBlockOnChain is stubbed ()=>{} + after AgreementTime the subjective check each peer does would fail, so if the block is accepted -> calldata path
         await postBlockCalldata(block1!);
 
-        await waitFor(
+        await h.eventCountsBarrier.waitFor(
             async () =>
                 (await h
                     .control(observer)
                     .query.getBlockByHash(block1!.hash)
                     .request()) !== null,
-            5000
+            {
+                timeoutMs: 5000,
+                timeoutMessage: `observer did not store block1 (${block1!.hash}) within 5000ms`
+            }
         );
 
         // Re-deliver block2 from the chain (as an event re-read would) — it
@@ -151,13 +153,16 @@ describe("E2E: Block Fraud Proofs", function () {
             keepConnection: true,
             waitForProcessed: false
         });
-        await waitFor(
+        await h.eventCountsBarrier.waitFor(
             async () =>
                 (await h
                     .control(observer)
                     .query.getBlockByHash(block2!.hash)
                     .request()) !== null,
-            5000
+            {
+                timeoutMs: 5000,
+                timeoutMessage: `observer did not store block2 (${block2!.hash}) within 5000ms`
+            }
         );
 
         const storedBlock2 = await h
@@ -245,7 +250,7 @@ describe("E2E: Block Fraud Proofs", function () {
             processedKeepConnection: true
         });
 
-        await waitFor(
+        await h.eventCountsBarrier.waitFor(
             async () =>
                 (
                     await h
@@ -253,7 +258,10 @@ describe("E2E: Block Fraud Proofs", function () {
                         .query.getBlockByHash(block!.hash)
                         .request()
                 )?.onChainTimestamp === expectedTimestamp,
-            5000
+            {
+                timeoutMs: 5000,
+                timeoutMessage: `observer's stored block ${block!.hash} did not merge onChainTimestamp ${expectedTimestamp} within 5000ms`
+            }
         );
         expect(
             Number(
@@ -304,19 +312,19 @@ describe("E2E: Block Fraud Proofs", function () {
             ingestOptions: { senderAddress: h.getPeer(1).address },
             keepConnection: true,
             // The merge is a scheduled task and setup echoes of this block
-            // fire matching processed events, so waiting on the event races —
-            // poll for the strategy's outcome (sender blacklisted) instead.
+            // fire matching processed events, so waiting on the *processed*
+            // event races (ingestBlockConfirmationWait's own wait matches
+            // stale spy-history hits) — wait on the strategy's outcome
+            // (sender blacklisted) instead, which reads live state rather
+            // than event history so it isn't vulnerable to the same race.
             waitForProcessed: false
         });
 
-        await waitFor(
-            async () =>
-                await h
-                    .control(observer)
-                    .query.isBlacklisted(h.getPeer(1).address)
-                    .request(),
-            5000
-        );
+        await h.assert.sync.peerBlacklistedWait({
+            peerIndex: observer.index,
+            targetAddress: h.getPeer(1).address,
+            timeoutMs: 5000
+        });
         const storedBlock = await h
             .control(observer)
             .query.getBlockByHash(block!.hash)

--- a/test/e2e/E2E-JoinChannelRaceConditions.test.ts
+++ b/test/e2e/E2E-JoinChannelRaceConditions.test.ts
@@ -6,7 +6,6 @@ import {
     encodeMathState,
     type MathStateDecoded
 } from "@test/utils/mathHarnessAbi";
-import { waitFor } from "@test/utils/waitFor";
 import { expect } from "chai";
 import Clock from "@/Clock";
 import assert from "node:assert/strict";
@@ -335,12 +334,10 @@ describe("E2E: Join channel race conditions", function () {
                 assertMaliciousRemoved: false
             });
 
-            await waitFor(async () => {
-                const snapshot = await h.channelManager.getStateSnapshot(
-                    h.channelId
-                );
-                return snapshot.forkId !== originalForkId;
-            }, 15000);
+            await h.assert.snapshot.localSnapshotsChangedWait({
+                previousForkId: originalForkId,
+                timeoutMs: 15000
+            });
 
             const onChainParticipants = await h.channelManager.getParticipants(
                 h.channelId
@@ -441,12 +438,10 @@ describe("E2E: Join channel race conditions", function () {
                 honestPeerIndices: remainingPeerIndices,
                 assertMaliciousRemoved: false
             });
-            await waitFor(async () => {
-                const snapshot = await h.channelManager.getStateSnapshot(
-                    h.channelId
-                );
-                return snapshot.forkId !== originalForkId;
-            }, 15000);
+            await h.assert.snapshot.localSnapshotsChangedWait({
+                previousForkId: originalForkId,
+                timeoutMs: 15000
+            });
 
             const union = await h
                 .control(h.getPeer(1))

--- a/test/e2e/E2E-MaliciousUpdateSnapshot.test.ts
+++ b/test/e2e/E2E-MaliciousUpdateSnapshot.test.ts
@@ -9,7 +9,6 @@ import {
 } from "@test/utils/mathHarnessAbi";
 import { Status } from "@/types";
 import { expect } from "chai";
-import { waitFor } from "@test/utils/waitFor";
 import type {
     MessageBlockStruct,
     BalanceStruct,
@@ -256,16 +255,12 @@ describe("E2E: Malicious updateSnapshot", function () {
         // getPeer to recover the harness's typed peer handle.
         const added = await h.join.addSpectator();
         const spectator = h.getPeer(added.index);
-        await h.control(spectator).stub.stubRecordSpectateAbort().request();
 
-        // Wait for abort.
-        await waitFor(
-            () => h.control(spectator).stub.wasSpectateAbortCalled().request(),
-            5000
-        );
-        expect(
-            await h.control(spectator).stub.wasSpectateAbortCalled().request()
-        ).to.equal(true, "SpectateService.abort must be called");
+        // Wait for abort. `SpectateService.abort` (not-yet-participating path)
+        // calls `StateManager.abort`, which fires the `onAbort` event hook.
+        await h.event.waitForPeers("onAbort", [spectator.index], 1, {
+            timeoutMs: 5000
+        });
 
         expect(
             await h.control(spectator).query.getStatus().request()

--- a/test/e2e/E2E-RuntimeContractEvents.test.ts
+++ b/test/e2e/E2E-RuntimeContractEvents.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai";
 
 import { MathTestSession as TestSession } from "@test/harness";
-import { waitFor } from "@test/utils/waitFor";
 
 /**
  * A contract event emitted by the host EVM must reach a subscriber on the
@@ -29,11 +28,17 @@ describe("E2E: Runtime contract events", function () {
 
         const received: Array<[bigint, bigint, bigint]> = [];
         // Subscribe exactly like the app: through the main-thread contract whose
-        // runner is the provider-less ClientP2pSigner.
+        // runner is the provider-less ClientP2pSigner. The listener itself
+        // signals arrival — no need to poll `received` afterwards.
+        let onReceived: () => void;
+        const receivedEvent = new Promise<void>((resolve) => {
+            onReceived = resolve;
+        });
         await contract.on(
             contract.filters.Addition(),
             (a: bigint, b: bigint, result: bigint) => {
                 received.push([a, b, result]);
+                onReceived();
             }
         );
 
@@ -42,7 +47,18 @@ describe("E2E: Runtime contract events", function () {
         // the log and forwards it over its own runtime port.
         await h.transition.advanceState({ count: 1 });
 
-        await waitFor(() => received.length >= 1, 15_000);
+        await Promise.race([
+            receivedEvent,
+            new Promise<never>((_, reject) =>
+                setTimeout(
+                    () =>
+                        reject(
+                            new Error("timed out waiting for Addition event")
+                        ),
+                    15_000
+                )
+            )
+        ]);
 
         expect(received).to.have.lengthOf(1);
         const [a, b, result] = received[0];

--- a/test/e2e/E2E-Spectate.test.ts
+++ b/test/e2e/E2E-Spectate.test.ts
@@ -1049,22 +1049,16 @@ describe("E2E: Spectate Service", function () {
                 .spectate.startSync(responder.address, forkId, 9999)
                 .request();
 
-            await waitFor(
-                async () =>
-                    await h
-                        .control(responder)
-                        .query.isBlacklisted(requester.address)
-                        .request(),
-                10000
-            );
-            await waitFor(
-                async () =>
-                    await h
-                        .control(requester)
-                        .query.isBlacklisted(responder.address)
-                        .request(),
-                10000
-            );
+            await h.assert.sync.peerBlacklistedWait({
+                peerIndex: responder.index,
+                targetAddress: requester.address,
+                timeoutMs: 10000
+            });
+            await h.assert.sync.peerBlacklistedWait({
+                peerIndex: requester.index,
+                targetAddress: responder.address,
+                timeoutMs: 10000
+            });
         });
     });
 

--- a/test/e2e/E2E-SpectateStaleProofGuard.test.ts
+++ b/test/e2e/E2E-SpectateStaleProofGuard.test.ts
@@ -1,6 +1,5 @@
 import { MathTestSession as TestSession } from "@test/harness";
 import { expect } from "chai";
-import { waitFor } from "@test/utils/waitFor";
 import { Status } from "@/types";
 
 describe("E2E: Spectate stale-proof guard", function () {
@@ -131,14 +130,11 @@ describe("E2E: Spectate stale-proof guard", function () {
 
         // The stale-proof bound aborts the sync and the participant blacklists
         // the responder.
-        await waitFor(
-            async () =>
-                await h
-                    .control(requester)
-                    .query.isBlacklisted(responder.address)
-                    .request(),
-            15000
-        );
+        await h.assert.sync.peerBlacklistedWait({
+            peerIndex: requesterIndex,
+            targetAddress: responder.address,
+            timeoutMs: 15000
+        });
         expect(
             await h
                 .control(requester)

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -460,35 +460,6 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
     }
 
     /**
-     * Wrap `spectateService.abort` to record when it fires (queried via
-     * `wasSpectateAbortCalled`) while still running the original — the host-side
-     * stand-in for spying on abort from the main thread.
-     */
-    public stubRecordSpectateAbort(): boolean {
-        const service = this.p2pManager.localRpc.spectateService;
-        if (!this.service.stubOriginals.has("spectateAbort")) {
-            this.service.stubOriginals.set(
-                "spectateAbort",
-                service.abort.bind(service)
-            );
-        }
-        this.service.spectateAbortCalled = false;
-        const original = this.service.stubOriginals.get(
-            "spectateAbort"
-        ) as typeof service.abort;
-        const stubService = this.service;
-        service.abort = (peerAddress) => {
-            stubService.spectateAbortCalled = true;
-            return original(peerAddress);
-        };
-        return true;
-    }
-
-    public wasSpectateAbortCalled(): boolean {
-        return this.service.spectateAbortCalled;
-    }
-
-    /**
      * Capture the transport this peer initiates a handshake over (its outbound
      * `initHandshake`), recording it on the service so a test can send an RPC
      * over a pre-handshake transport (read via `execOnHost`). Runs the original.

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -28,7 +28,6 @@ export type StubKey =
     | "captureInitHandshake"
     | "initHandshakeCreateRpcMethods"
     | "maybePostBlockOnChain"
-    | "spectateAbort"
     | "reductionTasks"
     | "snapshotUpdatedEvents"
     | "disputeCommittedEvents"
@@ -114,8 +113,6 @@ export class StubService extends ARpcService<
     spectateGuardBlocked = false;
     /** Transport captured by the init-handshake capture stub (pre-handshake). */
     capturedInitHandshakeTransport?: ATransport;
-    /** Set by the record-spectate-abort stub when `abort` fires. */
-    spectateAbortCalled = false;
     /** Incremented by the count-spectate-requests stub per onSpectateRequest. */
     spectateRequestCount = 0;
     /** `reduction-*` timer tasks captured by the hold-reduction-tasks stub. */

--- a/test/harness/actions/assert/AssertSyncActions.ts
+++ b/test/harness/actions/assert/AssertSyncActions.ts
@@ -1,4 +1,4 @@
-import type { ForkId, Hash } from "@/types/types";
+import type { Address, ForkId, Hash } from "@/types/types";
 import { expect } from "chai";
 import { PeerTestHarness } from "@test/fixtures/PeerTestHarness";
 import type { HarnessControlRpc } from "@test/fixtures/customRpc/harnessControl/HarnessControlRpc";
@@ -356,6 +356,27 @@ export class AssertSyncActions<
             {
                 timeoutMs,
                 timeoutMessage: `Spectator ${spectatorPeerIndex} should have no transport to/from peers [${peerIndices.join(", ")}] within ${timeoutMs}ms`
+            }
+        );
+    }
+
+    async peerBlacklistedWait(options: {
+        peerIndex: number;
+        targetAddress: Address;
+        timeoutMs?: number;
+    }): Promise<void> {
+        const { peerIndex, targetAddress, timeoutMs = 15000 } = options;
+        const peer = this.harness.getPeer(peerIndex);
+
+        await this.harness.eventCountsBarrier.waitFor(
+            async () =>
+                await this.harness
+                    .control(peer)
+                    .query.isBlacklisted(targetAddress)
+                    .request(),
+            {
+                timeoutMs,
+                timeoutMessage: `Peer ${peerIndex} did not blacklist ${targetAddress} within ${timeoutMs}ms`
             }
         );
     }

--- a/test/utils/waitFor.ts
+++ b/test/utils/waitFor.ts
@@ -1,7 +1,7 @@
 export async function waitFor(
     condition: () => boolean | Promise<boolean>,
     timeoutMs: number = 1000,
-    pollIntervalMs: number = 5
+    pollIntervalMs: number = 100
 ): Promise<void> {
     const startTime = Date.now();
 


### PR DESCRIPTION
Follow-up to PR #398's [PO1] comment (waitFor's 5ms default poll interval is a hazard under test:parallel load). Converts the call sites that had a real event to wait on, and raises the shared default for the rest.

1. Converted to event-driven waits (7 test files + 1 new harness helper AssertSyncActions.peerBlacklistedWait): E2E-JoinChannelRaceConditions, E2E-MaliciousUpdateSnapshot, E2E-RuntimeContractEvents, E2E-CustomRpcRequestResponse, E2E-Spectate, E2E-SpectateStaleProofGuard, E2E-BlockQueueManager, E2E-FraudProofsBlockConfirmation. Each replaces a waitFor(condition, ms) poll with eventCountsBarrier/an existing harness wait (onAbort, onConnection, forkChangedWait, peerBlacklistedWait, or a listener-resolved promise), re-checking on real signals instead of a fixed interval.

2. Left as polling, deliberately — where there's no event to hook into:

E2E-RuntimeTransportModes / E2E-CustomRpcRequestResponse's waitForNode — polling a hardhat node before it's even listening; no event source can exist yet.
E2E-PingService — bespoke demo RPC manifest with no wired event infra; not worth inventing plumbing for an example fixture.
E2E-Spectate's Guard Protection (x2) and Concurrent-sync-dedup (x1) — bespoke stub counters (capturedInitHandshakeTransport, stubCountSpectateRequests) with no corresponding domain event.
E2E-BlockQueueManager's isBlockQueued eviction-at-timeout waits (x2) and heldSnapshotEventCount (x2) — the eviction is a bare scheduled timer with no event, and the held-event-count stub intentionally intercepts the real handler, so by design nothing fires normally while it's active.
AssertDisputeActions.reductionCompletedWait (E2E-FinalDispute, E2E-ReductionManager) — the signal path (onDisputeReducedResultCommitted) wasn't clearly wired to eventCountsBarrier; stopped short rather than guess on a helper shared by multiple suites.
One file (E2E-FraudProofsBlockConfirmation) had an explicit comment claiming event-based waiting is racy there — traced the real mechanism (stale spy-call-history match on blockHash, specific to ingestBlockConfirmationWait's own internal wait) and confirmed the converted follow-up waits read live state instead, so they aren't exposed to that race. Verified 5/5 individually + 5/5 under  parallel load.

 3. Raised waitFor's default pollIntervalMs 5→100ms for the ~32 remaining default-reliant call sites left untouched.