### PR TITLE
fix(state-manager): handle stale reduceAndFinalize revert on the reduction path

### DIFF
--- a/src/stateManager/reduction/ReductionExecutor.ts
+++ b/src/stateManager/reduction/ReductionExecutor.ts
@@ -52,8 +52,9 @@ const REDUCTION_RACE_ERRORS = [
     "RaceConditionReductionExpectationDoesntMatch",
     // Not a race per se: our reduce inputs went stale against the chain, so
     // reduceAndFinalize reverts the inbound-block check. Classified here so
-    // classifyReductionRace can gate it (swallow vs discard) instead of letting
-    // it escape the detached reduction path as an unhandled rejection.
+    // classifyReductionRace can tell converging on another reducer's result
+    // from a stale candidate, instead of letting the revert escape the detached
+    // reduction path as an unhandled rejection.
     "ErrorDisputeInboundMessageBlocksInvalid"
 ] as const satisfies readonly RaceConditionErrorName[];
 type ReductionRaceErrorName = (typeof REDUCTION_RACE_ERRORS)[number];
@@ -195,6 +196,15 @@ export default class ReductionExecutor {
                 attempts: pendingRetry.attempts,
                 notBefore: pendingRetry.notBefore
             });
+            // Re-arm rather than trusting the timer that scheduled this retry.
+            // Second-granularity time means the scheduled attempt can itself
+            // arrive a tick early and stand down here; without re-arming, that
+            // attempt would be the last one and the fork would strand.
+            this.stateManager.reductionManager.schedule(
+                forkId,
+                pendingRetry.notBefore,
+                true
+            );
             return;
         }
 

--- a/src/stateManager/reduction/ReductionExecutor.ts
+++ b/src/stateManager/reduction/ReductionExecutor.ts
@@ -430,6 +430,21 @@ export default class ReductionExecutor {
                         disputes,
                         "detached"
                     );
+                    // complete() already installed this candidate and settled
+                    // the completion, and the fork has moved on — so no later
+                    // attempt re-enters the executor for this source fork and
+                    // nothing can reconcile the install. A candidate the chain
+                    // did not commit therefore has to fail closed here.
+                    if (status === "stale-candidate") {
+                        this.logger.error(
+                            "Reduction submit rejected a candidate that is already installed locally - aborting",
+                            { forkId, candidateForkId }
+                        );
+                        this.stateManager.abort();
+                        throw new Error(
+                            `Installed reduction candidate ${candidateForkId} for fork ${forkId} was rejected on submit`
+                        );
+                    }
                     if (status) return;
                 }
                 throw tryDecodeCustomError(error) ?? error;
@@ -462,30 +477,12 @@ export default class ReductionExecutor {
                 forkId
             );
 
-        // ErrorDisputeInboundMessageBlocksInvalid compares our submitted
-        // inboundMessageBlocks against the target hash reduce() derives live
-        // from chain storage: the channel's inbound head walked back to the
-        // dispute-window expiry (lastEvidenceSubmissionTimestamp +
-        // evidenceTime). _verifyInboundMessageBlocks itself is pure, but that
-        // target is not — the expiry moves whenever late evidence lands. So the
-        // usual cause is the chain moving between compute() and this submission,
-        // and a recompute against the new head converges.
-        //
-        // reduceAndFinalize only reaches this check while nothing is committed
-        // (a committed result short-circuits earlier), so the committed value we
-        // read back is non-zero only when another reducer won inside this
-        // window. Matching our candidate means we merely lost the race with a
-        // correct candidate — safe to install and converge. Otherwise the
-        // candidate is stale (or nothing is committed yet): discard it rather
-        // than install a value that would later trip the reduced-result mismatch
-        // -> abort — but never rethrow into the detached path either.
-        //
-        // "Discard without installing" only holds on the simulation path.
-        // complete() installs the candidate before submitDetached runs, so on
-        // the detached path the stale genesis is already installed and the
-        // discard degrades to swallow-and-eventual-abort (the reduced-result
-        // mismatch in completeWithGenesis). Logged distinctly so the two are
-        // told apart.
+        // The revert means our inboundMessageBlocks no longer chain to the
+        // target hash reduce() derives from live chain storage, so our candidate
+        // is stale. Only a committed result equal to our candidate means we
+        // simply lost the race and can converge; anything else is a stale
+        // candidate, and each call site decides its own policy (retry before
+        // installing, fail closed once installed).
         if (errorName === "ErrorDisputeInboundMessageBlocksInvalid") {
             if (
                 String(reducedResult.reducedForkId) === String(candidateForkId)

--- a/src/stateManager/reduction/ReductionExecutor.ts
+++ b/src/stateManager/reduction/ReductionExecutor.ts
@@ -35,7 +35,12 @@ type ReductionSubmissionStatus = "submit" | "already-reduced" | "superseded";
 const REDUCTION_RACE_ERRORS = [
     "RaceConditionDisputeAlreadyReduced",
     "RaceConditionBlockHeightTooOld",
-    "RaceConditionReductionExpectationDoesntMatch"
+    "RaceConditionReductionExpectationDoesntMatch",
+    // Not a race per se: the losing peer's own reduce inputs went stale, so its
+    // reduceAndFinalize reverts the calldata-pure inbound-block check. Classified
+    // here so classifyReductionRace can gate it (swallow vs discard) instead of
+    // letting it escape the detached reduction path as an unhandled rejection.
+    "ErrorDisputeInboundMessageBlocksInvalid"
 ] as const satisfies readonly RaceConditionErrorName[];
 type ReductionRaceErrorName = (typeof REDUCTION_RACE_ERRORS)[number];
 
@@ -200,6 +205,7 @@ export default class ReductionExecutor {
         const submission = await this.prepareSubmission(candidate);
         const submissionStatus = await this.simulateSubmission(
             forkId,
+            candidate.reducedForkId,
             disputes,
             submission
         );
@@ -233,7 +239,12 @@ export default class ReductionExecutor {
                 }
             );
         if (installed && submissionStatus === "submit") {
-            this.submitDetached(forkId, disputes, submission);
+            this.submitDetached(
+                forkId,
+                candidate.reducedForkId,
+                disputes,
+                submission
+            );
         }
     }
 
@@ -318,6 +329,7 @@ export default class ReductionExecutor {
 
     private async simulateSubmission(
         forkId: ForkId,
+        candidateForkId: ForkId,
         disputes: DisputeStruct[],
         submission: { calldata: string[] }
     ): Promise<ReductionSubmissionStatus> {
@@ -332,6 +344,7 @@ export default class ReductionExecutor {
             const status = await this.classifyReductionRace(
                 custom?.name,
                 forkId,
+                candidateForkId,
                 disputes
             );
             if (status) return status;
@@ -341,6 +354,7 @@ export default class ReductionExecutor {
 
     private submitDetached(
         forkId: ForkId,
+        candidateForkId: ForkId,
         disputes: DisputeStruct[],
         submission: { calldata: string[] }
     ): void {
@@ -379,6 +393,7 @@ export default class ReductionExecutor {
                     const status = await this.classifyReductionRace(
                         raceErrorName,
                         forkId,
+                        candidateForkId,
                         disputes
                     );
                     if (status) return;
@@ -391,6 +406,7 @@ export default class ReductionExecutor {
     private async classifyReductionRace(
         errorName: string | undefined,
         forkId: ForkId,
+        candidateForkId: ForkId,
         disputes: DisputeStruct[]
     ): Promise<ReductionSubmissionStatus | undefined> {
         if (!isReductionRaceErrorName(errorName)) return undefined;
@@ -410,6 +426,43 @@ export default class ReductionExecutor {
                 this.stateManager.channelId,
                 forkId
             );
+
+        // ErrorDisputeInboundMessageBlocksInvalid is a pure check over THIS
+        // peer's own calldata (its reduce-derived output doesn't chain from its
+        // local snapshot), so it means our local reduction diverged from chain
+        // — not merely that another reducer won. Compare the committed result to
+        // our own candidate: only when they match did we simply lose the race
+        // with a correct candidate (safe to install and converge). Otherwise the
+        // candidate is divergent (or nothing is committed yet) — discard it
+        // rather than install a value that would later trip the reduced-result
+        // mismatch -> abort — but never rethrow into the detached path either.
+        if (errorName === "ErrorDisputeInboundMessageBlocksInvalid") {
+            if (
+                String(reducedResult.reducedForkId) === String(candidateForkId)
+            ) {
+                this.logger.info(
+                    "Ordinary reduction superseded by another reducer",
+                    {
+                        forkId,
+                        reducedForkId: reducedResult.reducedForkId,
+                        reducer: reducedResult.reducer
+                    }
+                );
+                return "already-reduced";
+            }
+            // Logged at warn so a genuine, persistent local divergence stays
+            // diagnosable instead of vanishing as a benign race.
+            this.logger.warn(
+                "Reduction inbound-blocks invalid; local candidate diverged from chain - discarding",
+                {
+                    forkId,
+                    candidateForkId,
+                    committedForkId: reducedResult.reducedForkId
+                }
+            );
+            return "superseded";
+        }
+
         const finalDispute = disputes.find(
             (dispute) =>
                 String(dispute.outputSnapshotDataHash) ===

--- a/src/stateManager/reduction/ReductionExecutor.ts
+++ b/src/stateManager/reduction/ReductionExecutor.ts
@@ -31,7 +31,14 @@ type LocalReductionCandidate = ReductionComputation & {
 };
 
 type ReductionCacheKey = string;
-type ReductionSubmissionStatus = "submit" | "already-reduced" | "superseded";
+type ReductionSubmissionStatus =
+    | "submit"
+    | "already-reduced"
+    | "superseded"
+    // Our own candidate went stale against the chain. Unlike "superseded" (a
+    // final dispute won and drives the fork itself) nothing else will settle
+    // this fork, so the attempt must be retried against the moved head.
+    | "stale-candidate";
 // Which call site classified the revert. "simulation" still owns the decision
 // to install; "detached" already installed the candidate before submitting.
 type ReductionSubmissionPath = "simulation" | "detached";
@@ -54,10 +61,20 @@ function isReductionRaceErrorName(
 }
 
 export default class ReductionExecutor {
+    // A stale candidate is retried against the moved chain head, but a
+    // divergence that survives this many recomputes is not transient — stop
+    // retrying and let the attempt fail loudly instead of looping in silence.
+    private static readonly MAX_STALE_CANDIDATE_RETRIES = 3;
     // Every ordinary trigger enters through tryReduce, including timers and
     // reschedules. Serialize the attempt itself, then release this mutex before
     // callers resume waiting on ReductionManager's shared completion promise.
     private readonly attemptMutex: Mutex;
+    // Consecutive stale-candidate discards per (channel, fork). Cleared once the
+    // fork's reduction installs, so only an unbroken run counts.
+    private readonly staleCandidateRetries = new Map<
+        ReductionCacheKey,
+        number
+    >();
     // Memoized `isKillPeriodExpired` per (channel, fork). A junk-fork flood then
     // costs O(1) chain reads per window instead of one per block: a "not expired
     // until killPeriodEnd" answer is reused until that time; an "expired" answer
@@ -80,6 +97,7 @@ export default class ReductionExecutor {
     }
 
     public dispose(): void {
+        this.staleCandidateRetries.clear();
         this.killPeriodExpiryCache.clear();
     }
 
@@ -108,7 +126,7 @@ export default class ReductionExecutor {
     public async isKillPeriodExpiredCached(
         forkId: ForkId
     ): Promise<KillPeriodObservation> {
-        const key = `${this.stateManager.channelId}:${forkId}`;
+        const key = this.getReductionCacheKey(forkId);
         const cached = this.killPeriodExpiryCache.get(key);
         if (
             cached &&
@@ -179,7 +197,7 @@ export default class ReductionExecutor {
             killPeriodEnd: Number(freshExpiry.killPeriodEnd)
         };
         this.killPeriodExpiryCache.set(
-            `${this.stateManager.channelId}:${forkId}`,
+            this.getReductionCacheKey(forkId),
             freshObservation
         );
         if (!freshObservation.windowExists) return;
@@ -212,8 +230,19 @@ export default class ReductionExecutor {
             disputes,
             submission
         );
+        if (submissionStatus === "stale-candidate") {
+            // Nothing was installed and no other actor settles this fork, so
+            // leaving now would strand the completion promise. The cause is the
+            // chain moving under us, so recompute against the new head after
+            // letting it settle. A divergence that outlives the retries is a
+            // real local fault: rethrow so the completion fails and aborts
+            // rather than looping forever.
+            this.retryStaleCandidate(forkId, candidate.reducedForkId);
+            return;
+        }
         if (submissionStatus === "superseded") return;
 
+        this.staleCandidateRetries.delete(this.getReductionCacheKey(forkId));
         await this.complete(
             forkId,
             candidate,
@@ -484,7 +513,7 @@ export default class ReductionExecutor {
                     path
                 }
             );
-            return "superseded";
+            return "stale-candidate";
         }
 
         const finalDispute = disputes.find(
@@ -500,5 +529,39 @@ export default class ReductionExecutor {
             disputer: finalDispute.input.disputer
         });
         return "superseded";
+    }
+
+    // Reschedule a recompute against the moved chain head, waiting for the write
+    // that moved it to settle. Throws once the run of consecutive discards is
+    // exhausted so ReductionManager fails the completion and aborts.
+    private retryStaleCandidate(forkId: ForkId, candidateForkId: ForkId): void {
+        const key = this.getReductionCacheKey(forkId);
+        const attempt = (this.staleCandidateRetries.get(key) ?? 0) + 1;
+        if (attempt > ReductionExecutor.MAX_STALE_CANDIDATE_RETRIES) {
+            this.staleCandidateRetries.delete(key);
+            throw new Error(
+                `Reduction candidate ${candidateForkId} for fork ${forkId} stayed stale across ${ReductionExecutor.MAX_STALE_CANDIDATE_RETRIES} recomputes`
+            );
+        }
+        this.staleCandidateRetries.set(key, attempt);
+        const delay = Math.max(
+            1,
+            this.stateManager.timeConfig.chainFallbackTime
+        );
+        this.logger.info("Rescheduling reduction after a stale candidate", {
+            forkId,
+            candidateForkId,
+            attempt,
+            delay
+        });
+        this.stateManager.reductionManager.schedule(
+            forkId,
+            Clock.getTimeInSeconds() + delay,
+            true
+        );
+    }
+
+    private getReductionCacheKey(forkId: ForkId): ReductionCacheKey {
+        return `${this.stateManager.channelId}:${forkId}`;
     }
 }

--- a/src/stateManager/reduction/ReductionExecutor.ts
+++ b/src/stateManager/reduction/ReductionExecutor.ts
@@ -31,6 +31,10 @@ type LocalReductionCandidate = ReductionComputation & {
 };
 
 type ReductionCacheKey = string;
+type StaleCandidateRetry = {
+    attempts: number;
+    notBefore: Timestamp;
+};
 type ReductionSubmissionStatus =
     | "submit"
     | "already-reduced"
@@ -69,11 +73,14 @@ export default class ReductionExecutor {
     // reschedules. Serialize the attempt itself, then release this mutex before
     // callers resume waiting on ReductionManager's shared completion promise.
     private readonly attemptMutex: Mutex;
-    // Consecutive stale-candidate discards per (channel, fork). Cleared once the
-    // fork's reduction installs, so only an unbroken run counts.
+    // Consecutive stale-candidate discards per (channel, fork), with the time
+    // the scheduled retry is due. Callers already queued on the mutex would
+    // otherwise each burn an attempt the moment the first one reschedules, so
+    // they stand down until `notBefore`. Cleared once the fork's reduction
+    // installs, so only an unbroken run counts.
     private readonly staleCandidateRetries = new Map<
         ReductionCacheKey,
-        number
+        StaleCandidateRetry
     >();
     // Memoized `isKillPeriodExpired` per (channel, fork). A junk-fork flood then
     // costs O(1) chain reads per window instead of one per block: a "not expired
@@ -166,6 +173,21 @@ export default class ReductionExecutor {
 
     private async tryReduceLocked(forkId: ForkId): Promise<void> {
         if (forkId !== this.stateManager.forkId) return;
+
+        // A stale-candidate retry is already scheduled and its backoff has not
+        // elapsed. Callers that were queued behind the mutex stand down rather
+        // than spending the remaining attempts on the same unmoved chain state.
+        const pendingRetry = this.staleCandidateRetries.get(
+            this.getReductionCacheKey(forkId)
+        );
+        if (pendingRetry && Clock.getTimeInSeconds() < pendingRetry.notBefore) {
+            this.logger.debug("Reduction retry not due yet; standing down", {
+                forkId,
+                attempts: pendingRetry.attempts,
+                notBefore: pendingRetry.notBefore
+            });
+            return;
+        }
 
         const { windowExists, isExpired, killPeriodEnd } =
             await this.isKillPeriodExpiredCached(forkId);
@@ -533,29 +555,27 @@ export default class ReductionExecutor {
     // exhausted so ReductionManager fails the completion and aborts.
     private retryStaleCandidate(forkId: ForkId, candidateForkId: ForkId): void {
         const key = this.getReductionCacheKey(forkId);
-        const attempt = (this.staleCandidateRetries.get(key) ?? 0) + 1;
-        if (attempt > ReductionExecutor.MAX_STALE_CANDIDATE_RETRIES) {
+        const attempts =
+            (this.staleCandidateRetries.get(key)?.attempts ?? 0) + 1;
+        if (attempts > ReductionExecutor.MAX_STALE_CANDIDATE_RETRIES) {
             this.staleCandidateRetries.delete(key);
             throw new Error(
                 `Reduction candidate ${candidateForkId} for fork ${forkId} stayed stale across ${ReductionExecutor.MAX_STALE_CANDIDATE_RETRIES} recomputes`
             );
         }
-        this.staleCandidateRetries.set(key, attempt);
         const delay = Math.max(
             1,
             this.stateManager.timeConfig.chainFallbackTime
         );
+        const notBefore = Clock.getTimeInSeconds() + delay;
+        this.staleCandidateRetries.set(key, { attempts, notBefore });
         this.logger.info("Rescheduling reduction after a stale candidate", {
             forkId,
             candidateForkId,
-            attempt,
+            attempts,
             delay
         });
-        this.stateManager.reductionManager.schedule(
-            forkId,
-            Clock.getTimeInSeconds() + delay,
-            true
-        );
+        this.stateManager.reductionManager.schedule(forkId, notBefore, true);
     }
 
     private getReductionCacheKey(forkId: ForkId): ReductionCacheKey {

--- a/src/stateManager/reduction/ReductionExecutor.ts
+++ b/src/stateManager/reduction/ReductionExecutor.ts
@@ -267,7 +267,7 @@ export default class ReductionExecutor {
         const submission = await this.prepareSubmission(candidate);
         const submissionStatus = await this.simulateSubmission(
             forkId,
-            candidate.reducedForkId,
+            candidate,
             disputes,
             submission
         );
@@ -312,12 +312,7 @@ export default class ReductionExecutor {
                 }
             );
         if (installed && submissionStatus === "submit") {
-            this.submitDetached(
-                forkId,
-                candidate.reducedForkId,
-                disputes,
-                submission
-            );
+            this.submitDetached(forkId, candidate, disputes, submission);
         }
     }
 
@@ -402,7 +397,7 @@ export default class ReductionExecutor {
 
     private async simulateSubmission(
         forkId: ForkId,
-        candidateForkId: ForkId,
+        candidate: LocalReductionCandidate,
         disputes: DisputeStruct[],
         submission: { calldata: string[] }
     ): Promise<ReductionSubmissionStatus> {
@@ -417,7 +412,7 @@ export default class ReductionExecutor {
             const status = await this.classifyReductionRace(
                 custom?.name,
                 forkId,
-                candidateForkId,
+                candidate,
                 disputes,
                 "simulation"
             );
@@ -428,10 +423,11 @@ export default class ReductionExecutor {
 
     private submitDetached(
         forkId: ForkId,
-        candidateForkId: ForkId,
+        candidate: LocalReductionCandidate,
         disputes: DisputeStruct[],
         submission: { calldata: string[] }
     ): void {
+        const candidateForkId = candidate.reducedForkId;
         this.logger.info("Reduction transaction submit", {
             forkId,
             channelId: this.stateManager.channelId
@@ -467,7 +463,7 @@ export default class ReductionExecutor {
                     const status = await this.classifyReductionRace(
                         raceErrorName,
                         forkId,
-                        candidateForkId,
+                        candidate,
                         disputes,
                         "detached"
                     );
@@ -496,10 +492,11 @@ export default class ReductionExecutor {
     private async classifyReductionRace(
         errorName: string | undefined,
         forkId: ForkId,
-        candidateForkId: ForkId,
+        candidate: LocalReductionCandidate,
         disputes: DisputeStruct[],
         path: ReductionSubmissionPath
     ): Promise<ReductionSubmissionStatus | undefined> {
+        const candidateForkId = candidate.reducedForkId;
         if (!isReductionRaceErrorName(errorName)) return undefined;
         if (
             errorName === "RaceConditionDisputeAlreadyReduced" ||
@@ -538,6 +535,16 @@ export default class ReductionExecutor {
                 );
                 return "already-reduced";
             }
+            // Re-derive the target from the chain as it stands now. Equal to the
+            // one we submitted with means our supplied blocks never linked
+            // (local divergence); different means the chain moved under us
+            // between compute and submission (a genuine race). Without this the
+            // two are indistinguishable in the logs.
+            const chainTargetNow = await this.readChainInboundTarget(disputes);
+            const submittedTarget = String(
+                candidate.reduceData.reducedOutput.latestInboundMessageBlockHash
+            );
+
             // Logged at warn so a genuine, persistent local divergence stays
             // diagnosable instead of vanishing as a benign race.
             this.logger.warn(
@@ -548,7 +555,15 @@ export default class ReductionExecutor {
                     forkId,
                     candidateForkId,
                     committedForkId: reducedResult.reducedForkId,
-                    path
+                    reducer: reducedResult.reducer,
+                    path,
+                    inbound: LoggerUtils.getReductionInboundMetadata(
+                        candidate.reduceData
+                    ),
+                    chainTargetNow,
+                    targetMoved:
+                        chainTargetNow !== undefined &&
+                        chainTargetNow !== submittedTarget
                 }
             );
             return "stale-candidate";
@@ -595,6 +610,23 @@ export default class ReductionExecutor {
             delay
         });
         this.stateManager.reductionManager.schedule(forkId, notBefore, true);
+    }
+
+    // Diagnostic-only re-read of reduce()'s inbound target. Reverts are expected
+    // here (the disputes may no longer be the committed set), so a failure is
+    // reported as undefined rather than masking the error being classified.
+    private async readChainInboundTarget(
+        disputes: DisputeStruct[]
+    ): Promise<string | undefined> {
+        try {
+            const reducedOutput =
+                await this.stateManager.stateChannelManagerContract.reduce.staticCall(
+                    disputes
+                );
+            return String(reducedOutput.latestInboundMessageBlockHash);
+        } catch {
+            return undefined;
+        }
     }
 
     private getReductionCacheKey(forkId: ForkId): ReductionCacheKey {

--- a/src/stateManager/reduction/ReductionExecutor.ts
+++ b/src/stateManager/reduction/ReductionExecutor.ts
@@ -36,10 +36,10 @@ const REDUCTION_RACE_ERRORS = [
     "RaceConditionDisputeAlreadyReduced",
     "RaceConditionBlockHeightTooOld",
     "RaceConditionReductionExpectationDoesntMatch",
-    // Not a race per se: the losing peer's own reduce inputs went stale, so its
-    // reduceAndFinalize reverts the calldata-pure inbound-block check. Classified
-    // here so classifyReductionRace can gate it (swallow vs discard) instead of
-    // letting it escape the detached reduction path as an unhandled rejection.
+    // Not a race per se: our reduce inputs went stale against the chain, so
+    // reduceAndFinalize reverts the inbound-block check. Classified here so
+    // classifyReductionRace can gate it (swallow vs discard) instead of letting
+    // it escape the detached reduction path as an unhandled rejection.
     "ErrorDisputeInboundMessageBlocksInvalid"
 ] as const satisfies readonly RaceConditionErrorName[];
 type ReductionRaceErrorName = (typeof REDUCTION_RACE_ERRORS)[number];
@@ -427,15 +427,23 @@ export default class ReductionExecutor {
                 forkId
             );
 
-        // ErrorDisputeInboundMessageBlocksInvalid is a pure check over THIS
-        // peer's own calldata (its reduce-derived output doesn't chain from its
-        // local snapshot), so it means our local reduction diverged from chain
-        // — not merely that another reducer won. Compare the committed result to
-        // our own candidate: only when they match did we simply lose the race
-        // with a correct candidate (safe to install and converge). Otherwise the
-        // candidate is divergent (or nothing is committed yet) — discard it
-        // rather than install a value that would later trip the reduced-result
-        // mismatch -> abort — but never rethrow into the detached path either.
+        // ErrorDisputeInboundMessageBlocksInvalid compares our submitted
+        // inboundMessageBlocks against the target hash reduce() derives live
+        // from chain storage: the channel's inbound head walked back to the
+        // dispute-window expiry (lastEvidenceSubmissionTimestamp +
+        // evidenceTime). _verifyInboundMessageBlocks itself is pure, but that
+        // target is not — the expiry moves whenever late evidence lands. So the
+        // usual cause is the chain moving between compute() and this submission,
+        // and a recompute against the new head converges.
+        //
+        // reduceAndFinalize only reaches this check while nothing is committed
+        // (a committed result short-circuits earlier), so the committed value we
+        // read back is non-zero only when another reducer won inside this
+        // window. Matching our candidate means we merely lost the race with a
+        // correct candidate — safe to install and converge. Otherwise the
+        // candidate is stale (or nothing is committed yet): discard it rather
+        // than install a value that would later trip the reduced-result mismatch
+        // -> abort — but never rethrow into the detached path either.
         if (errorName === "ErrorDisputeInboundMessageBlocksInvalid") {
             if (
                 String(reducedResult.reducedForkId) === String(candidateForkId)

--- a/src/stateManager/reduction/ReductionExecutor.ts
+++ b/src/stateManager/reduction/ReductionExecutor.ts
@@ -32,6 +32,9 @@ type LocalReductionCandidate = ReductionComputation & {
 
 type ReductionCacheKey = string;
 type ReductionSubmissionStatus = "submit" | "already-reduced" | "superseded";
+// Which call site classified the revert. "simulation" still owns the decision
+// to install; "detached" already installed the candidate before submitting.
+type ReductionSubmissionPath = "simulation" | "detached";
 const REDUCTION_RACE_ERRORS = [
     "RaceConditionDisputeAlreadyReduced",
     "RaceConditionBlockHeightTooOld",
@@ -345,7 +348,8 @@ export default class ReductionExecutor {
                 custom?.name,
                 forkId,
                 candidateForkId,
-                disputes
+                disputes,
+                "simulation"
             );
             if (status) return status;
             throw custom ?? error;
@@ -394,7 +398,8 @@ export default class ReductionExecutor {
                         raceErrorName,
                         forkId,
                         candidateForkId,
-                        disputes
+                        disputes,
+                        "detached"
                     );
                     if (status) return;
                 }
@@ -407,7 +412,8 @@ export default class ReductionExecutor {
         errorName: string | undefined,
         forkId: ForkId,
         candidateForkId: ForkId,
-        disputes: DisputeStruct[]
+        disputes: DisputeStruct[],
+        path: ReductionSubmissionPath
     ): Promise<ReductionSubmissionStatus | undefined> {
         if (!isReductionRaceErrorName(errorName)) return undefined;
         if (
@@ -444,6 +450,13 @@ export default class ReductionExecutor {
         // candidate is stale (or nothing is committed yet): discard it rather
         // than install a value that would later trip the reduced-result mismatch
         // -> abort — but never rethrow into the detached path either.
+        //
+        // "Discard without installing" only holds on the simulation path.
+        // complete() installs the candidate before submitDetached runs, so on
+        // the detached path the stale genesis is already installed and the
+        // discard degrades to swallow-and-eventual-abort (the reduced-result
+        // mismatch in completeWithGenesis). Logged distinctly so the two are
+        // told apart.
         if (errorName === "ErrorDisputeInboundMessageBlocksInvalid") {
             if (
                 String(reducedResult.reducedForkId) === String(candidateForkId)
@@ -461,11 +474,14 @@ export default class ReductionExecutor {
             // Logged at warn so a genuine, persistent local divergence stays
             // diagnosable instead of vanishing as a benign race.
             this.logger.warn(
-                "Reduction inbound-blocks invalid; local candidate diverged from chain - discarding",
+                path === "detached"
+                    ? "Reduction inbound-blocks invalid after submit; stale candidate already installed"
+                    : "Reduction inbound-blocks invalid; local candidate diverged from chain - discarding",
                 {
                     forkId,
                     candidateForkId,
-                    committedForkId: reducedResult.reducedForkId
+                    committedForkId: reducedResult.reducedForkId,
+                    path
                 }
             );
             return "superseded";

--- a/src/stateManager/reduction/ReductionExecutor.ts
+++ b/src/stateManager/reduction/ReductionExecutor.ts
@@ -172,7 +172,16 @@ export default class ReductionExecutor {
     }
 
     private async tryReduceLocked(forkId: ForkId): Promise<void> {
-        if (forkId !== this.stateManager.forkId) return;
+        // The fork moved on, so this fork's reduction is settled one way or
+        // another and its retry budget is dead state — drop it here, the one
+        // place every trigger passes through, rather than leaking it until
+        // dispose().
+        if (forkId !== this.stateManager.forkId) {
+            this.staleCandidateRetries.delete(
+                this.getReductionCacheKey(forkId)
+            );
+            return;
+        }
 
         // A stale-candidate retry is already scheduled and its backoff has not
         // elapsed. Callers that were queued behind the mutex stand down rather

--- a/src/utils/LoggerUtils.ts
+++ b/src/utils/LoggerUtils.ts
@@ -32,7 +32,7 @@ import {
     SnapshotDataStruct
 } from "@typechain-types/contracts/V1/types/DataTypes";
 import Clock from "@/Clock";
-import { TimeConfig } from "@/types";
+import { ReduceData, TimeConfig } from "@/types";
 import type Rpc from "@/rpc/Rpc";
 import { ethers } from "ethers";
 
@@ -520,6 +520,26 @@ export class LoggerUtils {
             this.MESSAGE_TYPE_LABELS[messageType] ??
             "UNKNOWN_MESSAGE_TYPE"
         );
+    }
+
+    /**
+     * The three inbound-chain values `_verifyInboundMessageBlocks` compares:
+     * where our submitted snapshot says the chain starts, where `reduce()` said
+     * it ends, and the blocks we supplied to bridge them.
+     */
+    static getReductionInboundMetadata(reduceData: ReduceData) {
+        return {
+            submittedSnapshotInboundHash: String(
+                reduceData.latestStateSnapshot.snapshotData
+                    .latestInboundMessageBlockHash
+            ),
+            computedTargetInboundHash: String(
+                reduceData.reducedOutput.latestInboundMessageBlockHash
+            ),
+            submittedInboundBlocks: reduceData.inboundMessageBlocks.map(
+                (messageBlock) => this.getMessageBlockMetadata(messageBlock)
+            )
+        };
     }
 
     static getReducedOutputMetadata(reducedOutput: ReduceOutputStruct) {

--- a/src/utils/evmErrorHandler.ts
+++ b/src/utils/evmErrorHandler.ts
@@ -30,7 +30,8 @@ export type RaceConditionErrorName =
     | "ErrorCantParticipateInDispute"
     | "ErrorDisputePostedAuditingDataMismatch"
     | "ErrorDisputeChallengePeriodExpired"
-    | "ErrorDisputeCommitmentNotAvailable";
+    | "ErrorDisputeCommitmentNotAvailable"
+    | "ErrorDisputeInboundMessageBlocksInvalid";
 
 export type RaceConditionErrorHandlers = Partial<
     Record<RaceConditionErrorName, (error: CustomEvmError) => void>

--- a/test/e2e/E2E-ReductionManager.test.ts
+++ b/test/e2e/E2E-ReductionManager.test.ts
@@ -201,29 +201,32 @@ describe("E2E: ReductionManager", function () {
             expect(TestSession.getFirstDetachedError()).to.equal(undefined);
         });
 
-        it("ErrorDisputeInboundMessageBlocksInvalid on the detached submit is swallowed with the candidate already installed", async function () {
+        it("ErrorDisputeInboundMessageBlocksInvalid on the detached submit aborts the uncommitted candidate", async function () {
             // The staticCall passes, so complete() installs the candidate and
-            // only then does submitDetached fault. That is the call site the
-            // simulation stub cannot reach: the revert must be classified and
-            // swallowed instead of escaping as an unhandled rejection.
+            // settles the completion before submitDetached faults. Nothing can
+            // reconcile that install afterwards — the fork has already moved, so
+            // no later attempt re-enters the executor for this source fork. The
+            // peer must therefore fail closed rather than stay live on a
+            // candidate the chain never committed.
+            const targetPeer = h.getPeer(targetPeerIndex);
             await h.rpcStub.releaseReductionWithSubmitError(
                 targetPeerIndex,
                 "ErrorDisputeInboundMessageBlocksInvalid"
             );
 
-            await h.assert.dispute.reductionCompletedWait({
-                sourceForkId,
-                peerIndices: [targetPeerIndex]
+            await waitFor(
+                async () =>
+                    (await h
+                        .control(targetPeer)
+                        .query.getStatus()
+                        .request()) === Status.OPENED,
+                h.event.protocolEventTimeoutMs(0),
+                50
+            );
+            await TestSession.expectFirstDetachedError({
+                includes: "was rejected on submit",
+                timeoutMs: 5000
             });
-            expect(
-                await h
-                    .control(h.getPeer(targetPeerIndex))
-                    .query.getStatus()
-                    .request()
-            ).to.equal(Status.PARTICIPATING);
-            const hostErrors = await h.quiesceHosts();
-            expect(hostErrors).to.deep.equal([]);
-            expect(TestSession.getFirstDetachedError()).to.equal(undefined);
         });
     });
 

--- a/test/e2e/E2E-ReductionManager.test.ts
+++ b/test/e2e/E2E-ReductionManager.test.ts
@@ -109,6 +109,58 @@ describe("E2E: ReductionManager", function () {
                     .request()
             ).to.equal(null);
         });
+
+        it("ErrorDisputeInboundMessageBlocksInvalid swallows when another reducer already committed", async function () {
+            // beforeEach already holds reduction timers. Also hold snapshot /
+            // reduced-commit handlers on the target so the winner's commit
+            // cannot complete the target via event-driven tryReduce first.
+            const race = await h.rpcStub.holdReductionRace(targetPeerIndex);
+
+            // Another peer must commit first so classifyReductionRace's
+            // getReducedResult gate passes (non-ZeroHash reducedForkId).
+            const winnerIndex = 1;
+            await h
+                .control(h.getPeer(winnerIndex))
+                .stub.restoreReductionTasks(true)
+                .request();
+            await h.assert.dispute.reductionCompletedWait({
+                sourceForkId,
+                peerIndices: [winnerIndex]
+            });
+            // Local install can finish before the detached on-chain submit;
+            // await the winner observing its own reduced-result commit
+            // (event-driven, not a ground-truth poll).
+            await h.event.waitForPeers(
+                "onDisputeReducedResultCommitted",
+                [winnerIndex],
+                1,
+                { timeoutMs: 20000, mode: "atLeast" }
+            );
+
+            await h
+                .control(h.getPeer(targetPeerIndex))
+                .stub.stubNextReductionSimulationError(
+                    "ErrorDisputeInboundMessageBlocksInvalid"
+                )
+                .request();
+            await race.release({
+                runHeldTasks: true,
+                replayEvents: false
+            });
+            await h.assert.dispute.reductionCompletedWait({
+                sourceForkId,
+                peerIndices: [targetPeerIndex]
+            });
+            expect(
+                await h
+                    .control(h.getPeer(targetPeerIndex))
+                    .query.getStatus()
+                    .request()
+            ).to.equal(Status.PARTICIPATING);
+            const hostErrors = await h.quiesceHosts();
+            expect(hostErrors).to.deep.equal([]);
+            expect(TestSession.getFirstDetachedError()).to.equal(undefined);
+        });
     });
 
     it("an empty dispute set posts replacement evidence and resumes the same reduction", async function () {

--- a/test/e2e/E2E-ReductionManager.test.ts
+++ b/test/e2e/E2E-ReductionManager.test.ts
@@ -154,6 +154,52 @@ describe("E2E: ReductionManager", function () {
             expect(hostErrors).to.deep.equal([]);
             expect(TestSession.getFirstDetachedError()).to.equal(undefined);
         });
+
+        it("ErrorDisputeInboundMessageBlocksInvalid with nothing committed discards the candidate and retries", async function () {
+            // No winner is released, so getReducedResult stays ZeroHash and the
+            // candidate is classified stale rather than superseded — the branch
+            // that declines to install. Nothing else would settle this fork, so
+            // the reduction only finishes if the discard reschedules.
+            const stopRecordingReduce =
+                await h.rpcStub.recordReduce(targetPeerIndex);
+            try {
+                await h.rpcStub.releaseReductionWithSimulationError(
+                    targetPeerIndex,
+                    "ErrorDisputeInboundMessageBlocksInvalid"
+                );
+
+                // The retry waits a chainFallbackTime, so nothing can be
+                // installed yet whether or not the first attempt has landed.
+                expect(
+                    await h
+                        .control(h.getPeer(targetPeerIndex))
+                        .query.getCompletedReductionForkId(sourceForkId)
+                        .request()
+                ).to.equal(null);
+
+                // The injected error is one-shot: the rescheduled attempt
+                // recomputes against the real chain and completes.
+                await h.assert.dispute.reductionCompletedWait({
+                    sourceForkId,
+                    peerIndices: [targetPeerIndex]
+                });
+                expect(
+                    await h.rpcStub.reduceCallCount(targetPeerIndex)
+                ).to.be.greaterThan(1);
+            } finally {
+                await stopRecordingReduce();
+            }
+
+            expect(
+                await h
+                    .control(h.getPeer(targetPeerIndex))
+                    .query.getStatus()
+                    .request()
+            ).to.equal(Status.PARTICIPATING);
+            const hostErrors = await h.quiesceHosts();
+            expect(hostErrors).to.deep.equal([]);
+            expect(TestSession.getFirstDetachedError()).to.equal(undefined);
+        });
     });
 
     it("an empty dispute set posts replacement evidence and resumes the same reduction", async function () {

--- a/test/e2e/E2E-ReductionManager.test.ts
+++ b/test/e2e/E2E-ReductionManager.test.ts
@@ -201,6 +201,116 @@ describe("E2E: ReductionManager", function () {
             expect(TestSession.getFirstDetachedError()).to.equal(undefined);
         });
 
+        it("a stale candidate that survives every retry aborts instead of looping", async function () {
+            // MAX_STALE_CANDIDATE_RETRIES is 3, so four consecutive stale
+            // simulations must exhaust the budget: three reschedules, then the
+            // fourth attempt fails the completion.
+            const targetPeer = h.getPeer(targetPeerIndex);
+            await h
+                .control(targetPeer)
+                .stub.stubNextReductionSimulationError(
+                    "ErrorDisputeInboundMessageBlocksInvalid",
+                    4
+                )
+                .request();
+            await h
+                .control(targetPeer)
+                .stub.restoreReductionTasks(true)
+                .request();
+
+            await waitFor(
+                async () =>
+                    (await h
+                        .control(targetPeer)
+                        .query.getStatus()
+                        .request()) === Status.OPENED,
+                h.event.protocolEventTimeoutMs(0),
+                50
+            );
+            expect(
+                await h
+                    .control(targetPeer)
+                    .query.getCompletedReductionForkId(sourceForkId)
+                    .request()
+            ).to.equal(null);
+            // The budget is released once exhausted, not left pinned at the cap.
+            expect(
+                (
+                    await h
+                        .control(targetPeer)
+                        .stub.getStaleRetryState(sourceForkId)
+                        .request()
+                ).tracked
+            ).to.equal(false);
+            await TestSession.expectFirstDetachedError({
+                includes: "stayed stale across",
+                timeoutMs: 5000
+            });
+        });
+
+        it("a stale candidate holds its backoff against concurrently queued triggers", async function () {
+            // Every trigger funnels into the same executor mutex. Without the
+            // retry deadline the callers queued behind the first stale attempt
+            // would each burn one of the three attempts immediately. Two faults
+            // keep the run inside the budget, so this test observes the backoff
+            // rather than the exhaustion covered above.
+            const targetPeer = h.getPeer(targetPeerIndex);
+            await h
+                .control(targetPeer)
+                .stub.stubNextReductionSimulationError(
+                    "ErrorDisputeInboundMessageBlocksInvalid",
+                    2
+                )
+                .request();
+            await h
+                .control(targetPeer)
+                .stub.restoreReductionTasks(true)
+                .request();
+
+            await waitFor(
+                async () =>
+                    (
+                        await h
+                            .control(targetPeer)
+                            .stub.getStaleRetryState(sourceForkId)
+                            .request()
+                    ).attempts >= 1,
+                h.event.protocolEventTimeoutMs(0),
+                25
+            );
+
+            // Fire real triggers inside the backoff window; each enters the same
+            // executor mutex, so without the deadline they would each spend an
+            // attempt against chain state that has not moved.
+            const beforeBurst = await h
+                .control(targetPeer)
+                .stub.getStaleRetryState(sourceForkId)
+                .request();
+            await Promise.all(
+                [0, 1, 2].map(() =>
+                    h
+                        .control(targetPeer)
+                        .dispute.startReduction(sourceForkId)
+                        .request()
+                )
+            );
+            const afterBurst = await h
+                .control(targetPeer)
+                .stub.getStaleRetryState(sourceForkId)
+                .request();
+            // The scheduled retry can legitimately land during the burst, so
+            // allow one increment — three would mean the burst was charged.
+            expect(afterBurst.attempts).to.be.at.most(beforeBurst.attempts + 1);
+
+            // The run stays inside the budget and the reduction still lands.
+            await h.assert.dispute.reductionCompletedWait({
+                sourceForkId,
+                peerIndices: [targetPeerIndex]
+            });
+            const hostErrors = await h.quiesceHosts();
+            expect(hostErrors).to.deep.equal([]);
+        });
+
         it("ErrorDisputeInboundMessageBlocksInvalid on the detached submit aborts the uncommitted candidate", async function () {
             // The staticCall passes, so complete() installs the candidate and
             // settles the completion before submitDetached faults. Nothing can

--- a/test/e2e/E2E-ReductionManager.test.ts
+++ b/test/e2e/E2E-ReductionManager.test.ts
@@ -119,33 +119,26 @@ describe("E2E: ReductionManager", function () {
             // Another peer must commit first so classifyReductionRace's
             // getReducedResult gate passes (non-ZeroHash reducedForkId).
             const winnerIndex = 1;
-            await h
-                .control(h.getPeer(winnerIndex))
-                .stub.restoreReductionTasks(true)
-                .request();
-            await h.assert.dispute.reductionCompletedWait({
+            await h.rpcStub.loseReductionRaceWithSimulationError({
                 sourceForkId,
-                peerIndices: [winnerIndex]
-            });
-            // Local install can finish before the detached on-chain submit;
-            // await the winner observing its own reduced-result commit
-            // (event-driven, not a ground-truth poll).
-            await h.event.waitForPeers(
-                "onDisputeReducedResultCommitted",
-                [winnerIndex],
-                1,
-                { timeoutMs: 20000, mode: "atLeast" }
-            );
-
-            await h
-                .control(h.getPeer(targetPeerIndex))
-                .stub.stubNextReductionSimulationError(
-                    "ErrorDisputeInboundMessageBlocksInvalid"
-                )
-                .request();
-            await race.release({
-                runHeldTasks: true,
-                replayEvents: false
+                winnerIndex,
+                errorName: "ErrorDisputeInboundMessageBlocksInvalid",
+                releaseWinner: async () => {
+                    await h
+                        .control(h.getPeer(winnerIndex))
+                        .stub.restoreReductionTasks(true)
+                        .request();
+                },
+                losers: [
+                    {
+                        index: targetPeerIndex,
+                        release: () =>
+                            race.release({
+                                runHeldTasks: true,
+                                replayEvents: false
+                            })
+                    }
+                ]
             });
             await h.assert.dispute.reductionCompletedWait({
                 sourceForkId,

--- a/test/e2e/E2E-ReductionManager.test.ts
+++ b/test/e2e/E2E-ReductionManager.test.ts
@@ -200,6 +200,31 @@ describe("E2E: ReductionManager", function () {
             expect(hostErrors).to.deep.equal([]);
             expect(TestSession.getFirstDetachedError()).to.equal(undefined);
         });
+
+        it("ErrorDisputeInboundMessageBlocksInvalid on the detached submit is swallowed with the candidate already installed", async function () {
+            // The staticCall passes, so complete() installs the candidate and
+            // only then does submitDetached fault. That is the call site the
+            // simulation stub cannot reach: the revert must be classified and
+            // swallowed instead of escaping as an unhandled rejection.
+            await h.rpcStub.releaseReductionWithSubmitError(
+                targetPeerIndex,
+                "ErrorDisputeInboundMessageBlocksInvalid"
+            );
+
+            await h.assert.dispute.reductionCompletedWait({
+                sourceForkId,
+                peerIndices: [targetPeerIndex]
+            });
+            expect(
+                await h
+                    .control(h.getPeer(targetPeerIndex))
+                    .query.getStatus()
+                    .request()
+            ).to.equal(Status.PARTICIPATING);
+            const hostErrors = await h.quiesceHosts();
+            expect(hostErrors).to.deep.equal([]);
+            expect(TestSession.getFirstDetachedError()).to.equal(undefined);
+        });
     });
 
     it("an empty dispute set posts replacement evidence and resumes the same reduction", async function () {

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -1079,44 +1079,18 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
     public stubNextReductionSimulationError(
         errorName: ReductionSimulationErrorName
     ): boolean {
-        const contract = this.service.sm.stateChannelManagerContract;
-        const runner = contract.runner;
-        if (!runner?.call) {
-            throw new Error(
-                "Reduction simulation runner does not support call"
-            );
-        }
-        if (!this.service.stubOriginals.has("reductionSimulation")) {
-            this.service.stubOriginals.set(
-                "reductionSimulation",
-                runner.call.bind(runner)
-            );
-        }
-        const original = this.service.stubOriginals.get(
-            "reductionSimulation"
-        ) as NonNullable<typeof runner.call>;
-        const multicallSelector =
-            contract.interface.getFunction("multicall")!.selector;
-        runner.call = async (transaction) => {
-            if (!String(transaction.data).startsWith(multicallSelector)) {
-                return await original(transaction);
-            }
-            runner.call = original;
-            this.service.stubOriginals.delete("reductionSimulation");
-            throw { data: id(`${errorName}()`).slice(0, 10) };
-        };
-        return true;
+        return this.service.installOneShotMulticallFault({
+            stubKey: "reductionSimulation",
+            method: "call",
+            errorName
+        });
     }
 
     public restoreReductionSimulation(): boolean {
-        const contract = this.service.sm.stateChannelManagerContract;
-        const runner = contract.runner;
-        if (!runner?.call) return false;
-        const original = this.service.stubOriginals.get("reductionSimulation");
-        if (original === undefined) return false;
-        runner.call = original as NonNullable<typeof runner.call>;
-        this.service.stubOriginals.delete("reductionSimulation");
-        return true;
+        return this.service.restoreMulticallFault(
+            "reductionSimulation",
+            "call"
+        );
     }
 
     /**
@@ -1128,46 +1102,18 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
     public stubNextReductionSubmitError(
         errorName: ReductionSimulationErrorName
     ): boolean {
-        const contract = this.service.sm.stateChannelManagerContract;
-        const runner = contract.runner;
-        if (!runner?.sendTransaction) {
-            throw new Error(
-                "Reduction submit runner does not support sendTransaction"
-            );
-        }
-        if (!this.service.stubOriginals.has("reductionSubmit")) {
-            this.service.stubOriginals.set(
-                "reductionSubmit",
-                runner.sendTransaction.bind(runner)
-            );
-        }
-        const original = this.service.stubOriginals.get(
-            "reductionSubmit"
-        ) as NonNullable<typeof runner.sendTransaction>;
-        const multicallSelector =
-            contract.interface.getFunction("multicall")!.selector;
-        runner.sendTransaction = async (transaction) => {
-            if (!String(transaction.data).startsWith(multicallSelector)) {
-                return await original(transaction);
-            }
-            runner.sendTransaction = original;
-            this.service.stubOriginals.delete("reductionSubmit");
-            throw { data: id(`${errorName}()`).slice(0, 10) };
-        };
-        return true;
+        return this.service.installOneShotMulticallFault({
+            stubKey: "reductionSubmit",
+            method: "sendTransaction",
+            errorName
+        });
     }
 
     public restoreReductionSubmit(): boolean {
-        const contract = this.service.sm.stateChannelManagerContract;
-        const runner = contract.runner;
-        if (!runner?.sendTransaction) return false;
-        const original = this.service.stubOriginals.get("reductionSubmit");
-        if (original === undefined) return false;
-        runner.sendTransaction = original as NonNullable<
-            typeof runner.sendTransaction
-        >;
-        this.service.stubOriginals.delete("reductionSubmit");
-        return true;
+        return this.service.restoreMulticallFault(
+            "reductionSubmit",
+            "sendTransaction"
+        );
     }
 
     /**

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -1120,6 +1120,57 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
     }
 
     /**
+     * Make the next reduction submit transaction fail with a selected contract
+     * error. Sibling of stubNextReductionSimulationError: this one faults the
+     * real send, so the revert lands in submitDetached's catch instead of the
+     * staticCall — the path where the candidate is already installed.
+     */
+    public stubNextReductionSubmitError(
+        errorName: ReductionSimulationErrorName
+    ): boolean {
+        const contract = this.service.sm.stateChannelManagerContract;
+        const runner = contract.runner;
+        if (!runner?.sendTransaction) {
+            throw new Error(
+                "Reduction submit runner does not support sendTransaction"
+            );
+        }
+        if (!this.service.stubOriginals.has("reductionSubmit")) {
+            this.service.stubOriginals.set(
+                "reductionSubmit",
+                runner.sendTransaction.bind(runner)
+            );
+        }
+        const original = this.service.stubOriginals.get(
+            "reductionSubmit"
+        ) as NonNullable<typeof runner.sendTransaction>;
+        const multicallSelector =
+            contract.interface.getFunction("multicall")!.selector;
+        runner.sendTransaction = async (transaction) => {
+            if (!String(transaction.data).startsWith(multicallSelector)) {
+                return await original(transaction);
+            }
+            runner.sendTransaction = original;
+            this.service.stubOriginals.delete("reductionSubmit");
+            throw { data: id(`${errorName}()`).slice(0, 10) };
+        };
+        return true;
+    }
+
+    public restoreReductionSubmit(): boolean {
+        const contract = this.service.sm.stateChannelManagerContract;
+        const runner = contract.runner;
+        if (!runner?.sendTransaction) return false;
+        const original = this.service.stubOriginals.get("reductionSubmit");
+        if (original === undefined) return false;
+        runner.sendTransaction = original as NonNullable<
+            typeof runner.sendTransaction
+        >;
+        this.service.stubOriginals.delete("reductionSubmit");
+        return true;
+    }
+
+    /**
      * Count `spectateService.sync` requests; `forward` keeps the real sync
      * running (record-only otherwise — the punishment path stays quiet).
      */

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -20,7 +20,8 @@ import type {
     ConcurrentCalldataRecoveryProbe,
     CleanCommittedDivergenceProbe,
     DisputeStrategyResultMatrix,
-    MissingParticipantSnapshotsProbe
+    MissingParticipantSnapshotsProbe,
+    StaleRetryProbe
 } from "./StubService";
 import type { StubService } from "./StubService";
 
@@ -1075,15 +1076,25 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
         return this.service.reduceCallCount;
     }
 
-    /** Make the next reduction simulation fail with a selected contract error. */
+    /**
+     * Make the next `times` reduction simulations fail with a selected contract
+     * error (default one), so a whole retry run can be staged.
+     */
     public stubNextReductionSimulationError(
-        errorName: ReductionSimulationErrorName
+        errorName: ReductionSimulationErrorName,
+        times?: number
     ): boolean {
-        return this.service.installOneShotMulticallFault({
+        return this.service.installMulticallFault({
             stubKey: "reductionSimulation",
             method: "call",
-            errorName
+            errorName,
+            times
         });
+    }
+
+    /** Executor stale-candidate retry budget for a fork. */
+    public getStaleRetryState(forkId: ForkId): StaleRetryProbe {
+        return this.service.getStaleRetryState(forkId);
     }
 
     public restoreReductionSimulation(): boolean {
@@ -1102,7 +1113,7 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
     public stubNextReductionSubmitError(
         errorName: ReductionSimulationErrorName
     ): boolean {
-        return this.service.installOneShotMulticallFault({
+        return this.service.installMulticallFault({
             stubKey: "reductionSubmit",
             method: "sendTransaction",
             errorName

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -53,6 +53,8 @@ export type StaleRetryProbe = {
     notBefore: Timestamp | null;
     tracked: boolean;
 };
+/** Shape of the executor's private retry entry, as seen by the probe. */
+type StaleCandidateRetryView = { attempts: number; notBefore: Timestamp };
 type RunnerFaultFn = (transaction: TransactionRequest) => Promise<unknown>;
 type FaultableRunner = Record<RunnerFaultMethod, RunnerFaultFn | undefined>;
 
@@ -224,15 +226,16 @@ export class StubService extends ARpcService<
         const executor = (
             this.sm.reductionManager as unknown as {
                 reductionExecutor: {
-                    staleCandidateRetries: Map<
-                        string,
-                        { attempts: number; notBefore: number }
-                    >;
+                    staleCandidateRetries: Map<string, StaleCandidateRetryView>;
+                    // Reached rather than re-derived: a probe that rebuilt the
+                    // key format would silently read nothing if the executor
+                    // changed it, and the assertions would pass vacuously.
+                    getReductionCacheKey(forkId: ForkId): string;
                 };
             }
         ).reductionExecutor;
         const entry = executor.staleCandidateRetries.get(
-            `${this.sm.channelId}:${forkId}`
+            executor.getReductionCacheKey(forkId)
         );
         return {
             attempts: entry?.attempts ?? 0,

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -38,6 +38,7 @@ export type StubKey =
     | "reducedCommitEvents"
     | "reduce"
     | "reductionSimulation"
+    | "reductionSubmit"
     | "finalDisputePreparation"
     | "spectateSync"
     | "pausedReduction"

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -10,7 +10,7 @@ import { BlockValidationResult } from "@/types";
 import { Block, StateSnapshot } from "@/models";
 import * as factory from "@test/factory";
 import { recordValidationBoundary } from "./RecordingValidationStrategy";
-import type { Address, ForkId, Hash } from "@/types/types";
+import type { Address, ForkId, Hash, Timestamp } from "@/types/types";
 
 // `ATransport` is used both for `createRPCMethods` and the captured transport.
 
@@ -46,6 +46,13 @@ export type StubKey =
 
 /** Runner methods a one-shot multicall fault can be installed on. */
 export type RunnerFaultMethod = "call" | "sendTransaction";
+
+/** Executor stale-candidate retry budget for one fork. */
+export type StaleRetryProbe = {
+    attempts: number;
+    notBefore: Timestamp | null;
+    tracked: boolean;
+};
 type RunnerFaultFn = (transaction: TransactionRequest) => Promise<unknown>;
 type FaultableRunner = Record<RunnerFaultMethod, RunnerFaultFn | undefined>;
 
@@ -162,20 +169,21 @@ export class StubService extends ARpcService<
     }
 
     /**
-     * One-shot fault on the contract runner's `multicall` path — `call` for a
-     * simulation, `sendTransaction` for a real submit. Forwards everything that
-     * is not a multicall, then restores itself and throws the encoded custom
-     * error on the first matching invocation. Both reduction injectors share
-     * this so their matching and restoration cannot drift apart.
+     * Fault the contract runner's `multicall` path — `call` for a simulation,
+     * `sendTransaction` for a real submit. Forwards everything that is not a
+     * multicall, throws the encoded custom error on the next `times` matching
+     * invocations, then restores itself. Both reduction injectors share this so
+     * their matching and restoration cannot drift apart.
      *
      * Monkey-patching the runner is exactly the untyped-internal case casts are
      * for: the two methods have different return types, so the patch is written
      * once against a structural view and cast back on install/restore.
      */
-    public installOneShotMulticallFault(options: {
+    public installMulticallFault(options: {
         stubKey: StubKey;
         method: RunnerFaultMethod;
         errorName: string;
+        times?: number;
     }): boolean {
         const contract = this.sm.stateChannelManagerContract;
         const selector = contract.interface.getFunction("multicall")!.selector;
@@ -192,15 +200,45 @@ export class StubService extends ARpcService<
         const forward = this.stubOriginals.get(
             options.stubKey
         ) as RunnerFaultFn;
+        let remaining = options.times ?? 1;
         runner[options.method] = async (transaction) => {
             if (!String(transaction.data).startsWith(selector)) {
                 return await forward(transaction);
             }
-            runner[options.method] = forward;
-            this.stubOriginals.delete(options.stubKey);
+            remaining -= 1;
+            if (remaining <= 0) {
+                runner[options.method] = forward;
+                this.stubOriginals.delete(options.stubKey);
+            }
             throw { data: id(`${options.errorName}()`).slice(0, 10) };
         };
         return true;
+    }
+
+    /**
+     * Read the executor's stale-candidate retry budget for a fork. The map is a
+     * private implementation detail, so this is a deliberate cast to a private
+     * internal rather than a public surface.
+     */
+    public getStaleRetryState(forkId: ForkId): StaleRetryProbe {
+        const executor = (
+            this.sm.reductionManager as unknown as {
+                reductionExecutor: {
+                    staleCandidateRetries: Map<
+                        string,
+                        { attempts: number; notBefore: number }
+                    >;
+                };
+            }
+        ).reductionExecutor;
+        const entry = executor.staleCandidateRetries.get(
+            `${this.sm.channelId}:${forkId}`
+        );
+        return {
+            attempts: entry?.attempts ?? 0,
+            notBefore: entry?.notBefore ?? null,
+            tracked: entry !== undefined
+        };
     }
 
     /** Reinstall the original runner method saved by a one-shot fault. */

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -3,7 +3,7 @@ import type P2PManager from "@/P2PManager";
 import type ATransport from "@/transport/ATransport";
 import type { HarnessControlRpc } from "../../HarnessControlRpc";
 import StubRpcMethods from "./StubRpcMethods";
-import { ethers, id, Log } from "ethers";
+import { ethers, id, Log, type TransactionRequest } from "ethers";
 import { DetachedPromises } from "@/utils";
 import DisputeValidationStrategy from "@/stateManager/validationStrategy/DisputeValidationStrategy";
 import { BlockValidationResult } from "@/types";
@@ -43,6 +43,11 @@ export type StubKey =
     | "spectateSync"
     | "pausedReduction"
     | "pausedReductionKillPeriod";
+
+/** Runner methods a one-shot multicall fault can be installed on. */
+export type RunnerFaultMethod = "call" | "sendTransaction";
+type RunnerFaultFn = (transaction: TransactionRequest) => Promise<unknown>;
+type FaultableRunner = Record<RunnerFaultMethod, RunnerFaultFn | undefined>;
 
 export type ReductionSimulationErrorName =
     | "RaceConditionDisputeAlreadyReduced"
@@ -154,6 +159,63 @@ export class StubService extends ARpcService<
 
     get sm() {
         return this.p2pManager.stateManager;
+    }
+
+    /**
+     * One-shot fault on the contract runner's `multicall` path — `call` for a
+     * simulation, `sendTransaction` for a real submit. Forwards everything that
+     * is not a multicall, then restores itself and throws the encoded custom
+     * error on the first matching invocation. Both reduction injectors share
+     * this so their matching and restoration cannot drift apart.
+     *
+     * Monkey-patching the runner is exactly the untyped-internal case casts are
+     * for: the two methods have different return types, so the patch is written
+     * once against a structural view and cast back on install/restore.
+     */
+    public installOneShotMulticallFault(options: {
+        stubKey: StubKey;
+        method: RunnerFaultMethod;
+        errorName: string;
+    }): boolean {
+        const contract = this.sm.stateChannelManagerContract;
+        const selector = contract.interface.getFunction("multicall")!.selector;
+        const runner = contract.runner as FaultableRunner | null;
+        const original = runner?.[options.method];
+        if (!runner || !original) {
+            throw new Error(
+                `Contract runner does not support ${options.method}`
+            );
+        }
+        if (!this.stubOriginals.has(options.stubKey)) {
+            this.stubOriginals.set(options.stubKey, original.bind(runner));
+        }
+        const forward = this.stubOriginals.get(
+            options.stubKey
+        ) as RunnerFaultFn;
+        runner[options.method] = async (transaction) => {
+            if (!String(transaction.data).startsWith(selector)) {
+                return await forward(transaction);
+            }
+            runner[options.method] = forward;
+            this.stubOriginals.delete(options.stubKey);
+            throw { data: id(`${options.errorName}()`).slice(0, 10) };
+        };
+        return true;
+    }
+
+    /** Reinstall the original runner method saved by a one-shot fault. */
+    public restoreMulticallFault(
+        stubKey: StubKey,
+        method: RunnerFaultMethod
+    ): boolean {
+        const runner = this.sm.stateChannelManagerContract
+            .runner as FaultableRunner | null;
+        if (!runner?.[method]) return false;
+        const original = this.stubOriginals.get(stubKey);
+        if (original === undefined) return false;
+        runner[method] = original as RunnerFaultFn;
+        this.stubOriginals.delete(stubKey);
+        return true;
     }
 
     /** Exercise rejected-log retention through the real EventSyncService. */

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -46,7 +46,8 @@ export type StubKey =
 export type ReductionSimulationErrorName =
     | "RaceConditionDisputeAlreadyReduced"
     | "RaceConditionBlockHeightTooOld"
-    | "RaceConditionReductionExpectationDoesntMatch";
+    | "RaceConditionReductionExpectationDoesntMatch"
+    | "ErrorDisputeInboundMessageBlocksInvalid";
 
 export type PausedReductionStatus = {
     entered: boolean;

--- a/test/harness/actions/rpcStubActions.ts
+++ b/test/harness/actions/rpcStubActions.ts
@@ -1,4 +1,5 @@
 import { Logger } from "@/utils";
+import type { ForkId } from "@/types/types";
 import { PeerTestHarness } from "@test/fixtures/PeerTestHarness";
 import type { HarnessControlRpc } from "@test/fixtures/customRpc/harnessControl/HarnessControlRpc";
 import type { ReductionSimulationErrorName } from "@test/fixtures/customRpc/harnessControl/services/stub/StubService";
@@ -293,6 +294,50 @@ export class RpcStubActions<
         const stub = this.harness.control(this.harness.getPeer(peerIndex)).stub;
         await stub.stubNextReductionSimulationError(errorName).request();
         await stub.restoreReductionTasks(true).request();
+    }
+
+    /**
+     * Stage a lost reduction race: release the winner so it reduces and commits
+     * on-chain, wait until it observes its own commit (the losers'
+     * classification gate reads that committed result), then drive each loser
+     * into `errorName` on its next reduction submission.
+     *
+     * Callers pass their own release callbacks because tests hold their peers
+     * differently — a bare `stubHoldReductionTasks` on one side, a full
+     * `holdReductionRace` handle on the other.
+     */
+    async loseReductionRaceWithSimulationError(options: {
+        sourceForkId: ForkId;
+        winnerIndex: number;
+        releaseWinner: () => Promise<void>;
+        losers: { index: number; release: () => Promise<void> }[];
+        errorName: ReductionSimulationErrorName;
+        timeoutMs?: number;
+    }): Promise<void> {
+        await options.releaseWinner();
+        await this.harness.assert.dispute.reductionCompletedWait({
+            sourceForkId: options.sourceForkId,
+            peerIndices: [options.winnerIndex]
+        });
+        // Local install can finish before the detached on-chain submit, so wait
+        // on the winner observing its own commit rather than polling ground
+        // truth.
+        await this.harness.event.waitForPeers(
+            "onDisputeReducedResultCommitted",
+            [options.winnerIndex],
+            1,
+            { timeoutMs: options.timeoutMs ?? 20000, mode: "atLeast" }
+        );
+        for (const loser of options.losers) {
+            this.logger.debug(
+                `Reduction race won by peer ${options.winnerIndex}; forcing ${options.errorName} on peer ${loser.index}`
+            );
+            await this.harness
+                .control(this.harness.getPeer(loser.index))
+                .stub.stubNextReductionSimulationError(options.errorName)
+                .request();
+            await loser.release();
+        }
     }
 
     /**

--- a/test/harness/actions/rpcStubActions.ts
+++ b/test/harness/actions/rpcStubActions.ts
@@ -297,6 +297,20 @@ export class RpcStubActions<
     }
 
     /**
+     * Like `releaseReductionWithSimulationError`, but the revert lands on the
+     * real submit rather than the staticCall — `complete()` has already
+     * installed the candidate by then.
+     */
+    async releaseReductionWithSubmitError(
+        peerIndex: number,
+        errorName: ReductionSimulationErrorName
+    ): Promise<void> {
+        const stub = this.harness.control(this.harness.getPeer(peerIndex)).stub;
+        await stub.stubNextReductionSubmitError(errorName).request();
+        await stub.restoreReductionTasks(true).request();
+    }
+
+    /**
      * Stage a lost reduction race: release the winner so it reduces and commits
      * on-chain, wait until it observes its own commit (the losers'
      * classification gate reads that committed result), then drive each loser

--- a/test/unit/DisputeManager.test.ts
+++ b/test/unit/DisputeManager.test.ts
@@ -1,0 +1,119 @@
+import { expect } from "chai";
+
+import { MathTestSession as TestSession, sleep } from "@test/harness";
+
+describe("Unit: DisputeManager", function () {
+    describe("dispute", function () {
+        // Ported from origin/unit-test-dispute-manager (was it.skip / ~10% flaky).
+        // Forces the losing-peer ErrorDisputeInboundMessageBlocksInvalid path
+        // after another reducer has already committed, so the swallow is
+        // deterministic rather than left to a natural race.
+        it("fault-free writer-timeout on a pending-join fork → losing reducer's stale reduceAndFinalize revert is swallowed, no detached rejection", async function () {
+            this.timeout(90000);
+            const h = TestSession.getHarness();
+
+            // a pending inbound join leaves the head not-final-by-everyone, so a
+            // dispute here carries postedAuditingData=true (auditing calldata)
+            await h.scenario.preDisputeSetupCalldataPath({
+                timeConfig: { chainFallbackTime: 2, evidenceTime: 3 }
+            });
+            const sourceForkId = h.activeForkId!;
+
+            // no block is produced -> the next writer's turn lapses -> the honest
+            // peers dispute the timed-out writer. a timeout has no fraud proof, so
+            // on this calldata-backed fork dispute() takes the no-multicall +
+            // uploadDisputeWithCalldata path (the branch this test covers)
+            const darkWriter = await h.query.getNextPeerToWrite();
+            const disputers = h.peers
+                .filter((p) => p.index !== darkWriter.index)
+                .map((p) => p.index);
+
+            // Stage every peer's reduction entry points so the
+            // ErrorDisputeInboundMessageBlocksInvalid race is forced, not left
+            // to chance (~10% natural flake on the unstaged path).
+            const races = new Map(
+                await Promise.all(
+                    h.peers.map(
+                        async (peer) =>
+                            [
+                                peer.index,
+                                await h.rpcStub.holdReductionRace(peer.index)
+                            ] as const
+                    )
+                )
+            );
+
+            await h.assert.dispute.initiatedAndCommitedWait({
+                peersIndices: disputers,
+                expectedCount: disputers.length,
+                initiatedWithAuditingData: true, // the calldata upload we wanted
+                timeoutMs: 30000
+            });
+
+            await sleep(h.event.evidencePeriodWaitMs(2));
+
+            const winnerIndex = disputers[0];
+            const loserIndices = disputers.slice(1);
+
+            // Winner reduces for real and commits on-chain first.
+            await races.get(winnerIndex)!.release({
+                runHeldTasks: true,
+                replayEvents: true
+            });
+            races.delete(winnerIndex);
+            await h.assert.dispute.reductionCompletedWait({
+                sourceForkId,
+                peerIndices: [winnerIndex]
+            });
+
+            // Local completion can race ahead of the detached on-chain submit;
+            // the loser's swallow gate needs the commit visible. Await the
+            // winner observing its own reduced-result commit (event-driven, not
+            // a ground-truth poll).
+            await h.event.waitForPeers(
+                "onDisputeReducedResultCommitted",
+                [winnerIndex],
+                1,
+                { timeoutMs: 20000, mode: "atLeast" }
+            );
+
+            // Force each remaining honest peer through the inbound-blocks race
+            // error on simulateSubmission; the fix must confirm getReducedResult
+            // and swallow with zero unhandled rejections.
+            for (const loserIndex of loserIndices) {
+                await h
+                    .control(h.getPeer(loserIndex))
+                    .stub.stubNextReductionSimulationError(
+                        "ErrorDisputeInboundMessageBlocksInvalid"
+                    )
+                    .request();
+                await races.get(loserIndex)!.release({
+                    runHeldTasks: true,
+                    // Drive tryReduce via the held timer, not snapshot replay
+                    // (which could complete without hitting the injected error).
+                    replayEvents: false
+                });
+                races.delete(loserIndex);
+            }
+
+            // Dark writer was held too; release without replaying so teardown
+            // is clean (they are not expected to settle the fork).
+            for (const [peerIndex, race] of races) {
+                await race.release({
+                    runHeldTasks: false,
+                    replayEvents: false
+                });
+                races.delete(peerIndex);
+            }
+
+            await h.assert.dispute.reductionCompletedWait({
+                sourceForkId,
+                peerIndices: loserIndices
+            });
+
+            const hostErrors = await h.quiesceHosts();
+            expect(hostErrors).to.deep.equal([]);
+            expect(TestSession.getFirstDetachedError()).to.equal(undefined);
+        });
+    });
+});

--- a/test/unit/ReductionExecutor.test.ts
+++ b/test/unit/ReductionExecutor.test.ts
@@ -58,46 +58,35 @@ describe("Unit: ReductionExecutor", function () {
             const winnerIndex = disputers[0];
             const loserIndices = disputers.slice(1);
 
-            // Winner reduces for real and commits on-chain first.
-            await races.get(winnerIndex)!.release({
-                runHeldTasks: true,
-                replayEvents: true
-            });
-            races.delete(winnerIndex);
-            await h.assert.dispute.reductionCompletedWait({
+            // Winner reduces and commits first, then each remaining honest peer
+            // is forced through the inbound-blocks error on simulateSubmission;
+            // the fix must confirm getReducedResult and swallow with zero
+            // unhandled rejections.
+            await h.rpcStub.loseReductionRaceWithSimulationError({
                 sourceForkId,
-                peerIndices: [winnerIndex]
+                winnerIndex,
+                errorName: "ErrorDisputeInboundMessageBlocksInvalid",
+                releaseWinner: async () => {
+                    await races.get(winnerIndex)!.release({
+                        runHeldTasks: true,
+                        replayEvents: true
+                    });
+                    races.delete(winnerIndex);
+                },
+                losers: loserIndices.map((loserIndex) => ({
+                    index: loserIndex,
+                    release: async () => {
+                        await races.get(loserIndex)!.release({
+                            runHeldTasks: true,
+                            // Drive tryReduce via the held timer, not snapshot
+                            // replay (which could complete without hitting the
+                            // injected error).
+                            replayEvents: false
+                        });
+                        races.delete(loserIndex);
+                    }
+                }))
             });
-
-            // Local completion can race ahead of the detached on-chain submit;
-            // the loser's swallow gate needs the commit visible. Await the
-            // winner observing its own reduced-result commit (event-driven, not
-            // a ground-truth poll).
-            await h.event.waitForPeers(
-                "onDisputeReducedResultCommitted",
-                [winnerIndex],
-                1,
-                { timeoutMs: 20000, mode: "atLeast" }
-            );
-
-            // Force each remaining honest peer through the inbound-blocks race
-            // error on simulateSubmission; the fix must confirm getReducedResult
-            // and swallow with zero unhandled rejections.
-            for (const loserIndex of loserIndices) {
-                await h
-                    .control(h.getPeer(loserIndex))
-                    .stub.stubNextReductionSimulationError(
-                        "ErrorDisputeInboundMessageBlocksInvalid"
-                    )
-                    .request();
-                await races.get(loserIndex)!.release({
-                    runHeldTasks: true,
-                    // Drive tryReduce via the held timer, not snapshot replay
-                    // (which could complete without hitting the injected error).
-                    replayEvents: false
-                });
-                races.delete(loserIndex);
-            }
 
             // Dark writer was held too; release without replaying so teardown
             // is clean (they are not expected to settle the fork).

--- a/test/unit/ReductionExecutor.test.ts
+++ b/test/unit/ReductionExecutor.test.ts
@@ -2,9 +2,12 @@ import { expect } from "chai";
 
 import { MathTestSession as TestSession, sleep } from "@test/harness";
 
-describe("Unit: DisputeManager", function () {
-    describe("dispute", function () {
-        // Ported from origin/unit-test-dispute-manager (was it.skip / ~10% flaky).
+describe("Unit: ReductionExecutor", function () {
+    describe("classifyReductionRace", function () {
+        // Scenario ported from origin/unit-test-dispute-manager (was it.skip /
+        // ~10% flaky). It lives here, not in the DisputeManager suite that owns
+        // the same staging, because the subject is the reduction submission
+        // classification rather than dispute construction.
         // Forces the losing-peer ErrorDisputeInboundMessageBlocksInvalid path
         // after another reducer has already committed, so the swallow is
         // deterministic rather than left to a natural race.


### PR DESCRIPTION
## Summary

On the dispute **reduction** path, `reduceAndFinalize` reverts with `ErrorDisputeInboundMessageBlocksInvalid` when the submitted reduction inputs have gone stale against the chain. That revert was unclassified, so it escaped **both** reduction-submit catch sites — the `simulateSubmission` staticCall and the detached `submitDetached` — as an **unhandled detached promise rejection**.

The revert is *not* a pure check over the submitter's own calldata. `reduce()` is a `view` over live storage, and the target hash is the channel's inbound head walked back to the dispute-window expiry (`lastEvidenceSubmissionTimestamp + evidenceTime`) — an expiry that moves whenever late evidence lands. So the usual cause is the chain moving between `compute()` and submission. `reduceAndFinalize` also only reaches this check while nothing is committed, so a non-zero committed result means another reducer won inside that window.

`classifyReductionRace` now distinguishes the two, and each call site applies its own policy:

- **committed result == our candidate** → `already-reduced`; we lost the race with a correct candidate, so install and converge.
- **anything else** → the candidate is stale:
  - **simulation path** (nothing installed yet) → reschedule a recompute against the moved head, bounded by 3 consecutive discards, after which the completion fails and aborts. Queued callers stand down until the backoff elapses instead of spending the budget on chain state that has not moved.
  - **detached path** (`complete()` already installed and settled, and the fork has moved) → **fail closed**. Nothing re-enters the executor for that source fork, so a candidate the chain never committed cannot be reconciled and the peer must not stay live on it.

## Test Plan

- `yarn tsc --noEmit` on `tsconfig.json` and `tsconfig.browser.json` — clean. Prettier and `git diff --check` clean.
- `yarn test:parallel` — full canonical gate.
- Reduction coverage in `test/e2e/E2E-ReductionManager.test.ts` and `test/unit/ReductionExecutor.test.ts`:
  - lost race with a matching committed result → install and converge;
  - stale with nothing committed → no install, rescheduled attempt completes the reduction;
  - stale through the whole retry budget → abort, budget released, no silent loop;
  - concurrently queued triggers → backoff held, run stays inside the budget;
  - stale on the detached submit → peer goes `OPENED` with the failure surfaced, not left `PARTICIPATING`.
- **Mutation check**: removing the reschedule makes the stale-with-nothing-committed test fail; restoring it passes.

### Coverage caveats

- The revert is **fault-injected** at the runner boundary (`call` for the simulation, `sendTransaction` for the submit). There is **no** E2E that produces it through a genuine on-chain race — a second actor moving the reduction inputs between a passing static call and a mined transaction. That staging needs a hold point between simulate and submit plus a controlled late-evidence write; it is not built here.
- The third classifier state — a **non-zero committed result that differs from our candidate** — is not staged. Reduction is deterministic, so producing it requires a deliberately divergent reducer, which the harness cannot currently stage. It is covered by the same `stale-candidate` branch as the zero case, but not independently asserted.
