### PR TITLE
(test infra) parallel scheduler adapts to the machine

### DIFF
--- a/scripts/e2e-parallel/adaptiveScheduling.js
+++ b/scripts/e2e-parallel/adaptiveScheduling.js
@@ -1,0 +1,81 @@
+/* eslint-disable no-console */
+// Host probes and scheduling policy: available memory, core-scaled concurrency,
+// slot picking, per-tick admission.
+const fs = require("fs");
+const os = require("os");
+const { HW_THREADS_PER_TEST } = require("./constants");
+
+const GIB = 1024 ** 3;
+
+// OS-available memory in GiB, counting every process on the box, not just ours.
+// Linux: MemAvailable (free + reclaimable cache). Elsewhere: os.freemem().
+function availableMemGb() {
+    if (process.platform === "linux") {
+        try {
+            const meminfo = fs.readFileSync("/proc/meminfo", "utf8");
+            const m = meminfo.match(/^MemAvailable:\s+(\d+)\s*kB/m);
+            if (m) return Number(m[1]) / 1024 / 1024;
+        } catch {
+            // fall through to os.freemem()
+        }
+    }
+    return os.freemem() / GIB;
+}
+
+// Concurrent-test cap from core count: ~HW_THREADS_PER_TEST threads per test,
+// clamped to [2, maxCap]. The load and memory gates throttle below this.
+function resolveDefaultWorkers(cores, maxCap) {
+    const c = Number.isFinite(cores) && cores > 0 ? cores : 2;
+    const byCores = Math.floor(c / HW_THREADS_PER_TEST);
+    return Math.max(2, Math.min(maxCap, byCores));
+}
+
+// Idle slot if there is one, else the least loaded. Never blocks: slots are a
+// timing-isolation pool, not a concurrency limit.
+function pickLeastLoadedSlot(slotLoad) {
+    let best = 0;
+    for (let i = 1; i < slotLoad.length; i++) {
+        if (slotLoad[i] < slotLoad[best]) best = i;
+    }
+    return best;
+}
+
+// Admission decision for one tick. running === 0 always admits so the suite
+// never stalls.
+function evaluateAdmission({
+    running,
+    concurrencyCap,
+    cpuUtil,
+    targetLoad,
+    occupiedGb,
+    avgPerTestGb,
+    memBoundGb,
+    availGb,
+    memFloorGb
+}) {
+    const countOk = running < concurrencyCap;
+    const cpuOk = cpuUtil < targetLoad;
+    const memOwnedOk = occupiedGb + avgPerTestGb < memBoundGb;
+    const memSysOk = availGb - avgPerTestGb >= memFloorGb;
+
+    const admit = running === 0 || (countOk && cpuOk && memOwnedOk && memSysOk);
+
+    let reason = null;
+    if (!admit) {
+        reason = !countOk
+            ? `cap (running ${running}/${concurrencyCap})`
+            : !memSysOk
+              ? `system memory (avail ${availGb.toFixed(1)}−${avgPerTestGb.toFixed(1)}<${memFloorGb.toFixed(1)}GB free)`
+              : !memOwnedOk
+                ? `memory (owned ${occupiedGb.toFixed(1)}+${avgPerTestGb.toFixed(1)}≥${memBoundGb.toFixed(1)}GB)`
+                : `cpu ${(cpuUtil * 100).toFixed(0)}%>=${(targetLoad * 100).toFixed(0)}%`;
+    }
+    return { admit, reason };
+}
+
+module.exports = {
+    availableMemGb,
+    resolveDefaultWorkers,
+    pickLeastLoadedSlot,
+    evaluateAdmission
+};

--- a/scripts/e2e-parallel/adaptiveScheduling.js
+++ b/scripts/e2e-parallel/adaptiveScheduling.js
@@ -3,7 +3,11 @@
 // slot picking, per-tick admission.
 const fs = require("fs");
 const os = require("os");
-const { HW_THREADS_PER_TEST } = require("./constants");
+const {
+    ADAPTIVE_MIN_CAP,
+    HEALTHY_EL_DELAY_MS,
+    GROW_AFTER_HEALTHY
+} = require("./constants");
 
 const GIB = 1024 ** 3;
 
@@ -22,12 +26,57 @@ function availableMemGb() {
     return os.freemem() / GIB;
 }
 
-// Concurrent-test cap from core count: ~HW_THREADS_PER_TEST threads per test,
-// clamped to [2, maxCap]. The load and memory gates throttle below this.
-function resolveDefaultWorkers(cores, maxCap) {
-    const c = Number.isFinite(cores) && cores > 0 ? cores : 2;
-    const byCores = Math.floor(c / HW_THREADS_PER_TEST);
-    return Math.max(2, Math.min(maxCap, byCores));
+// Next ceiling to probe: double while nothing has starved yet, then bisect between
+// the highest healthy level and the lowest starved one. Adjacent bounds mean the
+// limit is known, so the ceiling stops moving.
+function probeTarget(goodCap, badCap, maxCap) {
+    if (!Number.isFinite(badCap)) return Math.min(maxCap, goodCap * 2);
+    if (goodCap + 1 >= badCap) return goodCap;
+    return Math.min(maxCap, Math.floor((goodCap + badCap) / 2));
+}
+
+// Next concurrency ceiling from one finished test. A starved test lowers the bad
+// bound immediately; a level is only promoted to good after GROW_AFTER_HEALTHY
+// healthy finishes, so it backs off fast and climbs deliberately. Tests with no
+// timing markers carry no signal and change nothing.
+function nextAdaptiveCap({
+    current,
+    starved,
+    elDelayMs,
+    hasTiming,
+    healthyStreak = 0,
+    goodCap = ADAPTIVE_MIN_CAP,
+    badCap = Infinity,
+    healthyElMs = HEALTHY_EL_DELAY_MS,
+    growAfter = GROW_AFTER_HEALTHY,
+    minCap = ADAPTIVE_MIN_CAP,
+    maxCap
+}) {
+    if (starved) {
+        const bad = Math.min(badCap, current);
+        const good = Math.max(minCap, Math.min(goodCap, bad - 1));
+        return {
+            cap: Math.max(minCap, probeTarget(good, bad, maxCap)),
+            healthyStreak: 0,
+            goodCap: good,
+            badCap: bad
+        };
+    }
+    if (!hasTiming || elDelayMs > healthyElMs) {
+        return { cap: current, healthyStreak, goodCap, badCap };
+    }
+
+    const streak = healthyStreak + 1;
+    if (streak < growAfter) {
+        return { cap: current, healthyStreak: streak, goodCap, badCap };
+    }
+    const good = Math.max(goodCap, current);
+    return {
+        cap: Math.max(minCap, probeTarget(good, badCap, maxCap)),
+        healthyStreak: 0,
+        goodCap: good,
+        badCap
+    };
 }
 
 // Idle slot if there is one, else the least loaded. Never blocks: slots are a
@@ -75,7 +124,7 @@ function evaluateAdmission({
 
 module.exports = {
     availableMemGb,
-    resolveDefaultWorkers,
+    nextAdaptiveCap,
     pickLeastLoadedSlot,
     evaluateAdmission
 };

--- a/scripts/e2e-parallel/argParser.js
+++ b/scripts/e2e-parallel/argParser.js
@@ -16,9 +16,11 @@ Options:
                                   Allow clearing an explicit dir outside logs/
       --slots <count>            Warm E2E infrastructure slots (0 disables)
   -w, --workers <count>          Maximum concurrent test processes
+                                  (default: auto-scaled from CPU core count)
       --target-load <number>     Maximum average system load per CPU core
   -i, --interval <ms>            Scheduler admission interval
       --mem-limit-gb <gb>        Memory budget for owned test processes
+      --mem-floor-gb <gb>        Min system-available memory to keep free
       --sdk-thread               Run the SDK host in a worker thread
       --no-sdk-thread            Run the SDK host on the main thread
       --vm-thread                Run the VM executor in a worker thread
@@ -63,6 +65,8 @@ function parseCliArgs(argv) {
         schedulerTickMs: undefined,
         // Memory budget in GiB; undefined → totalmem × MEM_LIMIT_FRACTION.
         memLimitGb: undefined,
+        // Min system-available memory to keep free (GiB); undefined → SYSTEM_MEM_FLOOR_GB.
+        memFloorGb: undefined,
         // Thread-mode toggles: undefined = fall back to env/default.
         sdkThread: undefined,
         vmThread: undefined
@@ -225,6 +229,20 @@ function parseCliArgs(argv) {
         if (arg.startsWith("--mem-limit-gb=")) {
             const v = takeNumber(arg.split("=")[1], Number.parseFloat);
             if (v !== undefined) options.memLimitGb = v;
+            continue;
+        }
+
+        if (arg === "--mem-floor-gb") {
+            const v = takeNumber(argv[i + 1], Number.parseFloat);
+            if (v !== undefined) {
+                options.memFloorGb = v;
+                i++;
+            }
+            continue;
+        }
+        if (arg.startsWith("--mem-floor-gb=")) {
+            const v = takeNumber(arg.split("=")[1], Number.parseFloat);
+            if (v !== undefined) options.memFloorGb = v;
             continue;
         }
 

--- a/scripts/e2e-parallel/constants.js
+++ b/scripts/e2e-parallel/constants.js
@@ -45,10 +45,6 @@ const PER_TEST_MEM_GB = 2;
 // ---------------------------------------------------------------------------
 // Machine-aware defaults
 // ---------------------------------------------------------------------------
-// Hardware threads reserved per concurrent E2E test when auto-sizing --workers.
-// Each test runs a Hardhat node plus an SDK and a VM thread per peer.
-const HW_THREADS_PER_TEST = 4;
-
 // Minimum MemAvailable to keep free. Counts other processes, unlike the
 // owned-RSS gate above, so a box full of browser/editor RSS stops before swapping.
 const SYSTEM_MEM_FLOOR_GB = 3;
@@ -56,6 +52,17 @@ const SYSTEM_MEM_FLOOR_GB = 3;
 // Event-loop peak that marks a failed task as load-induced and earns it one
 // retry. Below the 1s watchdog in test/peer3.test.config.ts.
 const LOAD_RETRY_EL_DELAY_MS = 750;
+
+// Adaptive concurrency. The ceiling is measured, not guessed: it doubles while
+// finished tests report healthy event loops and halves when one comes back
+// starved, so it converges on what the machine actually sustains.
+const ADAPTIVE_START_CAP = 4;
+const ADAPTIVE_MIN_CAP = 1;
+// Event-loop peak a finished test must stay under to count as headroom.
+const HEALTHY_EL_DELAY_MS = 250;
+// Healthy finishes required per +1 once slow-start is over, so one lucky test
+// doesn't push the ceiling up.
+const GROW_AFTER_HEALTHY = 2;
 
 module.exports = {
     DEFAULT_LOG_DIR,
@@ -70,7 +77,10 @@ module.exports = {
     TARGET_LOAD_PER_CORE,
     MEM_LIMIT_FRACTION,
     PER_TEST_MEM_GB,
-    HW_THREADS_PER_TEST,
     SYSTEM_MEM_FLOOR_GB,
-    LOAD_RETRY_EL_DELAY_MS
+    LOAD_RETRY_EL_DELAY_MS,
+    ADAPTIVE_START_CAP,
+    ADAPTIVE_MIN_CAP,
+    HEALTHY_EL_DELAY_MS,
+    GROW_AFTER_HEALTHY
 };

--- a/scripts/e2e-parallel/constants.js
+++ b/scripts/e2e-parallel/constants.js
@@ -42,6 +42,21 @@ const TARGET_LOAD_PER_CORE = 0.8;
 const MEM_LIMIT_FRACTION = 0.8;
 const PER_TEST_MEM_GB = 2;
 
+// ---------------------------------------------------------------------------
+// Machine-aware defaults
+// ---------------------------------------------------------------------------
+// Hardware threads reserved per concurrent E2E test when auto-sizing --workers.
+// Each test runs a Hardhat node plus an SDK and a VM thread per peer.
+const HW_THREADS_PER_TEST = 4;
+
+// Minimum MemAvailable to keep free. Counts other processes, unlike the
+// owned-RSS gate above, so a box full of browser/editor RSS stops before swapping.
+const SYSTEM_MEM_FLOOR_GB = 3;
+
+// Event-loop peak that marks a failed task as load-induced and earns it one
+// retry. Below the 1s watchdog in test/peer3.test.config.ts.
+const LOAD_RETRY_EL_DELAY_MS = 750;
+
 module.exports = {
     DEFAULT_LOG_DIR,
     HARDHAT_CLI,
@@ -54,5 +69,8 @@ module.exports = {
     SCHEDULER_TICK_MS,
     TARGET_LOAD_PER_CORE,
     MEM_LIMIT_FRACTION,
-    PER_TEST_MEM_GB
+    PER_TEST_MEM_GB,
+    HW_THREADS_PER_TEST,
+    SYSTEM_MEM_FLOOR_GB,
+    LOAD_RETRY_EL_DELAY_MS
 };

--- a/scripts/e2e-parallel/logging.js
+++ b/scripts/e2e-parallel/logging.js
@@ -259,13 +259,16 @@ function runHeader({
     targetLoad,
     tickMs,
     memBoundGb,
-    concurrencyCap
+    concurrencyCap,
+    autoWorkers,
+    cores,
+    memFloorGb
 }) {
     console.log(
         `Running ${taskCount} ${e2eOnly ? "E2E" : "Mocha"} task(s)${grep ? ` matching --grep ${JSON.stringify(grep)}` : ""}`
     );
     console.log(
-        `  slots=${slotCount} vmThread=${threadModes.vmThread} sdkThread=${threadModes.sdkThread} targetLoad/core=${targetLoad} schedulerTickMs=${tickMs} memBound=${memBoundGb.toFixed(1)}GB concurrencyCap=${concurrencyCap}`
+        `  slots=${slotCount} vmThread=${threadModes.vmThread} sdkThread=${threadModes.sdkThread} targetLoad/core=${targetLoad} schedulerTickMs=${tickMs} memBound=${memBoundGb.toFixed(1)}GB concurrencyCap=${concurrencyCap}${autoWorkers ? ` (auto from ${cores} cores)` : ""} · keep ≥${memFloorGb.toFixed(1)}GB free`
     );
 }
 
@@ -277,7 +280,10 @@ function dryRun({
     memBoundGb,
     totalGb,
     concurrencyCap,
-    tickMs
+    tickMs,
+    autoWorkers,
+    cores,
+    memFloorGb
 }) {
     console.log(`\nDry-run (${taskCount} task(s)):`);
     console.log(`  slots            : ${slotCount}`);
@@ -287,7 +293,12 @@ function dryRun({
     console.log(
         `  memBound         : ${memBoundGb.toFixed(1)}GB of ${totalGb.toFixed(1)}GB (${((memBoundGb / totalGb) * 100).toFixed(0)}%)`
     );
-    console.log(`  concurrencyCap   : ${concurrencyCap}`);
+    console.log(
+        `  concurrencyCap   : ${concurrencyCap}${autoWorkers ? ` (auto from ${cores} cores)` : " (--workers)"}`
+    );
+    console.log(
+        `  keep free        : ≥${memFloorGb.toFixed(1)}GB system-available`
+    );
     console.log(`  scheduler        : one admission per ${tickMs}ms tick`);
 }
 
@@ -320,11 +331,16 @@ function hold({ seq, total, reason }) {
 }
 
 // Light yellow: a starved task gets its single clean retry.
-function starvationRetry({ seq, total, label, starveCount }) {
+function starvationRetry({ seq, total, label, starveCount, elDelayMs }) {
+    // starveCount > 0 means the watchdog fired; otherwise report the stall.
+    const cause =
+        starveCount > 0
+            ? `STARVED x${starveCount}`
+            : `STARVED (event-loop peak ${elDelayMs}ms)`;
     console.log(
         colorize(
             "lightYellow",
-            `[${seq}/${total}] STARVED x${starveCount} — rescheduling once [${label}]`
+            `[${seq}/${total}] ${cause} — rescheduling once [${label}]`
         )
     );
 }

--- a/scripts/e2e-parallel/logging.js
+++ b/scripts/e2e-parallel/logging.js
@@ -260,15 +260,14 @@ function runHeader({
     tickMs,
     memBoundGb,
     concurrencyCap,
-    autoWorkers,
-    cores,
+    adaptiveWorkers,
     memFloorGb
 }) {
     console.log(
         `Running ${taskCount} ${e2eOnly ? "E2E" : "Mocha"} task(s)${grep ? ` matching --grep ${JSON.stringify(grep)}` : ""}`
     );
     console.log(
-        `  slots=${slotCount} vmThread=${threadModes.vmThread} sdkThread=${threadModes.sdkThread} targetLoad/core=${targetLoad} schedulerTickMs=${tickMs} memBound=${memBoundGb.toFixed(1)}GB concurrencyCap=${concurrencyCap}${autoWorkers ? ` (auto from ${cores} cores)` : ""} · keep ≥${memFloorGb.toFixed(1)}GB free`
+        `  slots=${slotCount} vmThread=${threadModes.vmThread} sdkThread=${threadModes.sdkThread} targetLoad/core=${targetLoad} schedulerTickMs=${tickMs} memBound=${memBoundGb.toFixed(1)}GB concurrency=${adaptiveWorkers ? `adaptive (ceiling ${concurrencyCap})` : concurrencyCap} · keep ≥${memFloorGb.toFixed(1)}GB free`
     );
 }
 
@@ -281,8 +280,7 @@ function dryRun({
     totalGb,
     concurrencyCap,
     tickMs,
-    autoWorkers,
-    cores,
+    adaptiveWorkers,
     memFloorGb
 }) {
     console.log(`\nDry-run (${taskCount} task(s)):`);
@@ -294,7 +292,7 @@ function dryRun({
         `  memBound         : ${memBoundGb.toFixed(1)}GB of ${totalGb.toFixed(1)}GB (${((memBoundGb / totalGb) * 100).toFixed(0)}%)`
     );
     console.log(
-        `  concurrencyCap   : ${concurrencyCap}${autoWorkers ? ` (auto from ${cores} cores)` : " (--workers)"}`
+        `  concurrency      : ${adaptiveWorkers ? `adaptive, ceiling ${concurrencyCap}` : `${concurrencyCap} (--workers)`}`
     );
     console.log(
         `  keep free        : ≥${memFloorGb.toFixed(1)}GB system-available`
@@ -331,6 +329,19 @@ function hold({ seq, total, reason }) {
 }
 
 // Light yellow: a starved task gets its single clean retry.
+// The measured concurrency ceiling moved.
+function adaptiveCap({ from, to, elDelayMs, starved, settled }) {
+    const why = starved
+        ? `starved (event-loop ${elDelayMs}ms)`
+        : `headroom (event-loop ${elDelayMs}ms)`;
+    console.log(
+        colorize(
+            to > from ? "lightGreen" : "yellow",
+            `concurrency ${from} -> ${to} · ${why}${settled ? " · settled" : ""}`
+        )
+    );
+}
+
 function starvationRetry({ seq, total, label, starveCount, elDelayMs }) {
     // starveCount > 0 means the watchdog fired; otherwise report the stall.
     const cause =
@@ -426,6 +437,7 @@ function summary({
     avgPerTestGb,
     memBoundGb,
     targetLoad,
+    peakAdaptiveCap,
     gasPeak
 }) {
     const totalFailing = failed.length;
@@ -500,7 +512,9 @@ function summary({
         `  mem: peak owned ${peakOccupiedGb.toFixed(1)}GB, avg/process ${avgPerTestGb.toFixed(2)}GB (bound ${memBoundGb.toFixed(1)}GB)`
     );
     console.log(
-        `  cpu: avg ${(avgCpu * 100).toFixed(0)}% · peak ${(peakCpu * 100).toFixed(0)}% (target ${(targetLoad * 100).toFixed(0)}%)`
+        `  cpu: avg ${(avgCpu * 100).toFixed(0)}% · peak ${(peakCpu * 100).toFixed(0)}% (target ${(targetLoad * 100).toFixed(0)}%)${
+            peakAdaptiveCap ? ` · peak concurrency ${peakAdaptiveCap}` : ""
+        }`
     );
     const elPeak = tasks.reduce(
         (best, t) =>
@@ -571,6 +585,7 @@ module.exports = {
     dryRun,
     admission,
     hold,
+    adaptiveCap,
     starvationRetry,
     result,
     gasPeakLine,

--- a/scripts/e2e-parallel/scheduler.js
+++ b/scripts/e2e-parallel/scheduler.js
@@ -6,12 +6,15 @@ const {
     SCHEDULER_TICK_MS,
     MAX_SLOTS_FROM_POOL,
     PER_TEST_MEM_GB,
-    LOAD_RETRY_EL_DELAY_MS
+    LOAD_RETRY_EL_DELAY_MS,
+    ADAPTIVE_START_CAP,
+    ADAPTIVE_MIN_CAP
 } = require("./constants");
 const { liveTaskChildren, runTask } = require("./runTask");
 const logging = require("./logging");
 const {
     availableMemGb,
+    nextAdaptiveCap,
     pickLeastLoadedSlot,
     evaluateAdmission
 } = require("./adaptiveScheduling");
@@ -100,6 +103,7 @@ async function runScheduler({
     slots,
     slotCount,
     concurrencyCap,
+    adaptiveWorkers = true,
     targetLoad,
     memBoundGb,
     memFloorGb,
@@ -142,6 +146,18 @@ async function runScheduler({
 
     // In-flight test count per slot, for idle-first assignment.
     const slotLoad = new Array(Math.max(slotCount, 0)).fill(0);
+
+    // Measured concurrency ceiling, bounded by --workers / the account pool.
+    // goodCap/badCap bracket the machine's real limit; the probe bisects between
+    // them and stops once they are adjacent. An explicit --workers is a fixed
+    // value, not a starting point: the probe never runs and the cap never moves.
+    let adaptiveCap = adaptiveWorkers
+        ? Math.min(ADAPTIVE_START_CAP, concurrencyCap)
+        : concurrencyCap;
+    let healthyStreak = 0;
+    let goodCap = ADAPTIVE_MIN_CAP;
+    let badCap = Infinity;
+    let peakAdaptiveCap = adaptiveCap;
 
     // Live memory: RSS of our own processes (infra + live test children), with a
     // running per-test average used to project whether one more test fits.
@@ -255,6 +271,39 @@ async function runScheduler({
             );
             task.timingFound = task.timingFound || timing.found;
 
+            // Feed this run's event loop back into the ceiling. Skipped entirely
+            // when --workers pins a fixed value.
+            const starvedSignal =
+                attemptStarveCount > 0 ||
+                timing.maxEventLoopDelayMs >= LOAD_RETRY_EL_DELAY_MS;
+            if (adaptiveWorkers) {
+                const next = nextAdaptiveCap({
+                    current: adaptiveCap,
+                    starved: starvedSignal,
+                    elDelayMs: timing.maxEventLoopDelayMs,
+                    hasTiming: timing.found,
+                    healthyStreak,
+                    goodCap,
+                    badCap,
+                    maxCap: concurrencyCap
+                });
+                if (next.cap !== adaptiveCap) {
+                    logging.adaptiveCap({
+                        from: adaptiveCap,
+                        to: next.cap,
+                        elDelayMs: timing.maxEventLoopDelayMs,
+                        starved: starvedSignal,
+                        settled: next.goodCap + 1 >= next.badCap
+                    });
+                }
+                adaptiveCap = next.cap;
+                healthyStreak = next.healthyStreak;
+                goodCap = next.goodCap;
+                badCap = next.badCap;
+                if (adaptiveCap > peakAdaptiveCap)
+                    peakAdaptiveCap = adaptiveCap;
+            }
+
             const starvationDisposition = getStarvationDisposition(
                 attemptStarveCount,
                 task.starvationRetryCount || 0,
@@ -322,7 +371,7 @@ async function runScheduler({
             // Admit one per tick when the gates allow; running === 0 always admits.
             const decision = evaluateAdmission({
                 running,
-                concurrencyCap,
+                concurrencyCap: adaptiveCap,
                 cpuUtil,
                 targetLoad,
                 occupiedGb,
@@ -365,7 +414,8 @@ async function runScheduler({
         peakCpu,
         avgCpu,
         peakOccupiedGb,
-        avgPerTestGb
+        avgPerTestGb,
+        peakAdaptiveCap
     };
 }
 

--- a/scripts/e2e-parallel/scheduler.js
+++ b/scripts/e2e-parallel/scheduler.js
@@ -5,10 +5,16 @@ const {
     HARDHAT_CLI,
     SCHEDULER_TICK_MS,
     MAX_SLOTS_FROM_POOL,
-    PER_TEST_MEM_GB
+    PER_TEST_MEM_GB,
+    LOAD_RETRY_EL_DELAY_MS
 } = require("./constants");
 const { liveTaskChildren, runTask } = require("./runTask");
 const logging = require("./logging");
+const {
+    availableMemGb,
+    pickLeastLoadedSlot,
+    evaluateAdmission
+} = require("./adaptiveScheduling");
 
 // Resolve a thread-mode boolean with precedence: CLI flag > inherited env > default.
 // (Env value "false" disables; any other set value enables; unset → fallback.)
@@ -60,9 +66,24 @@ function rssGbForPids(pids) {
     }
 }
 
-function getStarvationDisposition(starveCount, starvationRetryCount) {
-    if (starveCount === 0) return "complete";
-    return starvationRetryCount === 0 ? "retry" : "fail";
+// A failed task whose event loop was starved gets one retry. starveCount is the
+// watchdog signal; maxEventLoopDelayMs catches stalls under its threshold.
+function getStarvationDisposition(
+    starveCount,
+    starvationRetryCount,
+    { code = 0, maxEventLoopDelayMs = 0 } = {}
+) {
+    if (starveCount > 0) {
+        return starvationRetryCount === 0 ? "retry" : "fail";
+    }
+    if (
+        code !== 0 &&
+        starvationRetryCount === 0 &&
+        maxEventLoopDelayMs >= LOAD_RETRY_EL_DELAY_MS
+    ) {
+        return "retry";
+    }
+    return "complete";
 }
 
 /**
@@ -81,6 +102,7 @@ async function runScheduler({
     concurrencyCap,
     targetLoad,
     memBoundGb,
+    memFloorGb,
     baseEnv,
     logDir,
     infraPids,
@@ -118,6 +140,9 @@ async function runScheduler({
         (_, i) => i
     );
 
+    // In-flight test count per slot, for idle-first assignment.
+    const slotLoad = new Array(Math.max(slotCount, 0)).fill(0);
+
     // Live memory: RSS of our own processes (infra + live test children), with a
     // running per-test average used to project whether one more test fits.
     let avgPerTestGb = PER_TEST_MEM_GB; // conservative seed until measured
@@ -139,11 +164,20 @@ async function runScheduler({
         }
     };
 
+    // System-available memory, resampled each tick: counts other processes, so we
+    // back off before the box swaps.
+    let availGb = availableMemGb();
+    const sampleSystem = () => {
+        availGb = availableMemGb();
+    };
+
     const launch = (task, seq) => {
         running++;
         const acct = freeAccounts.shift();
-        const slot =
-            task.isE2E && slotCount > 0 ? slots[(seq - 1) % slotCount] : null;
+        const slotIdx =
+            task.isE2E && slotCount > 0 ? pickLeastLoadedSlot(slotLoad) : -1;
+        if (slotIdx >= 0) slotLoad[slotIdx]++;
+        const slot = slotIdx >= 0 ? slots[slotIdx] : null;
         const where = slot ? `slot ${slot.id}/${slotCount}` : "in-process";
 
         let taskArgs = task.args;
@@ -197,6 +231,7 @@ async function runScheduler({
         ).then(({ code, label, stdout, stderr, durationMs }) => {
             running--;
             freeAccounts.push(acct);
+            if (slotIdx >= 0) slotLoad[slotIdx]--;
             sumDurationMs += durationMs;
 
             const combined = stdout + stderr;
@@ -222,7 +257,8 @@ async function runScheduler({
 
             const starvationDisposition = getStarvationDisposition(
                 attemptStarveCount,
-                task.starvationRetryCount || 0
+                task.starvationRetryCount || 0,
+                { code, maxEventLoopDelayMs: timing.maxEventLoopDelayMs }
             );
             if (starvationDisposition === "retry") {
                 task.starvationRetryCount = 1;
@@ -231,7 +267,8 @@ async function runScheduler({
                     seq,
                     total: tasks.length,
                     label,
-                    starveCount: attemptStarveCount
+                    starveCount: attemptStarveCount,
+                    elDelayMs: timing.maxEventLoopDelayMs
                 });
                 return;
             }
@@ -269,6 +306,7 @@ async function runScheduler({
         const tick = () => {
             sampleCpu();
             sampleMemory();
+            sampleSystem();
 
             if (
                 idx >= tasks.length &&
@@ -281,13 +319,20 @@ async function runScheduler({
             }
             if (idx >= tasks.length && retryQueue.length === 0) return; // draining
 
-            const countOk = running < concurrencyCap;
-            const cpuOk = cpuUtil < targetLoad;
-            const memOk = occupiedGb + avgPerTestGb < memBoundGb;
+            // Admit one per tick when the gates allow; running === 0 always admits.
+            const decision = evaluateAdmission({
+                running,
+                concurrencyCap,
+                cpuUtil,
+                targetLoad,
+                occupiedGb,
+                avgPerTestGb,
+                memBoundGb,
+                availGb,
+                memFloorGb
+            });
 
-            // Always keep one test in flight (avoids stalling when the gates start
-            // closed); otherwise admit one only when all gates are open.
-            if (running === 0 || (countOk && cpuOk && memOk)) {
+            if (decision.admit) {
                 if (idx < tasks.length) {
                     idx++;
                     launch(tasks[idx - 1], idx);
@@ -298,12 +343,11 @@ async function runScheduler({
             } else {
                 const nextSeq =
                     idx < tasks.length ? idx + 1 : retryQueue[0].seq;
-                const reason = !countOk
-                    ? `cap (running ${running}/${concurrencyCap})`
-                    : !memOk
-                      ? `memory (owned ${occupiedGb.toFixed(1)}+${avgPerTestGb.toFixed(1)}≥${memBoundGb.toFixed(1)}GB)`
-                      : `cpu ${(cpuUtil * 100).toFixed(0)}%>=${(targetLoad * 100).toFixed(0)}%`;
-                logging.hold({ seq: nextSeq, total: tasks.length, reason });
+                logging.hold({
+                    seq: nextSeq,
+                    total: tasks.length,
+                    reason: decision.reason
+                });
             }
         };
         const timer = setInterval(tick, tickMs);

--- a/scripts/test-e2e-parallel.js
+++ b/scripts/test-e2e-parallel.js
@@ -8,7 +8,8 @@ const {
     TARGET_LOAD_PER_CORE,
     MEM_LIMIT_FRACTION,
     MAX_SLOTS_FROM_POOL,
-    DEFAULT_STREAM_CHILD_OUTPUT
+    DEFAULT_STREAM_CHILD_OUTPUT,
+    SYSTEM_MEM_FLOOR_GB
 } = require("./e2e-parallel/constants");
 
 const { getHelpText, parseCliArgs } = require("./e2e-parallel/argParser");
@@ -17,6 +18,7 @@ const {
     resolveThreadModes,
     runScheduler
 } = require("./e2e-parallel/scheduler");
+const { resolveDefaultWorkers } = require("./e2e-parallel/adaptiveScheduling");
 const {
     provisionSlots,
     teardownInfra,
@@ -95,24 +97,30 @@ async function main() {
     // non-E2E tests use the shared harness and could reuse slots, while plain
     // unit/contract tests still require an isolated in-process Hardhat node.
     const hasE2ETasks = tasks.some((task) => task.isE2E);
-    const requestedSlotCount = cli.slots ?? DEFAULT_SLOTS;
-    const slotCount = hasE2ETasks
-        ? Math.min(requestedSlotCount, MAX_SLOTS_FROM_POOL)
-        : 0;
-    if (hasE2ETasks && requestedSlotCount > slotCount) {
-        console.log(
-            `slots clamped to ${slotCount} (account pool allows ${MAX_SLOTS_FROM_POOL})`
-        );
-    }
     const threadModes = resolveThreadModes(cli);
     const targetLoad = cli.targetLoad ?? TARGET_LOAD_PER_CORE;
     const schedulerTickMs = cli.schedulerTickMs ?? SCHEDULER_TICK_MS;
     const totalGb = os.totalmem() / 1024 ** 3;
     const memBoundGb = cli.memLimitGb ?? totalGb * MEM_LIMIT_FRACTION;
+    const memFloorGb = cli.memFloorGb ?? SYSTEM_MEM_FLOOR_GB;
+    const cores = os.cpus().length;
+    // Auto-size --workers from cores unless pinned; the gates throttle below it.
+    const autoWorkers = cli.workers == null;
     const concurrencyCap = Math.min(
         MAX_SLOTS_FROM_POOL,
-        cli.workers ?? MAX_SLOTS_FROM_POOL
+        cli.workers ?? resolveDefaultWorkers(cores, MAX_SLOTS_FROM_POOL)
     );
+
+    // At most concurrencyCap tests run at once, so extra slots never get used.
+    const requestedSlotCount = cli.slots ?? DEFAULT_SLOTS;
+    const slotCount = hasE2ETasks
+        ? Math.min(requestedSlotCount, MAX_SLOTS_FROM_POOL, concurrencyCap)
+        : 0;
+    if (hasE2ETasks && requestedSlotCount > slotCount) {
+        console.log(
+            `slots clamped to ${slotCount} (concurrency cap ${concurrencyCap}, account pool allows ${MAX_SLOTS_FROM_POOL})`
+        );
+    }
 
     if (cli.dryRun) {
         logging.dryRun({
@@ -123,7 +131,10 @@ async function main() {
             memBoundGb,
             totalGb,
             concurrencyCap,
-            tickMs: schedulerTickMs
+            tickMs: schedulerTickMs,
+            autoWorkers,
+            cores,
+            memFloorGb
         });
         return;
     }
@@ -137,7 +148,10 @@ async function main() {
         targetLoad,
         tickMs: schedulerTickMs,
         memBoundGb,
-        concurrencyCap
+        concurrencyCap,
+        autoWorkers,
+        cores,
+        memFloorGb
     });
 
     // Default: a fresh run-N dir per run (./logs/run-0, ./logs/run-1, ...)
@@ -197,6 +211,7 @@ async function main() {
             targetLoad,
             tickMs: schedulerTickMs,
             memBoundGb,
+            memFloorGb,
             baseEnv: buildBaseEnv(threadModes),
             logDir,
             infraPids

--- a/scripts/test-e2e-parallel.js
+++ b/scripts/test-e2e-parallel.js
@@ -18,7 +18,6 @@ const {
     resolveThreadModes,
     runScheduler
 } = require("./e2e-parallel/scheduler");
-const { resolveDefaultWorkers } = require("./e2e-parallel/adaptiveScheduling");
 const {
     provisionSlots,
     teardownInfra,
@@ -103,12 +102,12 @@ async function main() {
     const totalGb = os.totalmem() / 1024 ** 3;
     const memBoundGb = cli.memLimitGb ?? totalGb * MEM_LIMIT_FRACTION;
     const memFloorGb = cli.memFloorGb ?? SYSTEM_MEM_FLOOR_GB;
-    const cores = os.cpus().length;
-    // Auto-size --workers from cores unless pinned; the gates throttle below it.
-    const autoWorkers = cli.workers == null;
+    // Hard ceiling only. Without --workers the scheduler measures its own
+    // concurrency from finished tests instead of guessing from the hardware.
+    const adaptiveWorkers = cli.workers == null;
     const concurrencyCap = Math.min(
         MAX_SLOTS_FROM_POOL,
-        cli.workers ?? resolveDefaultWorkers(cores, MAX_SLOTS_FROM_POOL)
+        cli.workers ?? MAX_SLOTS_FROM_POOL
     );
 
     // At most concurrencyCap tests run at once, so extra slots never get used.
@@ -132,8 +131,7 @@ async function main() {
             totalGb,
             concurrencyCap,
             tickMs: schedulerTickMs,
-            autoWorkers,
-            cores,
+            adaptiveWorkers,
             memFloorGb
         });
         return;
@@ -149,8 +147,7 @@ async function main() {
         tickMs: schedulerTickMs,
         memBoundGb,
         concurrencyCap,
-        autoWorkers,
-        cores,
+        adaptiveWorkers,
         memFloorGb
     });
 
@@ -208,6 +205,7 @@ async function main() {
             slots,
             slotCount,
             concurrencyCap,
+            adaptiveWorkers,
             targetLoad,
             tickMs: schedulerTickMs,
             memBoundGb,
@@ -229,6 +227,7 @@ async function main() {
             avgPerTestGb: stats.avgPerTestGb,
             memBoundGb,
             targetLoad,
+            peakAdaptiveCap: stats.peakAdaptiveCap,
             gasPeak: gasMonitor.gasPeak
         });
 

--- a/test/scripts/e2eParallelAdaptiveScheduling.test.ts
+++ b/test/scripts/e2eParallelAdaptiveScheduling.test.ts
@@ -2,17 +2,38 @@ import { expect } from "chai";
 
 const {
     availableMemGb,
-    resolveDefaultWorkers,
+    nextAdaptiveCap,
     pickLeastLoadedSlot,
     evaluateAdmission
 } = require("../../scripts/e2e-parallel/adaptiveScheduling.js") as {
     availableMemGb: () => number;
-    resolveDefaultWorkers: (cores: number, maxCap: number) => number;
+    nextAdaptiveCap: (params: {
+        current: number;
+        starved: boolean;
+        elDelayMs: number;
+        hasTiming: boolean;
+        healthyStreak?: number;
+        goodCap?: number;
+        badCap?: number;
+        maxCap: number;
+    }) => {
+        cap: number;
+        healthyStreak: number;
+        goodCap: number;
+        badCap: number;
+    };
     pickLeastLoadedSlot: (slotLoad: number[]) => number;
     evaluateAdmission: (params: Record<string, unknown>) => {
         admit: boolean;
         reason: string | null;
     };
+};
+
+const healthy = {
+    starved: false,
+    elDelayMs: 100,
+    hasTiming: true,
+    maxCap: 40
 };
 
 // A baseline where every gate is open, so each test can close exactly one.
@@ -29,21 +50,138 @@ const openGates = {
 };
 
 describe("parallel scheduler — machine-aware sizing", function () {
-    describe("resolveDefaultWorkers", function () {
-        it("gives each concurrent test ~4 hardware threads", function () {
-            expect(resolveDefaultWorkers(16, 40)).to.equal(4);
-            expect(resolveDefaultWorkers(128, 40)).to.equal(32);
+    describe("nextAdaptiveCap", function () {
+        // a level is promoted only after two healthy finishes
+        const confirm = { ...healthy, healthyStreak: 1 };
+
+        function converge(realLimit: number, steps = 60) {
+            let s = { cap: 2, healthyStreak: 0, goodCap: 1, badCap: Infinity };
+            const trace: number[] = [];
+            for (let i = 0; i < steps; i++) {
+                const starved = s.cap > realLimit;
+                s = nextAdaptiveCap({
+                    ...healthy,
+                    ...s,
+                    current: s.cap,
+                    starved,
+                    elDelayMs: starved ? 900 : 100
+                });
+                trace.push(s.cap);
+            }
+            return { cap: s.cap, trace };
+        }
+
+        it("doubles while nothing has starved yet", function () {
+            expect(nextAdaptiveCap({ ...confirm, current: 2 }).cap).to.equal(4);
+            expect(nextAdaptiveCap({ ...confirm, current: 8 }).cap).to.equal(
+                16
+            );
         });
 
-        it("never drops below 2, even on tiny hosts or bad input", function () {
-            expect(resolveDefaultWorkers(4, 40)).to.equal(2);
-            expect(resolveDefaultWorkers(2, 40)).to.equal(2);
-            expect(resolveDefaultWorkers(0, 40)).to.equal(2);
-            expect(resolveDefaultWorkers(NaN, 40)).to.equal(2);
+        it("needs two healthy finishes before moving up", function () {
+            const first = nextAdaptiveCap({
+                ...healthy,
+                current: 8,
+                healthyStreak: 0
+            });
+            expect(first.cap).to.equal(8);
+            expect(
+                nextAdaptiveCap({
+                    ...healthy,
+                    current: 8,
+                    healthyStreak: first.healthyStreak
+                }).cap
+            ).to.equal(16);
         });
 
-        it("never exceeds the account-pool cap on big workstations", function () {
-            expect(resolveDefaultWorkers(256, 40)).to.equal(40);
+        it("bisects between the good level and the starved one", function () {
+            const out = nextAdaptiveCap({
+                ...healthy,
+                current: 8,
+                starved: true,
+                goodCap: 4
+            });
+            expect(out.cap).to.equal(6);
+            expect(out.badCap).to.equal(8);
+        });
+
+        it("keeps bisecting down while the probe still starves", function () {
+            expect(
+                nextAdaptiveCap({
+                    ...healthy,
+                    current: 6,
+                    starved: true,
+                    goodCap: 4,
+                    badCap: 8
+                }).cap
+            ).to.equal(5);
+            expect(
+                nextAdaptiveCap({
+                    ...healthy,
+                    current: 5,
+                    starved: true,
+                    goodCap: 4,
+                    badCap: 6
+                }).cap
+            ).to.equal(4);
+        });
+
+        it("probes upward again when the midpoint is healthy", function () {
+            expect(
+                nextAdaptiveCap({
+                    ...confirm,
+                    current: 6,
+                    goodCap: 4,
+                    badCap: 8
+                }).cap
+            ).to.equal(7);
+        });
+
+        it("stops once the bounds are adjacent", function () {
+            expect(
+                nextAdaptiveCap({
+                    ...confirm,
+                    current: 3,
+                    goodCap: 3,
+                    badCap: 4
+                }).cap
+            ).to.equal(3);
+        });
+
+        it("never exceeds the ceiling or drops below 1", function () {
+            expect(
+                nextAdaptiveCap({ ...confirm, current: 30, maxCap: 40 }).cap
+            ).to.equal(40);
+            expect(
+                nextAdaptiveCap({ ...healthy, current: 1, starved: true }).cap
+            ).to.equal(1);
+        });
+
+        it("holds steady on a middling event loop or missing timing", function () {
+            expect(
+                nextAdaptiveCap({ ...confirm, current: 8, elDelayMs: 500 }).cap
+            ).to.equal(8);
+            expect(
+                nextAdaptiveCap({ ...confirm, current: 8, hasTiming: false })
+                    .cap
+            ).to.equal(8);
+        });
+
+        // #400 review: a 12-core box that comfortably runs 13 must not be pinned
+        // to 3 while its cpu sits at 20%
+        it("finds a roomy machine's real limit", function () {
+            expect(converge(13).cap).to.equal(13);
+        });
+
+        it("settles on a constrained machine and stops moving", function () {
+            const { cap, trace } = converge(3);
+            expect(cap).to.equal(3);
+            expect(new Set(trace.slice(-20)).size).to.equal(1);
+        });
+
+        it("converges after only a few starved probes", function () {
+            const { trace } = converge(8);
+            expect(trace.filter((c) => c > 8).length).to.be.lessThan(6);
         });
     });
 

--- a/test/scripts/e2eParallelAdaptiveScheduling.test.ts
+++ b/test/scripts/e2eParallelAdaptiveScheduling.test.ts
@@ -1,0 +1,164 @@
+import { expect } from "chai";
+
+const {
+    availableMemGb,
+    resolveDefaultWorkers,
+    pickLeastLoadedSlot,
+    evaluateAdmission
+} = require("../../scripts/e2e-parallel/adaptiveScheduling.js") as {
+    availableMemGb: () => number;
+    resolveDefaultWorkers: (cores: number, maxCap: number) => number;
+    pickLeastLoadedSlot: (slotLoad: number[]) => number;
+    evaluateAdmission: (params: Record<string, unknown>) => {
+        admit: boolean;
+        reason: string | null;
+    };
+};
+
+// A baseline where every gate is open, so each test can close exactly one.
+const openGates = {
+    running: 1,
+    concurrencyCap: 4,
+    cpuUtil: 0.2,
+    targetLoad: 0.8,
+    occupiedGb: 2,
+    avgPerTestGb: 1,
+    memBoundGb: 20,
+    availGb: 10,
+    memFloorGb: 3
+};
+
+describe("parallel scheduler — machine-aware sizing", function () {
+    describe("resolveDefaultWorkers", function () {
+        it("gives each concurrent test ~4 hardware threads", function () {
+            expect(resolveDefaultWorkers(16, 40)).to.equal(4);
+            expect(resolveDefaultWorkers(128, 40)).to.equal(32);
+        });
+
+        it("never drops below 2, even on tiny hosts or bad input", function () {
+            expect(resolveDefaultWorkers(4, 40)).to.equal(2);
+            expect(resolveDefaultWorkers(2, 40)).to.equal(2);
+            expect(resolveDefaultWorkers(0, 40)).to.equal(2);
+            expect(resolveDefaultWorkers(NaN, 40)).to.equal(2);
+        });
+
+        it("never exceeds the account-pool cap on big workstations", function () {
+            expect(resolveDefaultWorkers(256, 40)).to.equal(40);
+        });
+    });
+
+    describe("availableMemGb", function () {
+        it("returns a positive finite number", function () {
+            const gb = availableMemGb();
+            expect(gb).to.be.a("number");
+            expect(gb).to.be.greaterThan(0);
+            expect(Number.isFinite(gb)).to.equal(true);
+        });
+    });
+
+    describe("pickLeastLoadedSlot", function () {
+        it("prefers an idle slot over a busy one", function () {
+            expect(pickLeastLoadedSlot([1, 0, 1])).to.equal(1);
+            expect(pickLeastLoadedSlot([2, 2, 0])).to.equal(2);
+        });
+
+        it("falls back to the least-loaded slot when all are busy", function () {
+            expect(pickLeastLoadedSlot([3, 1, 2])).to.equal(1);
+        });
+
+        it("degenerates cleanly to the single shared slot", function () {
+            expect(pickLeastLoadedSlot([0])).to.equal(0);
+            expect(pickLeastLoadedSlot([7])).to.equal(0);
+        });
+
+        // completions don't follow admissions, so assignment tracks live occupancy
+        it("never double-books while a slot is free, under out-of-order completion", function () {
+            const slotCount = 4;
+            const cap = 4;
+            const load = new Array(slotCount).fill(0);
+            const durations = [12, 48, 15, 58, 11, 23, 45, 14, 27, 19];
+            const running: Array<{ end: number; slot: number }> = [];
+            let now = 0;
+            let seq = 0;
+            let doubleBookedWhileFree = 0;
+
+            while (seq < 40 || running.length) {
+                while (running.length < cap && seq < 40) {
+                    const slot = pickLeastLoadedSlot(load);
+                    if (load[slot] > 0 && load.some((l) => l === 0)) {
+                        doubleBookedWhileFree++;
+                    }
+                    load[slot]++;
+                    running.push({
+                        end: now + durations[seq % durations.length],
+                        slot
+                    });
+                    seq++;
+                }
+                now = Math.min(...running.map((r) => r.end));
+                for (let i = running.length - 1; i >= 0; i--) {
+                    if (running[i].end <= now) {
+                        load[running[i].slot]--;
+                        running.splice(i, 1);
+                    }
+                }
+            }
+
+            expect(doubleBookedWhileFree).to.equal(0);
+            expect(load.every((l) => l === 0)).to.equal(true);
+        });
+    });
+
+    describe("evaluateAdmission gates", function () {
+        it("admits when all gates are open", function () {
+            expect(evaluateAdmission(openGates).admit).to.equal(true);
+        });
+
+        it("always keeps one test in flight (running === 0 bypasses gates)", function () {
+            const decision = evaluateAdmission({
+                ...openGates,
+                running: 0,
+                cpuUtil: 0.99,
+                availGb: 0.1
+            });
+            expect(decision.admit).to.equal(true);
+        });
+
+        it("holds on the concurrency cap", function () {
+            const decision = evaluateAdmission({ ...openGates, running: 4 });
+            expect(decision.admit).to.equal(false);
+            expect(decision.reason).to.include("cap");
+        });
+
+        it("holds on system-available memory (the swap-avoidance gate)", function () {
+            const decision = evaluateAdmission({ ...openGates, availGb: 3.5 });
+            expect(decision.admit).to.equal(false);
+            expect(decision.reason).to.include("system memory");
+        });
+
+        it("holds on owned-RSS budget", function () {
+            const decision = evaluateAdmission({
+                ...openGates,
+                occupiedGb: 19.5
+            });
+            expect(decision.admit).to.equal(false);
+            expect(decision.reason).to.include("memory (owned");
+        });
+
+        it("holds on CPU utilization", function () {
+            const decision = evaluateAdmission({ ...openGates, cpuUtil: 0.9 });
+            expect(decision.admit).to.equal(false);
+            expect(decision.reason).to.include("cpu");
+        });
+
+        it("reports the highest-priority reason (cap before the rest)", function () {
+            const decision = evaluateAdmission({
+                ...openGates,
+                running: 4,
+                availGb: 1,
+                cpuUtil: 0.99
+            });
+            expect(decision.reason).to.include("cap");
+        });
+    });
+});

--- a/test/scripts/e2eParallelLogDir.test.ts
+++ b/test/scripts/e2eParallelLogDir.test.ts
@@ -46,7 +46,8 @@ const { getStarvationDisposition } =
     require("../../scripts/e2e-parallel/scheduler.js") as {
         getStarvationDisposition: (
             starveCount: number,
-            starvationRetryCount: number
+            starvationRetryCount: number,
+            attempt?: { code?: number; maxEventLoopDelayMs?: number }
         ) => "complete" | "retry" | "fail";
     };
 const { buildBaseEnv } = require("../../scripts/test-e2e-parallel.js") as {
@@ -207,6 +208,40 @@ describe("e2e-parallel logging - starvation diagnostics", function () {
         expect(getStarvationDisposition(1, 0)).to.equal("retry");
         expect(getStarvationDisposition(1, 1)).to.equal("fail");
         expect(getStarvationDisposition(0, 1)).to.equal("complete");
+    });
+
+    it("retries a failed task whose event loop stalled just under the watchdog", function () {
+        // stall under the 1s watchdog -> starveCount 0
+        expect(
+            getStarvationDisposition(0, 0, {
+                code: 1,
+                maxEventLoopDelayMs: 959
+            })
+        ).to.equal("retry");
+    });
+
+    it("does not retry a failure that ran on a healthy event loop", function () {
+        expect(
+            getStarvationDisposition(0, 0, {
+                code: 1,
+                maxEventLoopDelayMs: 120
+            })
+        ).to.equal("complete");
+    });
+
+    it("never retries a near-miss stall twice, and never retries a pass", function () {
+        expect(
+            getStarvationDisposition(0, 1, {
+                code: 1,
+                maxEventLoopDelayMs: 959
+            })
+        ).to.equal("complete");
+        expect(
+            getStarvationDisposition(0, 0, {
+                code: 0,
+                maxEventLoopDelayMs: 959
+            })
+        ).to.equal("complete");
     });
 
     it("uses light yellow for rescheduling and dark yellow for repeated starvation", function () {


### PR DESCRIPTION
`test:parallel` sized itself off the account pool and total ram, not the machine:
concurrency capped at 40 (400 accounts / 10 per test) whatever the core count,
memory gated on our own rss vs total ram. on a box whose ram is half held by
browser/editor -> oversubscribe -> swap -> tests miss their wall-clock barriers.
green on roomier machines, so it read as flaky tests. #391

- gate admission on real os-available memory (`MemAvailable`), not just our rss
- `--workers` defaults from cpu cores instead of the account pool
- assign to an idle slot, not `slots[(seq - 1) % slotCount]`
- never boot more slots than the concurrency cap can use
- retry a failed task once when its event-loop peak shows starvation
- new `--mem-floor-gb`

my machine, full e2e suite: 14-26 failing -> 197/198, 3.8x speedup