### PR TITLE
(fix) departed member can abort a spectator via a stale membership snapshot

### DIFF
--- a/contracts/V1/StateChannelDiamondProxy/DisputeFraudProofFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeFraudProofFacet.sol
@@ -8,6 +8,7 @@ import "./Errors.sol";
 import "../types/DisputeFraudProofTypes.sol";
 import "./utils/DisputeUtils.sol";
 import "./utils/GeneralUtils.sol";
+import "./utils/BlockUtils.sol";
 import "./UtilityFacet.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 

--- a/contracts/V1/StateChannelDiamondProxy/DisputeFraudProofFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeFraudProofFacet.sol
@@ -176,14 +176,9 @@ contract DisputeFraudProofFacet is StateChannelCommon {
             }
         }
 
-        if (
-            UtilityFacet(utilityFacetAddress).isAddressInArray(
-                proof.previousStateSnapshot.snapshotData.participants, signer
-            )
-                || UtilityFacet(utilityFacetAddress).isAddressInArray(
-                    proof.resultingStateSnapshot.snapshotData.participants, signer
-                )
-        ) return _invalid();
+        if (_isBlockAuthorParticipant(invalidBlock, proof.previousStateSnapshot, proof.resultingStateSnapshot)) {
+            return _invalid();
+        }
         return _valid(dispute.input.disputer);
     }
 

--- a/contracts/V1/StateChannelDiamondProxy/LocalDiamond.sol
+++ b/contracts/V1/StateChannelDiamondProxy/LocalDiamond.sol
@@ -7,6 +7,7 @@ import "../types/MessageTypeHashes.sol";
 import "../StateChannelManagerEvents.sol";
 import "./utils/DisputeUtils.sol";
 import "./utils/BlockUtils.sol";
+import "./utils/GeneralUtils.sol";
 import "hardhat/console.sol";
 
 /**
@@ -363,6 +364,14 @@ contract LocalDiamond is StateChannelManagerProxy {
         return DisputeVerificationFacet(disputeVerificationFacetAddress).checkDisputeAuditingDataCommitment(
             dispute, disputeAuditingData
         );
+    }
+
+    function isBlockAuthorParticipant(
+        Block memory _block,
+        StateSnapshot memory previousSnapshot,
+        StateSnapshot memory resultingSnapshot
+    ) public pure returns (bool) {
+        return _isBlockAuthorParticipant(_block, previousSnapshot, resultingSnapshot);
     }
 
     // function isCorrectAuditingData(Dispute memory dispute, DisputeAuditingData memory disputeAuditingData)

--- a/contracts/V1/StateChannelDiamondProxy/utils/BlockUtils.sol
+++ b/contracts/V1/StateChannelDiamondProxy/utils/BlockUtils.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.8.8;
 
 import "../../types/DisputeTypes.sol";
 import "../Errors.sol";
+import "./GeneralUtils.sol";
 
 function _getBlockHeight(Block memory _block) pure returns (uint256) {
     return _block.transaction.header.transactionCnt;
@@ -33,4 +34,23 @@ function _areBlocksSameChannel(Block memory _block1, Block memory _block2) pure 
 
 function _doesBlockCommitToSnapshot(Block memory _block, StateSnapshot memory snapshot) pure returns (bool) {
     return _block.stateSnapshotHash == keccak256(abi.encode(snapshot));
+}
+
+function _isBlockAuthorParticipant(
+    Block memory _block,
+    StateSnapshot memory previousSnapshot,
+    StateSnapshot memory resultingSnapshot
+) pure returns (bool) {
+    address author = _getBlockAuthor(_block);
+    if (_isAddressInArray(previousSnapshot.snapshotData.participants, author)) {
+        return true;
+    }
+
+    if (
+        resultingSnapshot.blockHeight == _getBlockHeight(_block) && resultingSnapshot.forkId == _getBlockFork(_block)
+            && _isAddressInArray(resultingSnapshot.snapshotData.participants, author)
+    ) {
+        return true;
+    }
+    return false;
 }

--- a/contracts/V1/StateChannelDiamondProxy/utils/GeneralUtils.sol
+++ b/contracts/V1/StateChannelDiamondProxy/utils/GeneralUtils.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.8.8;
 
 import "../../types/DisputeTypes.sol";
 import "../Errors.sol";
-import "./BlockUtils.sol";
 
 function _delegatecall(address target, bytes memory data) returns (bytes memory) {
     (bool success, bytes memory result) = target.delegatecall(data);
@@ -21,25 +20,6 @@ function _delegatecall(address target, bytes memory data) returns (bytes memory)
 function _isAddressInArray(address[] memory array, address adr) pure returns (bool) {
     for (uint256 i = 0; i < array.length; i++) {
         if (array[i] == adr) return true;
-    }
-    return false;
-}
-
-function _isBlockAuthorParticipant(
-    Block memory _block,
-    StateSnapshot memory previousSnapshot,
-    StateSnapshot memory resultingSnapshot
-) pure returns (bool) {
-    address author = _getBlockAuthor(_block);
-    if (_isAddressInArray(previousSnapshot.snapshotData.participants, author)) {
-        return true;
-    }
-
-    if (
-        resultingSnapshot.blockHeight == _getBlockHeight(_block) && resultingSnapshot.forkId == _getBlockFork(_block)
-            && _isAddressInArray(resultingSnapshot.snapshotData.participants, author)
-    ) {
-        return true;
     }
     return false;
 }

--- a/contracts/V1/StateChannelDiamondProxy/utils/GeneralUtils.sol
+++ b/contracts/V1/StateChannelDiamondProxy/utils/GeneralUtils.sol
@@ -24,3 +24,22 @@ function _isAddressInArray(address[] memory array, address adr) pure returns (bo
     }
     return false;
 }
+
+function _isBlockAuthorParticipant(
+    Block memory _block,
+    StateSnapshot memory previousSnapshot,
+    StateSnapshot memory resultingSnapshot
+) pure returns (bool) {
+    address author = _getBlockAuthor(_block);
+    if (_isAddressInArray(previousSnapshot.snapshotData.participants, author)) {
+        return true;
+    }
+
+    if (
+        resultingSnapshot.blockHeight == _getBlockHeight(_block) && resultingSnapshot.forkId == _getBlockFork(_block)
+            && _isAddressInArray(resultingSnapshot.snapshotData.participants, author)
+    ) {
+        return true;
+    }
+    return false;
+}

--- a/src/models/StateSnapshot.ts
+++ b/src/models/StateSnapshot.ts
@@ -24,6 +24,26 @@ export default class StateSnapshot {
         return StateSnapshot.from(snapshot);
     }
 
+    static empty(): StateSnapshot {
+        const emptyBalance = { amount: 0n, data: "0x" };
+        return StateSnapshot.from({
+            forkId: ethers.ZeroHash,
+            blockHeight: 0n,
+            timestamp: 0n,
+            snapshotData: {
+                originForkId: ethers.ZeroHash,
+                stateMachineStateHash: ethers.ZeroHash,
+                participants: [],
+                latestInboundMessageBlockHash: ethers.ZeroHash,
+                latestInboundMessageBlockHeight: 0n,
+                latestOutboundMessageBlockHash: ethers.ZeroHash,
+                latestOutboundMessageBlockHeight: 0n,
+                totalDeposits: emptyBalance,
+                totalWithdrawals: emptyBalance
+            }
+        });
+    }
+
     toStruct(): StateSnapshotStruct {
         return this.snapshot;
     }

--- a/src/stateManager/ValidationService.ts
+++ b/src/stateManager/ValidationService.ts
@@ -72,14 +72,8 @@ export default class ValidationService {
             return await strategy.channelNotOpened(entry);
         }
 
-        //  Get participants
-        const participants = await this.getParticipantsUnionOrOnChain(
-            block,
-            block.channelId
-        );
-
         // Author is a participant
-        if (!participants.has(block.author)) {
+        if (!(await this.isBlockAuthorParticipant(block, block.channelId))) {
             this.logger.warn(
                 "validateBlockConfirmation - author is not participant",
                 {
@@ -535,19 +529,16 @@ export default class ValidationService {
 
     // ────────────────────── Helpers ─────────────────────
 
-    private async getParticipantsUnionOrOnChain(
+    private async isBlockAuthorParticipant(
         block: Block,
         channelId: ChannelId
-    ): Promise<Set<Address>> {
-        let participants = new Set(
-            this.storage.getParticipantsUnion(
-                block.coordinates,
-                block.stateSnapshotHash
-            )
+    ): Promise<boolean> {
+        const previousSnapshot = this.storage.getPreviousStateSnapshot(
+            block.coordinates
         );
 
-        if (participants.size === 0) {
-            // get participants from chain
+        if (!previousSnapshot) {
+            // No local anchor to bind against - fall back to the on-chain union.
             const [participantsFromChain, pendingParticipants] =
                 await Promise.all([
                     this.stateChannelManagerContract.getParticipants(channelId),
@@ -555,13 +546,25 @@ export default class ValidationService {
                         channelId
                     )
                 ]);
-            participants = new Set([
+            return new Set<Address>([
                 ...participantsFromChain,
                 ...pendingParticipants
-            ]);
+            ]).has(block.author);
         }
 
-        return participants;
+        // The author counts if it is in the previous snapshot, or in the block's
+        // declared resulting snapshot bound to the block's coordinates.
+        const resultingSnapshot =
+            this.storage.stateSnapshots.getStateSnapshotByHash(
+                block.stateSnapshotHash
+            );
+        // No declared snapshot in storage -> an empty snapshot contributes no
+        // participants, so the check degrades to the previous snapshot alone.
+        return await this.diamondStateMachine.localDiamondContract.isBlockAuthorParticipant(
+            block.blockStruct,
+            previousSnapshot.toStruct(),
+            (resultingSnapshot ?? StateSnapshot.empty()).toStruct()
+        );
     }
 
     private async getOnChainPostTiming(

--- a/test/V1/StateChannelDiamondProxy/DisputeVerificationFacet.t.sol
+++ b/test/V1/StateChannelDiamondProxy/DisputeVerificationFacet.t.sol
@@ -374,6 +374,28 @@ contract DisputeVerificationFacetTest is DiamondHarness {
         assertEq(harness.handleBlockAuthorNotParticipant(abi.encode(proof), dispute), dispute.input.disputer);
     }
 
+    function test_disputeBlockAuthorNotParticipant_authorInWrongForkResultingSnapshot_valid() public {
+        // The author is in the block's declared resulting snapshot, and the
+        // height matches, but the snapshot's forkId does not (a departed
+        // member naming a stale snapshot from a different fork at the same
+        // height). The coordinate binding must not count it, so the author is
+        // not a participant and the proof is valid - matching the off-chain
+        // author gate so an honest auditor is never slashed.
+        DisputeExpiryGuardHarness harness = new DisputeExpiryGuardHarness();
+        (Dispute memory dispute, DisputeBlockAuthorNotParticipant memory proof, address signer) =
+            _disputeBlockAuthorNotParticipantProof();
+
+        proof.resultingStateSnapshot.snapshotData.participants[0] = signer;
+        // stale: the resulting snapshot belongs to a different fork, not this block's
+        proof.resultingStateSnapshot.forkId = keccak256("other-fork");
+        Block memory invalidBlock = abi.decode(dispute.input.stateProof.signedBlocks[0].encodedBlock, (Block));
+        invalidBlock.stateSnapshotHash = keccak256(abi.encode(proof.resultingStateSnapshot));
+        dispute.input.stateProof.signedBlocks[0].encodedBlock = abi.encode(invalidBlock);
+        dispute.input.stateProof.signedBlocks[0].signature = _sign(1, abi.encode(invalidBlock));
+
+        assertEq(harness.handleBlockAuthorNotParticipant(abi.encode(proof), dispute), dispute.input.disputer);
+    }
+
     function test_blockInvalidStateTransition_wrongTurnWithCorrectSnapshot_slashesSigner() public {
         address[] memory participants = new address[](2);
         participants[0] = vm.addr(1);

--- a/test/V1/StateChannelDiamondProxy/DisputeVerificationFacet.t.sol
+++ b/test/V1/StateChannelDiamondProxy/DisputeVerificationFacet.t.sol
@@ -302,9 +302,7 @@ contract DisputeVerificationFacetTest is DiamondHarness {
         require(diamond.getEvidenceTime() > 0, "evidenceTime is 0 - grace not observable");
         (Dispute memory dispute, TimeoutCalldataPosted memory proof) =
             _timeoutCalldataPostedProofPostedAfter(_firstBlockGraceWindow());
-        assertTrue(
-            diamond.validateTimeoutCalldataPostedProof(proof, dispute), "first-block grace edge rejected"
-        );
+        assertTrue(diamond.validateTimeoutCalldataPostedProof(proof, dispute), "first-block grace edge rejected");
     }
 
     function test_validateTimeoutCalldataPostedProof_pastFirstBlockGrace_invalid() public {
@@ -312,8 +310,7 @@ contract DisputeVerificationFacetTest is DiamondHarness {
         (Dispute memory dispute, TimeoutCalldataPosted memory proof) =
             _timeoutCalldataPostedProofPostedAfter(_firstBlockGraceWindow() + 1);
         assertFalse(
-            diamond.validateTimeoutCalldataPostedProof(proof, dispute),
-            "calldata posted past the grace window accepted"
+            diamond.validateTimeoutCalldataPostedProof(proof, dispute), "calldata posted past the grace window accepted"
         );
     }
 
@@ -354,6 +351,27 @@ contract DisputeVerificationFacetTest is DiamondHarness {
         dispute.input.stateProof.signedBlocks[0].encodedBlock = abi.encode(invalidBlock);
         dispute.input.stateProof.signedBlocks[0].signature = _sign(1, abi.encode(invalidBlock));
         assertEq(harness.handleBlockAuthorNotParticipant(abi.encode(proof), dispute), address(0));
+    }
+
+    function test_disputeBlockAuthorNotParticipant_authorInStaleResultingSnapshot_valid() public {
+        // The author is in the block's declared resulting snapshot, but that
+        // snapshot's coordinates do not match the block (a departed member
+        // naming a stale snapshot). The coordinate binding must not count it, so
+        // the author is not a participant and the proof is valid - matching the
+        // off-chain author gate so an honest auditor is never slashed.
+        DisputeExpiryGuardHarness harness = new DisputeExpiryGuardHarness();
+        (Dispute memory dispute, DisputeBlockAuthorNotParticipant memory proof, address signer) =
+            _disputeBlockAuthorNotParticipantProof();
+
+        proof.resultingStateSnapshot.snapshotData.participants[0] = signer;
+        // stale: the resulting snapshot belongs to a later height, not this block
+        proof.resultingStateSnapshot.blockHeight = 5;
+        Block memory invalidBlock = abi.decode(dispute.input.stateProof.signedBlocks[0].encodedBlock, (Block));
+        invalidBlock.stateSnapshotHash = keccak256(abi.encode(proof.resultingStateSnapshot));
+        dispute.input.stateProof.signedBlocks[0].encodedBlock = abi.encode(invalidBlock);
+        dispute.input.stateProof.signedBlocks[0].signature = _sign(1, abi.encode(invalidBlock));
+
+        assertEq(harness.handleBlockAuthorNotParticipant(abi.encode(proof), dispute), dispute.input.disputer);
     }
 
     function test_blockInvalidStateTransition_wrongTurnWithCorrectSnapshot_slashesSigner() public {
@@ -516,6 +534,9 @@ contract DisputeVerificationFacetTest is DiamondHarness {
         StateSnapshot memory resultingSnapshot;
         resultingSnapshot.snapshotData.participants = new address[](1);
         resultingSnapshot.snapshotData.participants[0] = address(0xA2);
+        // the resulting snapshot is this block's own -> coordinate-bound
+        resultingSnapshot.forkId = FORK_ID;
+        resultingSnapshot.blockHeight = 0;
 
         Block memory invalidBlock;
         invalidBlock.transaction.header.channelId = CHANNEL_ID;

--- a/test/e2e/E2E-SpectatingAbortDoS.test.ts
+++ b/test/e2e/E2E-SpectatingAbortDoS.test.ts
@@ -255,3 +255,72 @@ describe("E2E: spectating strategy junk-block handling", function () {
         });
     });
 });
+
+describe("E2E: active-participant stale-membership handling", function () {
+    it("cuts an ex-member's stale-membership block, stays PARTICIPATING, starts no dispute", async function () {
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(4, 0, { timeConfig: LIVE_FORK_TIME });
+        const forkId = h.activeForkId!;
+
+        // build the pre-leave snapshot the ex-member will name
+        await h.transition.advanceState({ count: 2 });
+        const staleHeight = await h
+            .control(h.getPeer(0))
+            .query.getLatestBlockHeight(forkId)
+            .request();
+
+        // a participant leaves; move past the leave so the current previous
+        // snapshot excludes them
+        const leaverIndex = await h.transition.participantLeaveWait();
+        const leaver = h.getPeer(leaverIndex);
+        await h.transition.advanceState({ count: 2 });
+
+        // victim = an active participant that is not the leaver; read the craft
+        // source from it too so the crafted block links to the live head (the
+        // departed leaver may no longer track it)
+        const victim = h
+            .getActiveHonestPeers()
+            .find((p) => p.index !== leaverIndex)!;
+        expect(
+            await h.control(victim).query.getStatus().request(),
+            "victim is an active participant"
+        ).to.equal(Status.PARTICIPATING);
+
+        const participants = await h
+            .control(victim)
+            .query.getParticipants()
+            .request();
+        expect(
+            participants.map((p) => p.toLowerCase()),
+            "leaver should be out of the current participant set"
+        ).to.not.include(leaver.address.toLowerCase());
+
+        // clean dispute-event baseline before the attack
+        h.event.resetEventSpies();
+
+        const { encodedBlockConfirmation } =
+            await h.byzantine.craftStaleMembershipBlockConfirmation(
+                victim.index,
+                forkId,
+                leaver.signer,
+                staleHeight!
+            );
+        await h
+            .control(leaver)
+            .byzantine.sendBlockConfirmation(
+                encodedBlockConfirmation,
+                victim.address
+            )
+            .request();
+
+        // leaver (author == sender) is cut, victim keeps participating
+        await h.assert.rpc.peerBlacklistedAndDisconnected({
+            observer: victim,
+            target: leaver,
+            expectedStatus: Status.PARTICIPATING
+        });
+        // no false dispute against the honest fork, everyone still in sync
+        h.assert.dispute.noDisputes();
+        await h.assert.sync.onlyHonestPeersInSync();
+    });
+});

--- a/test/e2e/E2E-SpectatingAbortDoS.test.ts
+++ b/test/e2e/E2E-SpectatingAbortDoS.test.ts
@@ -196,4 +196,62 @@ describe("E2E: spectating strategy junk-block handling", function () {
             expectedStatus: Status.SYNCED
         });
     });
+
+    // A participant that has LEFT is still connected. Snapshots are keyed by hash
+    // and never pruned, so the ex-member authors a block naming a snapshot from
+    // while it was still a member; without the coordinate binding the author gate
+    // unions that stale snapshot and re-admits it, the block reaches the leader
+    // check, and the spectator aborts as if a participant misbehaved. An ex-member
+    // is a non-participant: drop it, never abort.
+    it("cuts an ex-member that authors a linked block naming a stale membership snapshot, keeping the spectator SYNCED", async function () {
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(4, 0, { timeConfig: LIVE_FORK_TIME });
+        const forkId = h.activeForkId!;
+
+        // victim spectates and stores the pre-leave snapshots (still listing the
+        // leaver as a participant)
+        const victim = await h.join.addSpectatorWait();
+        await h.transition.advanceState({ count: 2 });
+
+        const staleHeight = await h
+            .control(h.getPeer(0))
+            .query.getLatestBlockHeight(forkId)
+            .request();
+
+        const leaverIndex = await h.transition.participantLeaveWait();
+        const leaver = h.getPeer(leaverIndex);
+
+        // move past the leave so the current previous snapshot excludes them
+        await h.transition.advanceState({ count: 2 });
+
+        const participants = await h
+            .control(h.getPeer(0))
+            .query.getParticipants()
+            .request();
+        expect(
+            participants.map((p) => p.toLowerCase()),
+            "leaver should be out of the current participant set"
+        ).to.not.include(leaver.address.toLowerCase());
+
+        const { encodedBlockConfirmation } =
+            await h.byzantine.craftStaleMembershipBlockConfirmation(
+                0,
+                forkId,
+                leaver.signer,
+                staleHeight!
+            );
+        await h
+            .control(leaver)
+            .byzantine.sendBlockConfirmation(
+                encodedBlockConfirmation,
+                victim.address
+            )
+            .request();
+
+        await h.assert.rpc.peerBlacklistedAndDisconnected({
+            observer: victim,
+            target: leaver,
+            expectedStatus: Status.SYNCED
+        });
+    });
 });

--- a/test/e2e/E2E-StaleMembershipDispute.test.ts
+++ b/test/e2e/E2E-StaleMembershipDispute.test.ts
@@ -1,0 +1,153 @@
+import { expect } from "chai";
+
+import {
+    DisputeFraudProofType,
+    toSolidityDisputeFraudProofType
+} from "@/types/sol-enums";
+import { MathTestSession as TestSession } from "@test/harness";
+
+describe("E2E: stale-membership dispute", function () {
+    it("departed author + stale resulting snapshot in a stateProof → DisputeBlockAuthorNotParticipant only, then killed on-chain", async function () {
+        const h = TestSession.getHarness();
+
+        // peer 2 will leave; 0/1/3 stay as the honest disputers
+        await h.lifecycle.timeoutSetup(4, 0);
+        await h.assert.sync.peersInSyncWait();
+        const forkId = h.activeForkId!;
+
+        // advance while everyone is still a member -> the head snapshot lists the
+        // leaver as a participant. capture its hash: the "stale" snapshot.
+        await h.transition.advanceState({ count: 2 });
+        const staleInfo = await h
+            .control(h.getPeer(0))
+            .query.getLatestBlockInfo(forkId)
+            .request();
+        if (!staleInfo) throw new Error("missing pre-leave head block info");
+        const staleSnapshotHash = staleInfo.stateSnapshotHash;
+
+        // the stale-era set still lists the future leaver: a naive membership
+        // check against this snapshot would admit the author, so only the
+        // coordinate binding can reject it later.
+        const preLeaveParticipants = await h
+            .control(h.getPeer(0))
+            .query.getParticipants()
+            .request();
+        expect(
+            preLeaveParticipants.map((p) => p.toLowerCase()),
+            "stale snapshot era must still list the leaver"
+        ).to.include(h.getPeer(2).address.toLowerCase());
+
+        // peer 2 leaves, then advance so the current previous snapshot excludes it
+        const leaverIndex = await h.transition.participantLeaveWait({
+            leaverIndex: 2
+        });
+        const leaver = h.getPeer(leaverIndex);
+        await h.transition.advanceState({ count: 2, waitForPeers: [0, 1, 3] });
+
+        const participants = await h
+            .control(h.getPeer(0))
+            .query.getParticipants()
+            .request();
+        expect(
+            participants.map((p) => p.toLowerCase()),
+            "leaver should be out of the current participant set"
+        ).to.not.include(leaver.address.toLowerCase());
+
+        h.event.resetEventSpies();
+        h.contextApi.captureOriginalFork();
+
+        // peer 3 builds the dispute; rewrite its stateProof head to a block
+        // authored by the leaver that names the stale (pre-leave) snapshot at the
+        // head's coordinates. re-signs as the leaver via the shared signer set.
+        await h.tamper.stubConstructDispute(
+            3,
+            async (dispute, sm, args) => {
+                const d = sm.p2pManager.localRpc.dispute;
+                // the leave finalized everything into milestones; append the
+                // attack block to the unfinalized tail of the last milestone.
+                d.expectMilestonesOnlyStateProof(dispute.input.stateProof);
+                const confirmations =
+                    dispute.input.stateProof.milestones.at(
+                        -1
+                    )?.blockConfirmations;
+                if (!confirmations || confirmations.length === 0) {
+                    throw new Error("expected a milestone anchor block");
+                }
+                const anchor = confirmations.at(-1)!;
+                const previousHash = d.hash(anchor.signedBlock.encodedBlock);
+                await d.appendLastMilestoneSignedBlockInDispute(
+                    dispute,
+                    (block) => {
+                        block.transaction.header.transactionCnt =
+                            BigInt(block.transaction.header.transactionCnt) +
+                            1n;
+                        block.transaction.header.timestamp =
+                            BigInt(block.transaction.header.timestamp) + 1n;
+                        // leaver authors at the head's next coordinates
+                        block.transaction.header.participant =
+                            args.leaverAddress as string;
+                        block.transaction.body.data = "0x";
+                        block.previousBlockHash = previousHash;
+                        // the lever: a snapshot whose participants still list the
+                        // leaver, bound to stale (pre-leave) coordinates
+                        block.stateSnapshotHash =
+                            args.staleSnapshotHash as string;
+                        return block;
+                    }
+                );
+            },
+            {
+                args: {
+                    leaverAddress: leaver.address,
+                    staleSnapshotHash
+                }
+            }
+        );
+
+        await h.byzantine.submitDoubleSignBlock(0);
+        await h.assert.dispute.initiatedWait({
+            peersIndices: [3],
+            initiatedWithAuditingData: false
+        });
+
+        await h.event.waitForPeers("onDisputeKilled", [0], 1, {
+            mode: "atLeast"
+        });
+        await h.assert.storage.honestPeersStoredDisputeFraudProofWait({
+            disputeFraudProofType:
+                DisputeFraudProofType.DisputeBlockAuthorNotParticipant,
+            peerIndices: [0, 1, 3],
+            timeoutMs: 15000
+        });
+
+        // exclusivity: the coordinate-binding proof fired, not a structural /
+        // state-proof / apply fallback.
+        const overlappingProofTypes = [
+            DisputeFraudProofType.DisputeInvalidBlockStructure,
+            DisputeFraudProofType.DisputeInvalidStateProof,
+            DisputeFraudProofType.DisputeInvalidBlockInStateProofApplyFraudProof
+        ].map((type) => String(toSolidityDisputeFraudProofType(type)));
+        for (const peer of h.getFilteredPeers([0, 1, 3])) {
+            const proofTypes = await h
+                .control(peer)
+                .query.getDisputeFraudProofTypes()
+                .request();
+            expect(proofTypes).to.include(
+                String(
+                    toSolidityDisputeFraudProofType(
+                        DisputeFraudProofType.DisputeBlockAuthorNotParticipant
+                    )
+                )
+            );
+            for (const overlappingType of overlappingProofTypes) {
+                expect(proofTypes).not.to.include(overlappingType);
+            }
+        }
+
+        // _killDispute slashes the disputer on-chain in the same tx that emits
+        // DisputeKilled -> peer 3 (the malicious disputer) is on-chain slashed.
+        // deterministic proof the malicious dispute died on-chain, independent of
+        // the double-sign fork reduction.
+        await h.assert.dispute.slashedOnChain(h.getPeer(3).address);
+    });
+});

--- a/test/fixtures/customRpc/harnessControl/services/stub/RecordingValidationStrategy.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/RecordingValidationStrategy.ts
@@ -1,0 +1,26 @@
+import type AValidationStrategy from "@/stateManager/validationStrategy/AValidationStrategy";
+import { BlockValidationResult } from "@/types";
+
+export const NO_BOUNDARY_REACHED = "SUCCESS";
+
+/**
+ * Wraps a live validation strategy and records the first hook it calls,
+ * suppressing that hook's side effect - so a probe can drive the real
+ * validateBlockConfirmation without disconnecting peers or opening disputes.
+ */
+export function recordValidationBoundary(target: AValidationStrategy) {
+    const result = { reached: NO_BOUNDARY_REACHED };
+    const strategy = new Proxy(target, {
+        get(t, prop) {
+            const value = Reflect.get(t, prop, t);
+            if (typeof value !== "function") return value;
+            return () => {
+                if (result.reached === NO_BOUNDARY_REACHED) {
+                    result.reached = String(prop);
+                }
+                return Promise.resolve(BlockValidationResult.DISCONNECT);
+            };
+        }
+    });
+    return { strategy, result };
+}

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -20,8 +20,7 @@ import type {
     ConcurrentCalldataRecoveryProbe,
     CleanCommittedDivergenceProbe,
     DisputeStrategyResultMatrix,
-    MissingParticipantSnapshotsProbe,
-    BlockAuthorParticipantProbe
+    MissingParticipantSnapshotsProbe
 } from "./StubService";
 import type { StubService } from "./StubService";
 
@@ -654,8 +653,48 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
         return this.service.probeMissingParticipantSnapshots();
     }
 
-    public async probeBlockAuthorParticipant(): Promise<BlockAuthorParticipantProbe> {
-        return this.service.probeBlockAuthorParticipant();
+    public async probeAuthorGatePreviousSnapshotMember(): Promise<string> {
+        return this.service.probeAuthorGatePreviousSnapshotMember();
+    }
+
+    public async probeAuthorGateMatchingResultingSnapshot(): Promise<string> {
+        return this.service.probeAuthorGateMatchingResultingSnapshot();
+    }
+
+    public async probeAuthorGateStaleHeightSnapshot(): Promise<string> {
+        return this.service.probeAuthorGateStaleHeightSnapshot();
+    }
+
+    public async probeAuthorGateWrongForkSnapshot(): Promise<string> {
+        return this.service.probeAuthorGateWrongForkSnapshot();
+    }
+
+    public async probeAuthorGateMatchingSnapshotExcludingAuthor(): Promise<string> {
+        return this.service.probeAuthorGateMatchingSnapshotExcludingAuthor();
+    }
+
+    public async probeAuthorGateMissingSnapshotPreviousMember(): Promise<string> {
+        return this.service.probeAuthorGateMissingSnapshotPreviousMember();
+    }
+
+    public async probeAuthorGateMissingSnapshotOutsider(): Promise<string> {
+        return this.service.probeAuthorGateMissingSnapshotOutsider();
+    }
+
+    public async probeAuthorGateNoAnchorCurrentParticipant(): Promise<string> {
+        return this.service.probeAuthorGateNoAnchorCurrentParticipant();
+    }
+
+    public async probeAuthorGateNoAnchorPendingParticipant(
+        pendingParticipant: string
+    ): Promise<string> {
+        return this.service.probeAuthorGateNoAnchorPendingParticipant(
+            pendingParticipant as Address
+        );
+    }
+
+    public async probeAuthorGateNoAnchorUnknownAddress(): Promise<string> {
+        return this.service.probeAuthorGateNoAnchorUnknownAddress();
     }
 
     /** Pause a real reduction once it enters its kill-period lookup. */

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -20,7 +20,8 @@ import type {
     ConcurrentCalldataRecoveryProbe,
     CleanCommittedDivergenceProbe,
     DisputeStrategyResultMatrix,
-    MissingParticipantSnapshotsProbe
+    MissingParticipantSnapshotsProbe,
+    BlockAuthorParticipantProbe
 } from "./StubService";
 import type { StubService } from "./StubService";
 
@@ -651,6 +652,10 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
 
     public async probeMissingParticipantSnapshots(): Promise<MissingParticipantSnapshotsProbe> {
         return this.service.probeMissingParticipantSnapshots();
+    }
+
+    public async probeBlockAuthorParticipant(): Promise<BlockAuthorParticipantProbe> {
+        return this.service.probeBlockAuthorParticipant();
     }
 
     /** Pause a real reduction once it enters its kill-period lookup. */

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -1,14 +1,15 @@
 import ARpcService from "@/rpc/ARpcService";
 import type P2PManager from "@/P2PManager";
 import type ATransport from "@/transport/ATransport";
-import type { ForkId } from "@/types/types";
 import type { HarnessControlRpc } from "../../HarnessControlRpc";
 import StubRpcMethods from "./StubRpcMethods";
-import { id, Log } from "ethers";
+import { ethers, id, Log } from "ethers";
 import { DetachedPromises } from "@/utils";
 import DisputeValidationStrategy from "@/stateManager/validationStrategy/DisputeValidationStrategy";
 import { BlockValidationResult } from "@/types";
-import { Block } from "@/models";
+import { Block, StateSnapshot } from "@/models";
+import * as factory from "@test/factory";
+import type { Address, ChannelId, ForkId, Hash } from "@/types/types";
 
 // `ATransport` is used both for `createRPCMethods` and the captured transport.
 
@@ -89,6 +90,26 @@ export type MissingParticipantSnapshotsProbe = {
     earlyAuthorResult: string;
     signatureUnionResult: string;
     proofStored: boolean;
+};
+
+export type BlockAuthorParticipantProbe = {
+    /** author already in the previous snapshot -> participant */
+    previousSnapshotMember: string;
+    /** author absent from the previous snapshot but present in a resulting
+     *  snapshot whose (forkId, height) match the block's own coordinates ->
+     *  participant */
+    matchingResultingSnapshotMember: string;
+    /** author absent from the previous snapshot; the named resulting snapshot
+     *  exists but belongs to a different height (a stale/ex-member snapshot)
+     *  -> not a participant */
+    staleResultingSnapshotMember: string;
+    /** no locally-anchored previous snapshot for the block's coordinates ->
+     *  falls back to the on-chain participant set; author is a real
+     *  on-chain participant -> participant */
+    noLocalAnchorKnownParticipant: string;
+    /** same on-chain fallback, author is an unrelated address -> not a
+     *  participant */
+    noLocalAnchorUnknownAddress: string;
 };
 
 /**
@@ -395,6 +416,148 @@ export class StubService extends ARpcService<
                 this.sm.storage.disputeFraudProofs.getDisputeFraudProofForDispute(
                     dispute
                 ) !== undefined
+        };
+    }
+
+    public async probeBlockAuthorParticipant(): Promise<BlockAuthorParticipantProbe> {
+        const validationService = this.sm.validationService as unknown as {
+            isBlockAuthorParticipant: (
+                block: Block,
+                channelId: ChannelId
+            ) => Promise<boolean>;
+        };
+
+        const forkId = this.sm.forkId;
+        const channelId = this.sm.channelId;
+        const latestBlock = this.sm.storage.blocks.getLatestBlock(forkId);
+        if (!latestBlock) throw new Error("Expected a latest block");
+
+        const previousSnapshot =
+            this.sm.storage.stateSnapshots.getStateSnapshotByHash(
+                latestBlock.stateSnapshotHash
+            );
+        if (!previousSnapshot) {
+            throw new Error("Expected the latest block's snapshot");
+        }
+        const knownParticipant = previousSnapshot.snapshotData
+            .participants[0] as Address;
+        const outsider = ethers.Wallet.createRandom().address as Address;
+        const nextHeight = latestBlock.height + 1;
+
+        const buildSnapshot = (
+            participants: Address[],
+            height: number,
+            snapshotForkId: ForkId
+        ) =>
+            StateSnapshot.from({
+                forkId: snapshotForkId,
+                blockHeight: BigInt(height),
+                timestamp: 0n,
+                snapshotData: {
+                    originForkId: ethers.ZeroHash,
+                    stateMachineStateHash: ethers.ZeroHash,
+                    participants,
+                    latestInboundMessageBlockHash: ethers.ZeroHash,
+                    latestInboundMessageBlockHeight: 0n,
+                    latestOutboundMessageBlockHash: ethers.ZeroHash,
+                    latestOutboundMessageBlockHeight: 0n,
+                    totalDeposits: { amount: 0n, data: "0x" },
+                    totalWithdrawals: { amount: 0n, data: "0x" }
+                }
+            });
+
+        const buildBlock = (
+            participant: Address,
+            stateSnapshotHash: Hash,
+            overrides?: { forkId?: ForkId; height?: number }
+        ) => {
+            const blockStruct = {
+                ...factory.blockStructWithTransactionHeader(
+                    latestBlock.blockStruct,
+                    {
+                        participant,
+                        transactionCnt: overrides?.height ?? nextHeight,
+                        forkId: overrides?.forkId ?? forkId
+                    }
+                ),
+                previousBlockHash: latestBlock.hash,
+                stateSnapshotHash
+            };
+            return Block.fromBlockStruct(blockStruct, this.sm.signer);
+        };
+
+        // author already a participant in the (real) previous snapshot
+        const previousMemberBlock = await buildBlock(
+            knownParticipant,
+            latestBlock.stateSnapshotHash
+        );
+        const previousSnapshotMember = String(
+            await validationService.isBlockAuthorParticipant(
+                previousMemberBlock,
+                channelId
+            )
+        );
+
+        // author absent from the previous snapshot, but present in a
+        // resulting snapshot bound to this block's own coordinates
+        const matchingSnapshot = buildSnapshot([outsider], nextHeight, forkId);
+        this.sm.storage.stateSnapshots.storeStateSnapshot(matchingSnapshot);
+        const matchingBlock = await buildBlock(outsider, matchingSnapshot.hash);
+        const matchingResultingSnapshotMember = String(
+            await validationService.isBlockAuthorParticipant(
+                matchingBlock,
+                channelId
+            )
+        );
+
+        // same outsider, but the named snapshot belongs to a different
+        // height - an ex-member's stale snapshot
+        const staleSnapshot = buildSnapshot(
+            [outsider],
+            nextHeight + 100,
+            forkId
+        );
+        this.sm.storage.stateSnapshots.storeStateSnapshot(staleSnapshot);
+        const staleBlock = await buildBlock(outsider, staleSnapshot.hash);
+        const staleResultingSnapshotMember = String(
+            await validationService.isBlockAuthorParticipant(
+                staleBlock,
+                channelId
+            )
+        );
+
+        // no locally-anchored previous snapshot for the block's coordinates
+        // -> falls back to the on-chain participant set
+        const unknownForkId = id("probeBlockAuthorParticipant-unknown-fork");
+        const knownParticipantFallbackBlock = await buildBlock(
+            knownParticipant,
+            ethers.ZeroHash,
+            { forkId: unknownForkId, height: 1 }
+        );
+        const noLocalAnchorKnownParticipant = String(
+            await validationService.isBlockAuthorParticipant(
+                knownParticipantFallbackBlock,
+                channelId
+            )
+        );
+        const outsiderFallbackBlock = await buildBlock(
+            outsider,
+            ethers.ZeroHash,
+            { forkId: unknownForkId, height: 1 }
+        );
+        const noLocalAnchorUnknownAddress = String(
+            await validationService.isBlockAuthorParticipant(
+                outsiderFallbackBlock,
+                channelId
+            )
+        );
+
+        return {
+            previousSnapshotMember,
+            matchingResultingSnapshotMember,
+            staleResultingSnapshotMember,
+            noLocalAnchorKnownParticipant,
+            noLocalAnchorUnknownAddress
         };
     }
 

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -103,6 +103,10 @@ export type BlockAuthorParticipantProbe = {
      *  exists but belongs to a different height (a stale/ex-member snapshot)
      *  -> not a participant */
     staleResultingSnapshotMember: string;
+    /** author absent from the previous snapshot; the named resulting snapshot
+     *  exists and matches the block's height but belongs to a different fork
+     *  (a stale/ex-member snapshot) -> not a participant */
+    wrongForkResultingSnapshotMember: string;
     /** no locally-anchored previous snapshot for the block's coordinates ->
      *  falls back to the on-chain participant set; author is a real
      *  on-chain participant -> participant */
@@ -526,6 +530,26 @@ export class StubService extends ARpcService<
             )
         );
 
+        // same outsider, but the named snapshot belongs to a different fork
+        // at the same height - an ex-member's stale snapshot
+        const wrongForkId = id("probeBlockAuthorParticipant-wrong-fork");
+        const wrongForkSnapshot = buildSnapshot(
+            [outsider],
+            nextHeight,
+            wrongForkId
+        );
+        this.sm.storage.stateSnapshots.storeStateSnapshot(wrongForkSnapshot);
+        const wrongForkBlock = await buildBlock(
+            outsider,
+            wrongForkSnapshot.hash
+        );
+        const wrongForkResultingSnapshotMember = String(
+            await validationService.isBlockAuthorParticipant(
+                wrongForkBlock,
+                channelId
+            )
+        );
+
         // no locally-anchored previous snapshot for the block's coordinates
         // -> falls back to the on-chain participant set
         const unknownForkId = id("probeBlockAuthorParticipant-unknown-fork");
@@ -556,6 +580,7 @@ export class StubService extends ARpcService<
             previousSnapshotMember,
             matchingResultingSnapshotMember,
             staleResultingSnapshotMember,
+            wrongForkResultingSnapshotMember,
             noLocalAnchorKnownParticipant,
             noLocalAnchorUnknownAddress
         };

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -9,7 +9,8 @@ import DisputeValidationStrategy from "@/stateManager/validationStrategy/Dispute
 import { BlockValidationResult } from "@/types";
 import { Block, StateSnapshot } from "@/models";
 import * as factory from "@test/factory";
-import type { Address, ChannelId, ForkId, Hash } from "@/types/types";
+import { recordValidationBoundary } from "./RecordingValidationStrategy";
+import type { Address, ForkId, Hash } from "@/types/types";
 
 // `ATransport` is used both for `createRPCMethods` and the captured transport.
 
@@ -90,30 +91,6 @@ export type MissingParticipantSnapshotsProbe = {
     earlyAuthorResult: string;
     signatureUnionResult: string;
     proofStored: boolean;
-};
-
-export type BlockAuthorParticipantProbe = {
-    /** author already in the previous snapshot -> participant */
-    previousSnapshotMember: string;
-    /** author absent from the previous snapshot but present in a resulting
-     *  snapshot whose (forkId, height) match the block's own coordinates ->
-     *  participant */
-    matchingResultingSnapshotMember: string;
-    /** author absent from the previous snapshot; the named resulting snapshot
-     *  exists but belongs to a different height (a stale/ex-member snapshot)
-     *  -> not a participant */
-    staleResultingSnapshotMember: string;
-    /** author absent from the previous snapshot; the named resulting snapshot
-     *  exists and matches the block's height but belongs to a different fork
-     *  (a stale/ex-member snapshot) -> not a participant */
-    wrongForkResultingSnapshotMember: string;
-    /** no locally-anchored previous snapshot for the block's coordinates ->
-     *  falls back to the on-chain participant set; author is a real
-     *  on-chain participant -> participant */
-    noLocalAnchorKnownParticipant: string;
-    /** same on-chain fallback, author is an unrelated address -> not a
-     *  participant */
-    noLocalAnchorUnknownAddress: string;
 };
 
 /**
@@ -423,167 +400,183 @@ export class StubService extends ARpcService<
         };
     }
 
-    public async probeBlockAuthorParticipant(): Promise<BlockAuthorParticipantProbe> {
-        const validationService = this.sm.validationService as unknown as {
-            isBlockAuthorParticipant: (
-                block: Block,
-                channelId: ChannelId
-            ) => Promise<boolean>;
+    private async runAuthorGate(
+        author: Address,
+        stateSnapshotHash: Hash,
+        coordinates?: { forkId: ForkId; height: number }
+    ): Promise<string> {
+        const head = this.sm.storage.blocks.getLatestBlock(this.sm.forkId);
+        if (!head) throw new Error("Expected a latest block");
+
+        const blockStruct = {
+            ...factory.blockStructWithTransactionHeader(head.blockStruct, {
+                participant: author,
+                transactionCnt: coordinates?.height ?? head.height + 1,
+                forkId: coordinates?.forkId ?? this.sm.forkId
+            }),
+            previousBlockHash: head.hash,
+            stateSnapshotHash
         };
+        const block = await Block.fromBlockStruct(blockStruct, this.sm.signer);
 
-        const forkId = this.sm.forkId;
-        const channelId = this.sm.channelId;
-        const latestBlock = this.sm.storage.blocks.getLatestBlock(forkId);
-        if (!latestBlock) throw new Error("Expected a latest block");
-
-        const previousSnapshot =
-            this.sm.storage.stateSnapshots.getStateSnapshotByHash(
-                latestBlock.stateSnapshotHash
+        const { strategy, result } = recordValidationBoundary(
+            this.sm.blockValidationStrategy
+        );
+        await this.sm.validationService.validateBlockConfirmation(
+            this.sm.storage.queues.createEntry(block),
+            strategy
+        );
+        // the staged blocks always target the live, open channel - stopping
+        // this early means the staging broke, not that the gate decided
+        if (["wrongChannel", "channelNotOpened"].includes(result.reached)) {
+            throw new Error(
+                `author-gate probe stopped at ${result.reached}, before the gate`
             );
-        if (!previousSnapshot) {
-            throw new Error("Expected the latest block's snapshot");
         }
-        const knownParticipant = previousSnapshot.snapshotData
-            .participants[0] as Address;
-        const outsider = ethers.Wallet.createRandom().address as Address;
-        const nextHeight = latestBlock.height + 1;
+        return result.reached;
+    }
 
-        const buildSnapshot = (
-            participants: Address[],
-            height: number,
-            snapshotForkId: ForkId
-        ) =>
-            StateSnapshot.from({
-                forkId: snapshotForkId,
-                blockHeight: BigInt(height),
-                timestamp: 0n,
-                snapshotData: {
-                    originForkId: ethers.ZeroHash,
-                    stateMachineStateHash: ethers.ZeroHash,
-                    participants,
-                    latestInboundMessageBlockHash: ethers.ZeroHash,
-                    latestInboundMessageBlockHeight: 0n,
-                    latestOutboundMessageBlockHash: ethers.ZeroHash,
-                    latestOutboundMessageBlockHeight: 0n,
-                    totalDeposits: { amount: 0n, data: "0x" },
-                    totalWithdrawals: { amount: 0n, data: "0x" }
-                }
-            });
+    /** The head block's own resulting snapshot - the anchor the gate binds against. */
+    private previousSnapshot(): StateSnapshot {
+        const head = this.sm.storage.blocks.getLatestBlock(this.sm.forkId);
+        if (!head) throw new Error("Expected a latest block");
+        const snapshot = this.sm.storage.stateSnapshots.getStateSnapshotByHash(
+            head.stateSnapshotHash
+        );
+        if (!snapshot) throw new Error("Expected the latest block's snapshot");
+        return snapshot;
+    }
 
-        const buildBlock = (
-            participant: Address,
-            stateSnapshotHash: Hash,
-            overrides?: { forkId?: ForkId; height?: number }
-        ) => {
-            const blockStruct = {
-                ...factory.blockStructWithTransactionHeader(
-                    latestBlock.blockStruct,
-                    {
-                        participant,
-                        transactionCnt: overrides?.height ?? nextHeight,
-                        forkId: overrides?.forkId ?? forkId
-                    }
-                ),
-                previousBlockHash: latestBlock.hash,
-                stateSnapshotHash
-            };
-            return Block.fromBlockStruct(blockStruct, this.sm.signer);
-        };
+    /** Store a snapshot listing `participants` at the given coordinates. */
+    private storeSnapshotAt(
+        participants: Address[],
+        height: number,
+        forkId: ForkId = this.sm.forkId
+    ): Hash {
+        const snapshot = factory.stateSnapshot({
+            forkId,
+            blockHeight: height,
+            timestamp: 0,
+            snapshotData: factory.snapshotData({ participants })
+        });
+        this.sm.storage.stateSnapshots.storeStateSnapshot(snapshot);
+        return snapshot.hash;
+    }
 
-        // author already a participant in the (real) previous snapshot
-        const previousMemberBlock = await buildBlock(
-            knownParticipant,
-            latestBlock.stateSnapshotHash
-        );
-        const previousSnapshotMember = String(
-            await validationService.isBlockAuthorParticipant(
-                previousMemberBlock,
-                channelId
-            )
-        );
+    private nextHeight(): number {
+        const head = this.sm.storage.blocks.getLatestBlock(this.sm.forkId);
+        if (!head) throw new Error("Expected a latest block");
+        return head.height + 1;
+    }
 
-        // author absent from the previous snapshot, but present in a
-        // resulting snapshot bound to this block's own coordinates
-        const matchingSnapshot = buildSnapshot([outsider], nextHeight, forkId);
-        this.sm.storage.stateSnapshots.storeStateSnapshot(matchingSnapshot);
-        const matchingBlock = await buildBlock(outsider, matchingSnapshot.hash);
-        const matchingResultingSnapshotMember = String(
-            await validationService.isBlockAuthorParticipant(
-                matchingBlock,
-                channelId
-            )
-        );
+    private randomAddress(): Address {
+        return ethers.Wallet.createRandom().address as Address;
+    }
 
-        // same outsider, but the named snapshot belongs to a different
-        // height - an ex-member's stale snapshot
-        const staleSnapshot = buildSnapshot(
-            [outsider],
-            nextHeight + 100,
-            forkId
-        );
-        this.sm.storage.stateSnapshots.storeStateSnapshot(staleSnapshot);
-        const staleBlock = await buildBlock(outsider, staleSnapshot.hash);
-        const staleResultingSnapshotMember = String(
-            await validationService.isBlockAuthorParticipant(
-                staleBlock,
-                channelId
-            )
-        );
-
-        // same outsider, but the named snapshot belongs to a different fork
-        // at the same height - an ex-member's stale snapshot
-        const wrongForkId = id("probeBlockAuthorParticipant-wrong-fork");
-        const wrongForkSnapshot = buildSnapshot(
-            [outsider],
-            nextHeight,
-            wrongForkId
-        );
-        this.sm.storage.stateSnapshots.storeStateSnapshot(wrongForkSnapshot);
-        const wrongForkBlock = await buildBlock(
-            outsider,
-            wrongForkSnapshot.hash
-        );
-        const wrongForkResultingSnapshotMember = String(
-            await validationService.isBlockAuthorParticipant(
-                wrongForkBlock,
-                channelId
-            )
-        );
-
-        // no locally-anchored previous snapshot for the block's coordinates
-        // -> falls back to the on-chain participant set
-        const unknownForkId = id("probeBlockAuthorParticipant-unknown-fork");
-        const knownParticipantFallbackBlock = await buildBlock(
-            knownParticipant,
-            ethers.ZeroHash,
-            { forkId: unknownForkId, height: 1 }
-        );
-        const noLocalAnchorKnownParticipant = String(
-            await validationService.isBlockAuthorParticipant(
-                knownParticipantFallbackBlock,
-                channelId
-            )
-        );
-        const outsiderFallbackBlock = await buildBlock(
-            outsider,
-            ethers.ZeroHash,
-            { forkId: unknownForkId, height: 1 }
-        );
-        const noLocalAnchorUnknownAddress = String(
-            await validationService.isBlockAuthorParticipant(
-                outsiderFallbackBlock,
-                channelId
-            )
-        );
-
+    /** Coordinates with no locally-anchored previous snapshot. */
+    private unanchoredCoordinates() {
         return {
-            previousSnapshotMember,
-            matchingResultingSnapshotMember,
-            staleResultingSnapshotMember,
-            wrongForkResultingSnapshotMember,
-            noLocalAnchorKnownParticipant,
-            noLocalAnchorUnknownAddress
+            forkId: id("probeAuthorGate-unknown-fork") as ForkId,
+            height: 1
         };
+    }
+
+    /** Author already listed in the previous snapshot. */
+    public async probeAuthorGatePreviousSnapshotMember(): Promise<string> {
+        const previous = this.previousSnapshot();
+        const member = previous.snapshotData.participants[0] as Address;
+        const head = this.sm.storage.blocks.getLatestBlock(this.sm.forkId)!;
+        return this.runAuthorGate(member, head.stateSnapshotHash);
+    }
+
+    /** Author only in a resulting snapshot bound to the block's own coordinates. */
+    public async probeAuthorGateMatchingResultingSnapshot(): Promise<string> {
+        const outsider = this.randomAddress();
+        const snapshotHash = this.storeSnapshotAt(
+            [outsider],
+            this.nextHeight()
+        );
+        return this.runAuthorGate(outsider, snapshotHash);
+    }
+
+    /** Author only in a resulting snapshot from a different height. */
+    public async probeAuthorGateStaleHeightSnapshot(): Promise<string> {
+        const outsider = this.randomAddress();
+        const snapshotHash = this.storeSnapshotAt(
+            [outsider],
+            this.nextHeight() + 100
+        );
+        return this.runAuthorGate(outsider, snapshotHash);
+    }
+
+    /** Author only in a resulting snapshot from a different fork, same height. */
+    public async probeAuthorGateWrongForkSnapshot(): Promise<string> {
+        const outsider = this.randomAddress();
+        const snapshotHash = this.storeSnapshotAt(
+            [outsider],
+            this.nextHeight(),
+            id("probeAuthorGate-wrong-fork") as ForkId
+        );
+        return this.runAuthorGate(outsider, snapshotHash);
+    }
+
+    /** Resulting snapshot matches the coordinates but omits the author. */
+    public async probeAuthorGateMatchingSnapshotExcludingAuthor(): Promise<string> {
+        const outsider = this.randomAddress();
+        const snapshotHash = this.storeSnapshotAt(
+            [this.randomAddress()],
+            this.nextHeight()
+        );
+        return this.runAuthorGate(outsider, snapshotHash);
+    }
+
+    /** Declared resulting snapshot absent from storage; author is in the previous one. */
+    public async probeAuthorGateMissingSnapshotPreviousMember(): Promise<string> {
+        const member = this.previousSnapshot().snapshotData
+            .participants[0] as Address;
+        return this.runAuthorGate(
+            member,
+            id("probeAuthorGate-unstored-result") as Hash
+        );
+    }
+
+    /** Declared resulting snapshot absent from storage; author is an outsider. */
+    public async probeAuthorGateMissingSnapshotOutsider(): Promise<string> {
+        return this.runAuthorGate(
+            this.randomAddress(),
+            id("probeAuthorGate-unstored-result") as Hash
+        );
+    }
+
+    /** No local anchor; author is a current on-chain participant. */
+    public async probeAuthorGateNoAnchorCurrentParticipant(): Promise<string> {
+        const member = this.previousSnapshot().snapshotData
+            .participants[0] as Address;
+        return this.runAuthorGate(
+            member,
+            ethers.ZeroHash as Hash,
+            this.unanchoredCoordinates()
+        );
+    }
+
+    /** No local anchor; author is a pending (not-yet-current) on-chain participant. */
+    public async probeAuthorGateNoAnchorPendingParticipant(
+        pendingParticipant: Address
+    ): Promise<string> {
+        return this.runAuthorGate(
+            pendingParticipant,
+            ethers.ZeroHash as Hash,
+            this.unanchoredCoordinates()
+        );
+    }
+
+    /** No local anchor; author is unrelated to the channel. */
+    public async probeAuthorGateNoAnchorUnknownAddress(): Promise<string> {
+        return this.runAuthorGate(
+            this.randomAddress(),
+            ethers.ZeroHash as Hash,
+            this.unanchoredCoordinates()
+        );
     }
 
     public createRPCMethods(transport: ATransport): StubRpcMethods {

--- a/test/harness/actions/ByzantineActions.ts
+++ b/test/harness/actions/ByzantineActions.ts
@@ -304,4 +304,57 @@ export class ByzantineActions<
             ) as string
         };
     }
+
+    /**
+     * Craft the next block authored + signed by `author`, but declaring the
+     * state-snapshot hash of the block at `staleSnapshotHeight` instead of the
+     * head's.
+     */
+    async craftStaleMembershipBlockConfirmation(
+        sourcePeerIndex: number,
+        forkId: ForkId,
+        author: Signer,
+        staleSnapshotHeight: BlockHeight
+    ): Promise<{ encodedBlockConfirmation: string }> {
+        const source = this.harness.control(
+            this.harness.getPeer(sourcePeerIndex)
+        );
+        const headBundle = await source.query
+            .getLatestBlockBundle(forkId)
+            .request();
+        const staleBundle = await source.query
+            .getBlockByHeight(forkId, staleSnapshotHeight)
+            .request();
+        if (!headBundle) throw new Error("missing head block");
+        if (!staleBundle)
+            throw new Error(
+                `missing block at stale height ${staleSnapshotHeight}`
+            );
+
+        const head = Block.fromSignedBlock(
+            Codec.decode(headBundle.encodedSignedBlock, Type.SignedBlock)
+        );
+        const stale = Block.fromSignedBlock(
+            Codec.decode(staleBundle.encodedSignedBlock, Type.SignedBlock)
+        );
+        const authorAddress = (await author.getAddress()) as Address;
+        const nextBlockStruct = {
+            ...factory.blockStructWithTransactionHeader(head.blockStruct, {
+                participant: authorAddress,
+                transactionCnt: Number(head.height) + 1
+            }),
+            previousBlockHash: headBundle.hash,
+            // the lever: a snapshot whose participant set still contains `author`
+            stateSnapshotHash: stale.stateSnapshotHash
+        };
+        const staleSignedBlock = (
+            await Block.fromBlockStruct(nextBlockStruct, author)
+        ).signedBlock;
+        return {
+            encodedBlockConfirmation: Codec.encode(
+                { signedBlock: staleSignedBlock, signatures: [] },
+                Type.BlockConfirmation
+            ) as string
+        };
+    }
 }

--- a/test/stateManager/ValidationService.test.ts
+++ b/test/stateManager/ValidationService.test.ts
@@ -26,6 +26,10 @@ describe("ValidationService - isBlockAuthorParticipant", function () {
             "author in a resulting snapshot from a different height must not count"
         ).to.equal("false");
         expect(
+            probe.wrongForkResultingSnapshotMember,
+            "author in a resulting snapshot from a different fork at the same height must not count"
+        ).to.equal("false");
+        expect(
             probe.noLocalAnchorKnownParticipant,
             "with no local anchor, a real on-chain participant falls back to the on-chain union"
         ).to.equal("true");

--- a/test/stateManager/ValidationService.test.ts
+++ b/test/stateManager/ValidationService.test.ts
@@ -1,41 +1,91 @@
 import { expect } from "chai";
 
+import { Status } from "@/types";
 import { MathTestSession as TestSession } from "@test/harness";
 
-describe("ValidationService - isBlockAuthorParticipant", function () {
-    it("binds the resulting snapshot to the block's own coordinates", async function () {
+const AUTHOR_GATE = "blockAuthorIsNotParticipant";
+
+describe("ValidationService - block author participant gate", function () {
+    it("binds the author to the previous snapshot and to a coordinate-matched resulting snapshot", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(4, 0);
         await h.transition.advanceState();
+        const peer = h.control(h.getPeer(0));
 
-        const probe = await h
-            .control(h.getPeer(0))
-            .stub.probeBlockAuthorParticipant()
+        expect(
+            await peer.stub.probeAuthorGatePreviousSnapshotMember().request(),
+            "author listed in the previous snapshot is accepted"
+        ).to.not.equal(AUTHOR_GATE);
+
+        expect(
+            await peer.stub
+                .probeAuthorGateMatchingResultingSnapshot()
+                .request(),
+            "author in a resulting snapshot bound to the block's own coordinates is accepted"
+        ).to.not.equal(AUTHOR_GATE);
+
+        expect(
+            await peer.stub.probeAuthorGateStaleHeightSnapshot().request(),
+            "author whose only snapshot is from a different height is rejected"
+        ).to.equal(AUTHOR_GATE);
+
+        expect(
+            await peer.stub.probeAuthorGateWrongForkSnapshot().request(),
+            "author whose only snapshot is from a different fork is rejected"
+        ).to.equal(AUTHOR_GATE);
+
+        expect(
+            await peer.stub
+                .probeAuthorGateMatchingSnapshotExcludingAuthor()
+                .request(),
+            "author absent from a coordinate-matched snapshot is rejected"
+        ).to.equal(AUTHOR_GATE);
+
+        expect(
+            await peer.stub
+                .probeAuthorGateMissingSnapshotPreviousMember()
+                .request(),
+            "missing declared snapshot falls back to the previous snapshot, which lists the author"
+        ).to.not.equal(AUTHOR_GATE);
+
+        expect(
+            await peer.stub.probeAuthorGateMissingSnapshotOutsider().request(),
+            "missing declared snapshot rejects an author the previous snapshot omits"
+        ).to.equal(AUTHOR_GATE);
+
+        expect(
+            await peer.stub
+                .probeAuthorGateNoAnchorCurrentParticipant()
+                .request(),
+            "with no local anchor, a current on-chain participant is accepted"
+        ).to.not.equal(AUTHOR_GATE);
+
+        expect(
+            await peer.stub.probeAuthorGateNoAnchorUnknownAddress().request(),
+            "with no local anchor, an unrelated address is rejected"
+        ).to.equal(AUTHOR_GATE);
+
+        // a real pending participant: joined on-chain but not yet in the
+        // current set, so only the pending half of the union can admit it
+        const joiner = await h.join.addSpectatorWait();
+        await h.join.joinChannelWait({ joiner });
+        expect(
+            await h.control(joiner).query.getStatus().request(),
+            "joiner is a pending participant"
+        ).to.equal(Status.PENDING_PARTICIPANT);
+        const currentParticipants = await peer.query
+            .getParticipants()
             .request();
+        expect(
+            currentParticipants.map((p) => p.toLowerCase()),
+            "joiner is not yet in the current participant set"
+        ).to.not.include(joiner.address.toLowerCase());
 
         expect(
-            probe.previousSnapshotMember,
-            "author already in the previous snapshot counts as a participant"
-        ).to.equal("true");
-        expect(
-            probe.matchingResultingSnapshotMember,
-            "author in a resulting snapshot bound to the block's own coordinates counts"
-        ).to.equal("true");
-        expect(
-            probe.staleResultingSnapshotMember,
-            "author in a resulting snapshot from a different height must not count"
-        ).to.equal("false");
-        expect(
-            probe.wrongForkResultingSnapshotMember,
-            "author in a resulting snapshot from a different fork at the same height must not count"
-        ).to.equal("false");
-        expect(
-            probe.noLocalAnchorKnownParticipant,
-            "with no local anchor, a real on-chain participant falls back to the on-chain union"
-        ).to.equal("true");
-        expect(
-            probe.noLocalAnchorUnknownAddress,
-            "with no local anchor, an unrelated address is not a participant"
-        ).to.equal("false");
+            await peer.stub
+                .probeAuthorGateNoAnchorPendingParticipant(joiner.address)
+                .request(),
+            "with no local anchor, a pending on-chain participant is accepted via the current+pending union"
+        ).to.not.equal(AUTHOR_GATE);
     });
 });

--- a/test/stateManager/ValidationService.test.ts
+++ b/test/stateManager/ValidationService.test.ts
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+
+import { MathTestSession as TestSession } from "@test/harness";
+
+describe("ValidationService - isBlockAuthorParticipant", function () {
+    it("binds the resulting snapshot to the block's own coordinates", async function () {
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(4, 0);
+        await h.transition.advanceState();
+
+        const probe = await h
+            .control(h.getPeer(0))
+            .stub.probeBlockAuthorParticipant()
+            .request();
+
+        expect(
+            probe.previousSnapshotMember,
+            "author already in the previous snapshot counts as a participant"
+        ).to.equal("true");
+        expect(
+            probe.matchingResultingSnapshotMember,
+            "author in a resulting snapshot bound to the block's own coordinates counts"
+        ).to.equal("true");
+        expect(
+            probe.staleResultingSnapshotMember,
+            "author in a resulting snapshot from a different height must not count"
+        ).to.equal("false");
+        expect(
+            probe.noLocalAnchorKnownParticipant,
+            "with no local anchor, a real on-chain participant falls back to the on-chain union"
+        ).to.equal("true");
+        expect(
+            probe.noLocalAnchorUnknownAddress,
+            "with no local anchor, an unrelated address is not a participant"
+        ).to.equal("false");
+    });
+});


### PR DESCRIPTION
a participant that leaves the channel stays connected to the p2p network, and
state snapshots are keyed by hash and never pruned (`StateSnapshotStorage`) -> a
departed member can author a block whose `stateSnapshotHash` points at a snapshot
from while it was still a member.

`ValidationService`'s author gate unions the previous snapshot with the block's
declared resulting snapshot, so it re-admits the ex-member as a participant. the
block then reaches the leader check, fails `nextLeader !== author`, and
`SpectatingValidationStrategy` treats it as provable participant fraud ->
`abort()` -> the spectator goes offline (SYNCED -> OPENED).

fix binds the declared snapshot to the block's own coordinates (forkId + height),