### PR TITLE
chore: retire stale TODOs, remove dead code, and ship unhandled browser errors

### DIFF
--- a/contracts/V1/AStateMachine.sol
+++ b/contracts/V1/AStateMachine.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.8.8;
 
 import "./types/DataTypes.sol";
 import "./types/MessageTypeHashes.sol";
-import "hardhat/console.sol";
 
 abstract contract AStateMachine {
     Transaction _tx; // This should be used instead of msg.sender at least for now
@@ -103,11 +102,6 @@ abstract contract AStateMachine {
 
     function _clearOutboundMessages() internal {
         delete _outboundMessages;
-        // TODO - pop loop since for some reason sometimes delete doesn't set length to 0
-        while (_outboundMessages.length > 0) {
-            _outboundMessages.pop();
-        }
-        console.log("Clearing outbound messages. Count after clear:", _outboundMessages.length);
     }
 
     function setState(bytes memory encodedState) external _nonReentrant {
@@ -157,7 +151,6 @@ abstract contract AStateMachine {
             }
         }
         Message[] memory recordedMessages = new Message[](_outboundMessages.length);
-        console.log("Recorded outbound messages count:", _outboundMessages.length);
         for (uint256 i = 0; i < _outboundMessages.length; i++) {
             recordedMessages[i] = _outboundMessages[i];
         }

--- a/contracts/V1/StateChannelDiamondProxy/DisputeFraudProofFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeFraudProofFacet.sol
@@ -280,7 +280,7 @@ contract DisputeFraudProofFacet is StateChannelCommon {
     {
         DisputeInvalidStateProof memory proof = abi.decode(encodedFraudProof, (DisputeInvalidStateProof));
 
-        // TODO extract this into its own fraud proof and test it
+        // TODO extract genesis-fork linking, signed-block linking, and latest-state checks into fraud proofs
         if (!dispute.postedAuditingData) {
             // fraud prover supplies the genesis reference -> it must be linked to the fork
             if (!_isGenesisSnapshotDataLinkedToFork(dispute.input.forkId, proof.auditingData.genesisStateSnapshotData))

--- a/contracts/V1/StateChannelDiamondProxy/DisputeVerificationFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeVerificationFacet.sol
@@ -419,15 +419,6 @@ contract DisputeVerificationFacet is StateChannelCommon {
 
     // =============================== State Proofs Verification  ===============================
 
-    function _isCorrectGenesis(Dispute memory dispute) internal view returns (bool) {
-        (bool hasBlock, Block memory latestBlock) = _getLatestBlock(dispute.input.stateProof);
-        if (!hasBlock) {
-            //no blocks in state proof - must be genesis
-            return true; // TODO This will be a dispute fraud proof, since the dispute struct doesn't have enough information to deduct this
-        }
-        return _areDisputeAndBlockSameFork(dispute, latestBlock);
-    }
-
     function _verifyDisputeOutboundMessageBlocks(DisputeAuditingData memory disputeAuditingData)
         internal
         view

--- a/contracts/V1/StateChannelDiamondProxy/StateProofFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateProofFacet.sol
@@ -246,6 +246,7 @@ contract StateProofFacet is StateChannelCommon {
         address[] memory expectedParticipants,
         MilestoneProof memory milestone
     ) internal view returns (bool isFinal, bytes32 finalizedSnapshotHash) {
+        // TODO - need a gas limit on verifyMilestone and on verifyStateProof, so large proofs that can't be verified won't be spammed
         address[] memory thresholdSet = new address[](expectedParticipants.length);
         uint256 thresholdCount = 0;
         bytes memory previousEncodedBlock;
@@ -292,7 +293,6 @@ contract StateProofFacet is StateChannelCommon {
             }
             bool isParticipant = UtilityFacet(utilityFacetAddress).isAddressInArray(expectedParticipants, adr);
             if (isParticipant) {
-                // TODO - need a gas limit on verifyMilestone and on verifyStateProof, so large proofs that can't be verified won't be spamed
                 thresholdCount =
                     _tryInsertAddressInThresholdSet(adr, thresholdSet, thresholdCount, expectedParticipants);
             }
@@ -307,7 +307,6 @@ contract StateProofFacet is StateChannelCommon {
                 }
                 isParticipant = UtilityFacet(utilityFacetAddress).isAddressInArray(expectedParticipants, adr);
                 if (isParticipant) {
-                    // TODO - need a gas limit on verifyMilestone and on verifyStateProof, so large proofs that can't be verified won't be spamed
                     thresholdCount =
                         _tryInsertAddressInThresholdSet(adr, thresholdSet, thresholdCount, expectedParticipants);
                 }

--- a/docs/tests/todo.md
+++ b/docs/tests/todo.md
@@ -5,29 +5,32 @@ PR #384 fixes). Each needs a real dispute + on-chain reduction staged determinis
 dispute-heavy class that flakes on the sandbox (the harness stalls under load and tests fail for
 environmental reasons, not logic). They're better authored/run on a machine that can sustain the load.
 
-Source of the behaviours under test: `temp/pr/1-block-queue-crdt-redesign/implementation-1.md`.
-
 ---
 
-## 1. A junk-block flood costs one recovery attempt, not one per block
+## 1. An N-block junk flood is gated to one kill-period read while unexpired, one recovery after expiry
 
-**Scenario.** Our own current fork is under an active dispute whose kill period has **not** yet expired.
-A byzantine peer then floods us with many block confirmations, each on a different bogus fork.
+**Scenario.** Our own current fork is under an active dispute. A byzantine peer floods us with many block
+confirmations, each on a different bogus fork — first while the dispute's kill period has **not** yet
+expired, then again after it expires.
 
 **Expected.** Our node must:
 
-- schedule only **one** background local-reduction attempt for our current fork (not one per incoming
-  block), and
-- make only **one** on-chain "is the kill period expired?" read per kill-period window (subsequent
-  incoming junk blocks reuse the cached answer, they do not each hit the chain).
+- **While unexpired:** schedule **zero** background local-reduction attempts across all N incoming blocks
+  (`maybeScheduleForkRecovery` returns after caching the suppression window when `isExpired` is false),
+  and make only **one** on-chain "is the kill period expired?" read (subsequent junk reuses the cached
+  answer, it does not each hit the chain).
+- **After expiry:** a further junk burst schedules exactly **one** coalesced local-reduction attempt for
+  the fork.
 
 **Why it matters.** Without the per-fork recovery gate + the kill-period cache, a flood would schedule a
-task and an on-chain read per junk block — an amplification vector. The gate and cache are in the code;
-this test is the end-to-end proof.
+task and an on-chain read per junk block — an amplification vector. The existing single-block test
+already proves one local reduction for one wrong-fork block; this test must prove the N-block gate (no
+recovery while suppressed), the cached kill-period read, and the single coalesced recovery after expiry.
 
-**How to stage.** Put the node's current fork into dispute (kill period not yet expired), stub the
+**How to stage.** Put the node's current fork into dispute with the kill period not yet expired; stub the
 recovery reduction to a no-op that counts calls, and count on-chain kill-period reads. Ingest N distinct
-bogus-fork blocks. Assert: scheduled-recovery count == 1 and kill-period-read count == 1.
+bogus-fork blocks and assert scheduled-recovery count == 0 and kill-period-read count == 1. Then advance
+past kill-period expiry, ingest another junk burst, and assert exactly one coalesced recovery is scheduled.
 
 ---
 
@@ -78,12 +81,14 @@ author is never blacklisted, the node stays connected to it, and the block is pr
 
 ## Preferred minimum before merge (host-side, not full dispute e2e)
 
-Test #1 above (junk-flood → one recovery attempt / one kill-period read) is the DoS invariant this
-redesign introduces. A lighter, more deterministic **host-side** integration check (via `execOnHost`,
-in the style of the existing `E2E-BlockQueueManager` "never validates…" test) would pin it without the
-full dispute pipeline: stub `isForkDisputed` → true for the current fork, count `isKillPeriodExpired`
-chain reads and scheduled `runForkRecovery` tasks while ingesting N distinct bogus-fork blocks, and
-assert both counts == 1. Same idea can pin the B6 kill-period cache (N kicks → 1 chain read).
+Test #1 above (junk-flood gated to one kill-period read while unexpired, one recovery after expiry) is
+the DoS invariant this redesign introduces. A lighter, more deterministic **host-side** integration check
+(via `execOnHost`, in the style of the existing `E2E-BlockQueueManager` "never validates…" test) would
+pin it without the full dispute pipeline: stub `isForkDisputed` → true for the current fork, count
+`isKillPeriodExpired` chain reads and scheduled `runForkRecovery` tasks while ingesting N distinct
+bogus-fork blocks. While the kill period is unexpired, assert one chain read and zero recoveries; after
+advancing past expiry, ingest another burst and assert one coalesced recovery. Same idea can pin the B6
+kill-period cache (N kicks → 1 chain read).
 
 ## Follow-up: CRDT attribution ordering (not shipped)
 
@@ -98,6 +103,6 @@ purely for attribution/punishment. Deferred alongside the future rate-limiter.
 ## Accepted AGENTS exception (user-approved)
 
 The three e2e scenarios above are peer-observable `src/` behavior; AGENTS asks for same-pass e2e. They
-are **deferred by explicit user (Luka) acceptance** because they need real dispute + on-chain reduction
+are **deferred by explicit user acceptance** because they need real dispute + on-chain reduction
 staging that trips the sandbox event-loop watchdog, producing environmental (not logic) failures. Run
-condition: a machine that can sustain `test:parallel` without watchdog throttling (Luka's box).
+condition: a machine that can sustain `test:parallel` without watchdog throttling.

--- a/src/P2PManager.ts
+++ b/src/P2PManager.ts
@@ -34,7 +34,7 @@ class P2PManager<TCustomRpc extends MainRpcService = MainRpcService>
     remoteRpc: RemoteRpcProxyType<TCustomRpc>;
     /** In-process transport used for "send to self" (no-target) delivery. */
     loopbackTransport: LoopbackTransport;
-    //TODO - map EVM address to websocket
+    // TODO - route WebRTCSetupService and LocalDiscoveryServer scans through ProfileManager
     openConnections: ATransport[] = [];
     holepunch: Holepunch;
     self = config.DEBUG_P2P_MANAGER ? DebugProxy.createProxy(this) : this;

--- a/src/disputeManager/DisputeManager.ts
+++ b/src/disputeManager/DisputeManager.ts
@@ -144,7 +144,7 @@ class DisputeManager {
             } else {
                 // no multicall - upload dispute separately
                 if (shouldPostAuditingData) {
-                    // TODO - do the actual check (_isAuditingCalldataRequired) when we have early finalization implemented
+                    // TODO - revisit postedAuditingData under early finalization
                     txResponse =
                         await this.stateChannelManagerContract.uploadDisputeWithCalldata(
                             disputeConfirmation,

--- a/src/eventHandlers/EventHandler.ts
+++ b/src/eventHandlers/EventHandler.ts
@@ -109,7 +109,7 @@ export class EventHandler {
         channelId: ChannelId,
         stateSnapshot: StateSnapshotStruct
     ): Promise<void> {
-        //TODO - make sure snapshots are in ascending order if events can be collected in random order - e.g we have the latest one always
+        // TODO - gate this TS handler by ascending (blockNumber, logIndex); the local-EVM mirror already does
 
         const updatedSnapshot = StateSnapshot.from(stateSnapshot);
         const knownSnapshot =
@@ -119,7 +119,8 @@ export class EventHandler {
         if (!knownSnapshot) {
             const status = this.stateManager.getStatus();
             if (status === Status.SYNCED) {
-                // TODO: replace with general abort() once it exists outside spectate
+                // TODO: call stateManager.abort() here; it drops to OPENED and disposes,
+                // but no resync path exists yet.
 
                 this.logger.warn(
                     "onStateSnapshotUpdated - unknown snapshot while SYNCED, should abort + resync",
@@ -572,7 +573,6 @@ export class EventHandler {
             disputeConfirmation
         );
 
-        // this is like success - TODO - consider moving this to DisputeStrategy.success
         const canConstructMoreEvidence =
             await this.canConstructMoreEvidence(dispute);
         if (canConstructMoreEvidence) {
@@ -888,7 +888,6 @@ export class EventHandler {
         forkId: ForkId,
         reducedForkId: ForkId
     ): Promise<boolean> {
-        // TODO - extract this function since it's used in multiple places (e.g spectating RPC...)
         const disputes =
             await this.stateManager.reductionManager.getSyncedForkDisputes(
                 forkId

--- a/src/rpc/services/WebRTCSetup/WebRTCSetupService.ts
+++ b/src/rpc/services/WebRTCSetup/WebRTCSetupService.ts
@@ -180,7 +180,6 @@ class WebRTCSetupService extends ARpcService<WebRTCSetupRpcMethods> {
 
     //Ran by the peer who is initiating the connection - this creates the offer
     public async initiateWebRTC(transport: ATransport) {
-        //TODO! - require seccusfull init handshake (also on other methods)
         try {
             this.logger.debug("initiateWebRTC");
             const profileManager = this.p2pManager.profileManager;

--- a/src/rpc/services/initHandshake/InitHandshakeService.ts
+++ b/src/rpc/services/initHandshake/InitHandshakeService.ts
@@ -215,7 +215,6 @@ class InitHandshakeService extends ARpcService<InitHandshakeRpcMethods> {
             signerAddress
         });
         // Check if this peer is blacklisted
-        // TODO - we destory the profile, so we wouldn't have this information
         if (this.p2pManager.isBlacklisted(signerAddress)) {
             LoggerUtils.logInitHandshakeMessage(this.logger, transport, {
                 direction: "local",

--- a/src/stateManager/DisputeValidationService.ts
+++ b/src/stateManager/DisputeValidationService.ts
@@ -339,8 +339,6 @@ export default class DisputeValidationService {
 
         // isLatestState
 
-        // TODO
-        // should  this be  input.disputeAuditingDataHash or input.forkId??
         const result = this.agreementManager.getLatestSignedBlockByParticipant(
             dispute.input.forkId,
             dispute.input.disputer
@@ -420,7 +418,7 @@ export default class DisputeValidationService {
                 throw new Error(
                     "Timeout timestamp not found, dispute state not synced locally"
                 );
-            // TODO - this doesn't account for race condition (us not aware of on-chain calldata)
+            // TODO - cross-audit race: calldata may be posted after the kill decision
             const previousBlockOrSnapshot =
                 this.storage.getPreviousBlockOrSnapshot(cooridnates);
             let previousTimestamp = 0;

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -406,7 +406,6 @@ class StateManager<
         return this.signerAddress;
     }
     public getParticipantsCurrent(): Promise<Address[]> {
-        //TODO? this can be done through the AgreementManager for the given fork or thought the stateMachine
         return this.diamondStateMachine.getParticipants();
     }
     public get forkId(): ForkId {
@@ -490,7 +489,7 @@ class StateManager<
                     // TODO: support concurrent joins by collecting safe extra signatures before submission.
                     // Rethrown as CustomEvmError
                     this.abort();
-                    throw custom; //TODO - comunncate abort to the outside
+                    throw custom;
             }
             this.logger.warn("joinChannel - tx failed, reverting to SYNCED", {
                 error: error instanceof Error ? error.message : String(error)
@@ -1165,7 +1164,7 @@ class StateManager<
                 // their byzantine senders — continue with the valid ones.
             }
 
-            // TODO - apply strategy here too
+            // TODO - move DisputeValidationStrategy handling in success() behind a strategy hook
             // All validations passed - proceed with success action
             await this.success(
                 block,

--- a/src/stateManager/ValidationService.ts
+++ b/src/stateManager/ValidationService.ts
@@ -149,7 +149,6 @@ export default class ValidationService {
                 strategy: strategy.name,
                 block: LoggerUtils.getBlockMetadata(block, this.storage)
             });
-            // TODO -> here for the dispute strategy we can kill the dispute, since the stateProof comitted to the whole structure
             return await strategy.blockIsNotLinkedAndIsNotFirstBlock(entry);
         }
 

--- a/src/stateManager/validationStrategy/CalldataCommittedStrategy.ts
+++ b/src/stateManager/validationStrategy/CalldataCommittedStrategy.ts
@@ -129,7 +129,6 @@ export default class CalldataCommittedStrategy extends AValidationStrategy {
     public async blockIsNotLinkedAndIsNotFirstBlock(
         entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
-        // TODO - this one is anyoing since we have to treat this as `junk` even though peers are maybe colluding to perform a double sign or invalid state transition - we don't have the data for that
         // We have to FORCE TIMEOUT this - the force timeout challenge HAS TO require that presenting this calldata on-chain is linked to the dispute.StateProof for the disputeFraudProof to be accepted,
         // otherwise our dispute.StateProof will reveal information for the timeout peer to do a dispute containing a double sign or invalid state transition fraud proof, which when reduce will cancel the timeout
         return this.blockValidationStrategy.blockIsNotLinkedAndIsNotFirstBlock(

--- a/src/stateManager/validationStrategy/DisputeValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/DisputeValidationStrategy.ts
@@ -207,17 +207,14 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
         // Create and apply normal fraud proof to slash the offender + DEFER creating a new dispute - this dispute may still be honest, so continute validation
         this.fraudProofService.createDoubleSignProof(conflictingBlock, block);
         // TODO - apply the fraud proof without creating a new dispute
-        // await this.disputeManager.dispute(block.forkId);
         return BlockValidationResult.SUCCESS; // so we continue 'syncing' and checking new blocks
     }
     public async invalidStateTransitionDetected(
         block: Block
     ): Promise<BlockValidationResult> {
-        // TODO - here we have to kill the dispute, since the dispute contains incorrect state
         const hash =
             this.fraudProofService.createInvalidStateTransitionProof(block);
         this.createDisputeInvalidBlockInStateProofApplyFraudProof(hash);
-        // await this.disputeManager.dispute(block.forkId);
         return BlockValidationResult.DISPUTE;
     }
     public async wrongGenesisDetected(
@@ -236,10 +233,8 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
         ) {
             throw new Error("Unexpected genesisSnapshot missing");
         }
-        // TODO - here we have to kill the dispute, since the dispute contains incorrect state
         const hash = this.fraudProofService.createWrongGenesisProof(block);
         this.createDisputeInvalidBlockInStateProofApplyFraudProof(hash);
-        // await this.disputeManager.dispute(block.forkId);
         return BlockValidationResult.DISPUTE;
     }
     public async forgedInboundMessageBlockDetected(
@@ -281,11 +276,9 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
     public async objectiveInvalidTimestampDetected(
         block: Block
     ): Promise<BlockValidationResult> {
-        // TODO - here we have to kill the dispute, since the dispute contains incorrect state
         // TODO - think about this - can this change over time? i.e. can onChainTimestamp or the presence of calldata change things
         const hash = this.fraudProofService.createInvalidTimestampProof(block);
         this.createDisputeInvalidBlockInStateProofApplyFraudProof(hash);
-        // await this.disputeManager.dispute(block.forkId);
         return BlockValidationResult.DISPUTE;
     }
     public async subjectiveInvalidTimestampDetected(

--- a/src/transport/WebRTCTransport.ts
+++ b/src/transport/WebRTCTransport.ts
@@ -40,7 +40,6 @@ class WebRTCTransport extends ATransport {
         if (this.webRTCChannel.readyState === "open") {
             this.onChannelOpen();
         }
-        //TODO! update peerProfile and close old socket
     }
 
     private onChannelOpen(): void {

--- a/src/utils/logging/LogUploader.ts
+++ b/src/utils/logging/LogUploader.ts
@@ -23,6 +23,9 @@ export type LogUploaderOptions = {
 export type LogUploaderConfig = {
     uploadEndpoint: string;
     apiToken?: string;
+    // Fixed upload jitter in ms. Unset in production (random 0-3s); tests set it
+    // for a deterministic delay instead of stubbing Math.random.
+    jitterMs?: number;
 };
 
 export abstract class LogUploader {
@@ -67,21 +70,47 @@ export abstract class LogUploader {
         return Promise.resolve(undefined);
     }
 
-    public async uploadLogs(
-        unhandledError?: Error,
-        isUserInitiated = false
-    ): Promise<void> {
-        // TODO - use the above arguments
+    // Single owner of unhandled-error capture for both platforms (browser window
+    // events, node process events). Normalizes the reason safely, then logs it -
+    // Logger.error() stores it and schedules the upload. Redaction of the error
+    // graph happens once, in encodeLogEntry, so both crash paths stay in sync.
+    public captureUnhandled(reason: unknown, source: string): void {
+        const error =
+            reason instanceof Error
+                ? reason
+                : new Error(LogUploader.safeStringify(reason));
+        this.logger?.error(`Unhandled ${source} captured for log upload`, {
+            error
+        });
+    }
+
+    // A non-Error rejection reason can have a throwing toString; the global crash
+    // handler must not itself throw and lose the rejection.
+    private static safeStringify(reason: unknown): string {
+        try {
+            return String(reason);
+        } catch {
+            return "[unstringifiable rejection reason]";
+        }
+    }
+
+    // Random jitter (0-3s) to spread upload bursts. Overridable via config so
+    // tests get a deterministic delay without stubbing Math.random.
+    protected getJitterMs(): number {
+        return this.config.jitterMs ?? Math.floor(Math.random() * 3000);
+    }
+
+    public async uploadLogs(): Promise<void> {
         let rawLogsSize;
         let compressedLogsSize;
         const uploadStartedAt = Date.now();
         try {
             if (!this.isEnabled()) return;
 
-            // Random jitter (0-3s) to spread upload bursts
-            const jitterMs = Math.floor(Math.random() * 3000);
             if (this.uploadInitiated) return;
             this.uploadInitiated = true;
+
+            const jitterMs = this.getJitterMs();
             await sleep(jitterMs);
             this.uploadInitiated = false;
 

--- a/src/utils/logging/browser/BrowserLogUploader.ts
+++ b/src/utils/logging/browser/BrowserLogUploader.ts
@@ -9,17 +9,13 @@ export class BrowserLogUploader extends LogUploader {
 
         this.onWindowError = (e: ErrorEvent) => {
             if (e.error) {
-                this.uploadLogs(e.error);
+                this.captureUnhandled(e.error, "error");
             }
         };
         window.addEventListener("error", this.onWindowError);
 
         this.onWindowUnhandledRejection = (e: PromiseRejectionEvent) => {
-            this.uploadLogs(
-                e.reason instanceof Error
-                    ? e.reason
-                    : new Error(String(e.reason))
-            );
+            this.captureUnhandled(e.reason, "unhandledrejection");
         };
         window.addEventListener(
             "unhandledrejection",

--- a/src/utils/logging/logEncoder.ts
+++ b/src/utils/logging/logEncoder.ts
@@ -13,40 +13,93 @@ export function decodeLogs(encodedLogs: string): LogEntry[] {
     return parsed.map((encodedLog) => decodeLogEntry(encodedLog));
 }
 
+// Reads one allowlisted Error field defensively. A hostile error can define a
+// throwing getter (must not escape the crash handler that is trying to log it)
+// or a getter that returns a non-string - e.g. the secret-bearing error itself -
+// which must not slip a raw object into the "safe" record.
+function readErrorField(error: Error, key: "name" | "message" | "stack"): string {
+    try {
+        const value = error[key];
+        if (value === undefined || value === null) return "";
+        return typeof value === "string" ? value : "[non-string]";
+    } catch {
+        return "[unreadable]";
+    }
+}
+
+// Allowlist only safe fields. Never copy arbitrary own properties: rich error
+// graphs (e.g. an AxiosError) own `config`, `request`, and `response`, so
+// `config.headers.Authorization`, cookies, and request bodies must not be
+// serialized. Keep a vetted `code` when it is a plain scalar.
+function toSafeErrorRecord(error: Error): Record<string, unknown> {
+    const safeError: Record<string, unknown> = {
+        name: readErrorField(error, "name"),
+        message: readErrorField(error, "message"),
+        stack: readErrorField(error, "stack")
+    };
+    try {
+        const code = (error as { code?: unknown }).code;
+        if (typeof code === "string" || typeof code === "number") {
+            safeError.code = code;
+        }
+    } catch {
+        // unreadable code getter - drop it
+    }
+    return safeError;
+}
+
+// Sanitize the whole graph BEFORE JSON.stringify. stringify invokes an object's
+// own toJSON() before any replacer sees it, and AxiosError.toJSON() returns a
+// plain object carrying `config` - so a replacer-only allowlist is bypassed.
+// We therefore walk EVERY object into a safe clone: replacing every Error with
+// the safe record no matter how deeply it is wrapped, and never returning an
+// object to JSON.stringify (which would let it invoke a nested Error's toJSON or
+// throw on a cycle). `Date` keeps its native serialization; an untrusted
+// enumerable `toJSON` is neither copied nor invoked.
+function sanitizeForEncoding(value: unknown, seen: WeakSet<object>): unknown {
+    if (value instanceof Error) return toSafeErrorRecord(value);
+    // Never hand a function to JSON.stringify: an own `toJSON` on a function is
+    // invoked after this walk and can re-expose an Error graph. Functions carry
+    // no log payload, so drop them.
+    if (typeof value === "function") return undefined;
+    if (typeof value !== "object" || value === null) return value;
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value.toISOString();
+    }
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
+
+    if (Array.isArray(value)) {
+        return value.map((item) => sanitizeForEncoding(item, seen));
+    }
+
+    const sanitized: Record<string, unknown> = {};
+    for (const key of Object.keys(value)) {
+        // Skip an enumerable `toJSON` so a nested error/secret can never be
+        // re-serialized through an untrusted serializer on the clone.
+        if (key === "toJSON") continue;
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
+        if (!descriptor) continue;
+        // Do not invoke accessors while building the wire-safe clone: a getter
+        // can materialize an Error's `config`/`toJSON()` into a plain object,
+        // erasing the Error identity before recursion can redact it.
+        if (
+            typeof descriptor.get === "function" ||
+            typeof descriptor.set === "function"
+        ) {
+            sanitized[key] = "[accessor]";
+            continue;
+        }
+        sanitized[key] = sanitizeForEncoding(descriptor.value, seen);
+    }
+    return sanitized;
+}
+
 export function encodeLogEntry(logEntry: LogEntry): string {
-    const seen = new WeakSet<object>();
-
-    return JSON.stringify(logEntry, (_key, value) => {
-        if (typeof value === "bigint") {
-            return value.toString();
-        }
-
-        if (value instanceof Error) {
-            const serializedError: Record<string, unknown> = {
-                name: value.name,
-                message: value.message,
-                stack: value.stack
-            };
-
-            for (const propertyName of Object.getOwnPropertyNames(value)) {
-                if (!(propertyName in serializedError)) {
-                    serializedError[propertyName] =
-                        value[propertyName as keyof Error];
-                }
-            }
-
-            return serializedError;
-        }
-
-        if (typeof value === "object" && value !== null) {
-            if (seen.has(value)) {
-                return "[Circular]";
-            }
-            seen.add(value);
-        }
-
-        return value;
-    });
+    const sanitized = sanitizeForEncoding(logEntry, new WeakSet<object>());
+    return JSON.stringify(sanitized, (_key, value) =>
+        typeof value === "bigint" ? value.toString() : value
+    );
 }
 
 export function decodeLogEntry(encodedLogEntry: string): LogEntry {

--- a/src/utils/logging/node/NodeLogUploader.ts
+++ b/src/utils/logging/node/NodeLogUploader.ts
@@ -30,22 +30,12 @@ export class NodeLogUploader extends LogUploader {
         if (typeof process === "undefined" || !process.on) return;
 
         this.onUncaughtException = (error: unknown) => {
-            this.logger?.error(
-                " ######### Uncaught exception captured, uploading logs",
-                {
-                    error
-                }
-            );
+            this.captureUnhandled(error, "uncaughtException");
         };
         process.on("uncaughtException", this.onUncaughtException);
 
         this.onUnhandledRejection = (reason: unknown) => {
-            this.logger?.error(
-                " ######### Unhandled rejection captured, uploading logs",
-                {
-                    reason
-                }
-            );
+            this.captureUnhandled(reason, "unhandledRejection");
         };
         process.on("unhandledRejection", this.onUnhandledRejection);
     }

--- a/test/e2e/E2E-Spectate.test.ts
+++ b/test/e2e/E2E-Spectate.test.ts
@@ -526,7 +526,7 @@ describe("E2E: Spectate Service", function () {
     });
 
     describe("Fork Traversal Spectating", function () {
-        // TODO(separate-PR): product/protocol bug, NOT a harness-conversion issue.
+        // TODO(#351): product/protocol bug, NOT a harness-conversion issue.
         // After the dispute reduction all 4 remaining peers agree on the reduced
         // fork's genesis block (identical hash) but it only collects 3/4
         // signatures, so finalization stalls (`sigs=3/4 union=4`). One
@@ -598,7 +598,7 @@ describe("E2E: Spectate Service", function () {
     });
 
     describe("Spectators before and after dispute", function () {
-        // TODO(separate-PR): flaky due to the same post-dispute-reduction
+        // TODO(#351): flaky due to the same post-dispute-reduction
         // finalization product bug as the "traverse forks" test — after the
         // dispute the reduced fork's genesis block intermittently collects only
         // N-1 of N signatures (e.g. sigs=2/3), so sync stalls. Passes on some
@@ -850,7 +850,7 @@ describe("E2E: Spectate Service", function () {
     });
 
     describe("forceInboundJoin during dispute", function () {
-        // TODO(separate-PR): product bug, NOT a harness-conversion issue. After
+        // TODO(#352, #353): product bug, NOT a harness-conversion issue. After
         // resolving the dispute on the reduced fork the on-chain snapshot never
         // changes within the timeout (same post-dispute-reduction class as the
         // "traverse forks" test above), and teardown then hits a fatal

--- a/test/e2e/E2E-Timeouts.test.ts
+++ b/test/e2e/E2E-Timeouts.test.ts
@@ -44,8 +44,7 @@ describe("E2E: Timeouts", function () {
                 }
             });
             await h.network.disconnectPeer(2);
-            // TODO - never flaky when run in isolation - very flaky when run in parallel
-            // TODO - under load Peer 1 can experience RaceConditionBlockCalldataTimestampTooLate - investigate
+            // TODO - under load Peer 1 can hit StateChannelManagerProxy's RaceConditionBlockCalldataTimestampTooLate revert; fix the timing bug (not #391 - that tracker sets the E2E-Timeouts cluster aside as an anomaly)
             await h.transition.advanceState({ count: 2, waitForPeers: [0, 1] }); // Peers 0 and 1 write (peer 2 disconnected)
             await h.assert.calldata.calldataPosted();
             await h.assert.sync.peersInSyncWait({ peerIndices: [0, 1] });

--- a/test/e2e/disputeValidation/futureBlock.test.ts
+++ b/test/e2e/disputeValidation/futureBlock.test.ts
@@ -9,7 +9,7 @@ import { Codec, Type } from "@/utils";
 // dispute commitment — otherwise the attacker can move state forward unilaterally.
 
 describe("E2E: dispute validation / futureBlock", function () {
-    // TODO(separate-PR): the test BODY passes, but the afterEach hits the known
+    // TODO(#353): the test BODY passes, but the afterEach hits the known
     // product teardown bug `onStateSnapshotUpdated: unknown snapshot while
     // status=4` (EventHandler.apply) — the self-removed peer (status=4) receives
     // an unknown snapshot after resolution. Same class as the deferred

--- a/test/fixtures/logging/LogUploader.fixture.ts
+++ b/test/fixtures/logging/LogUploader.fixture.ts
@@ -1,0 +1,127 @@
+import http from "http";
+import { AddressInfo } from "net";
+import { ethers } from "ethers";
+import { LogStore } from "@/utils/logging/logStore";
+import { NodeLogUploader } from "@/utils/logging/node/NodeLogUploader";
+import { NodeLogger } from "@/utils/logging/node/NodeLogger";
+import { decodeLogs, decompressFromBase64 } from "@/utils/logging/logEncoder";
+import { LogEntry } from "@/utils/logging/Logger";
+
+export type ReceivedUpload = {
+    channelId: string;
+    peerAddress: string;
+    compressedLogs: string;
+};
+
+export type LogReceiver = {
+    url: string;
+    requests: ReceivedUpload[];
+    // Resolves once `count` uploads have been received (event-driven, resolved by
+    // the request handler) - so tests assert what was actually delivered.
+    waitForRequests: (count: number, timeoutMs?: number) => Promise<void>;
+    close: () => Promise<void>;
+};
+
+// A real local HTTP endpoint that captures the uploader's POSTed payloads, so
+// tests exercise the actual upload boundary instead of stubbing the HTTP client.
+export async function startLogReceiver(): Promise<LogReceiver> {
+    const requests: ReceivedUpload[] = [];
+    const waiters: Array<{ count: number; resolve: () => void }> = [];
+
+    const server = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (chunk) => chunks.push(chunk as Buffer));
+        req.on("end", () => {
+            try {
+                requests.push(
+                    JSON.parse(Buffer.concat(chunks).toString("utf8"))
+                );
+            } catch {
+                // ignore non-JSON probes
+            }
+            for (let i = waiters.length - 1; i >= 0; i--) {
+                if (requests.length >= waiters[i].count) {
+                    waiters[i].resolve();
+                    waiters.splice(i, 1);
+                }
+            }
+            res.setHeader("x-upload-id", "test-receiver");
+            res.statusCode = 200;
+            res.end(JSON.stringify({ ok: true }));
+        });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    return {
+        url: `http://127.0.0.1:${port}/logs`,
+        requests,
+        waitForRequests: (count, timeoutMs = 2000) =>
+            new Promise<void>((resolve, reject) => {
+                if (requests.length >= count) return resolve();
+                const timer = setTimeout(
+                    () =>
+                        reject(
+                            new Error(
+                                `timed out waiting for ${count} uploads (got ${requests.length})`
+                            )
+                        ),
+                    timeoutMs
+                );
+                waiters.push({
+                    count,
+                    resolve: () => {
+                        clearTimeout(timer);
+                        resolve();
+                    }
+                });
+            }),
+        close: () =>
+            new Promise<void>((resolve, reject) =>
+                server.close((err) => (err ? reject(err) : resolve()))
+            )
+    };
+}
+
+export function decodeUpload(received: ReceivedUpload): LogEntry[] {
+    return decodeLogs(decompressFromBase64(received.compressedLogs));
+}
+
+export type UploaderFixture = {
+    logUploader: NodeLogUploader;
+    logStore: LogStore;
+    logger: NodeLogger;
+};
+
+// Builds a real uploader + logger against a real endpoint, wired exactly as the
+// platform loggers do (`logUploader.setLogger(this)` in the logger constructor).
+// jitterMs is deterministic (default 0) so tests get a fixed delay without
+// stubbing Math.random.
+export function createUploaderFixture(opts: {
+    uploadEndpoint: string;
+    jitterMs?: number;
+}): UploaderFixture {
+    const logStore = new LogStore(1024 * 1024, true);
+    const sharedContext = {
+        channelId: ethers.ZeroHash,
+        peerAddress: ethers.Wallet.createRandom().address
+    };
+    const logUploader = new NodeLogUploader(
+        logStore,
+        { uploadEndpoint: opts.uploadEndpoint, jitterMs: opts.jitterMs ?? 0 },
+        { component: "LogUploaderTest" },
+        sharedContext,
+        false
+    );
+    const logger = new NodeLogger(
+        { component: "LogUploaderTest" },
+        sharedContext,
+        undefined,
+        logStore,
+        { logUploader },
+        new Set(),
+        true
+    );
+    return { logUploader, logStore, logger };
+}

--- a/test/harness/actions/math/MathScenarioActions.ts
+++ b/test/harness/actions/math/MathScenarioActions.ts
@@ -364,7 +364,7 @@ export class MathScenarioActions extends ScenarioActions {
         await this.harness.lifecycle.start(initialPeers, initialTransitions, {
             timeConfig
         });
-        // TODO -  try making this task detached, since it requires us to increase p2pTime
+        // TODO - switch to addSpectatorDetached and drop the inflated timeConfig
         const spectator = await this.harness.join.addSpectatorWait();
         await this.harness.assert.sync.peersInSyncWait();
         return { spectator, initialPeers };

--- a/test/utils/LogUploader.test.ts
+++ b/test/utils/LogUploader.test.ts
@@ -1,0 +1,132 @@
+import { expect } from "chai";
+import { AxiosError } from "axios";
+import {
+    createUploaderFixture,
+    decodeUpload,
+    startLogReceiver,
+    LogReceiver
+} from "@test/fixtures/logging/LogUploader.fixture";
+
+describe("LogUploader", function () {
+    let receiver: LogReceiver | undefined;
+
+    beforeEach(async function () {
+        // Clear first so a rejected startup never leaves a previous test's closed
+        // receiver in the variable for afterEach to re-close.
+        receiver = undefined;
+        receiver = await startLogReceiver();
+    });
+
+    afterEach(async function () {
+        const started = receiver;
+        receiver = undefined;
+        if (started) await started.close();
+    });
+
+    it("uploads a captured error without leaking secret fields of a real AxiosError", async function () {
+        const { logUploader } = createUploaderFixture({
+            uploadEndpoint: receiver!.url
+        });
+        // A genuine AxiosError: its toJSON() (invoked by JSON.stringify before any
+        // replacer) exposes `config` with the auth header, cookie, and body.
+        const secretError = new AxiosError(
+            "Request failed with status code 401",
+            "ERR_BAD_REQUEST"
+        );
+        Object.assign(secretError, {
+            config: {
+                headers: {
+                    Authorization: "Bearer super-secret-token",
+                    Cookie: "session=topsecret"
+                },
+                data: JSON.stringify({ password: "hunter2" })
+            }
+        });
+
+        logUploader.captureUnhandled(secretError, "error");
+        await receiver!.waitForRequests(1);
+
+        const payload = JSON.stringify(decodeUpload(receiver!.requests[0]));
+        expect(payload).to.include("AxiosError");
+        expect(payload).to.include("ERR_BAD_REQUEST");
+        expect(payload).to.include("Request failed with status code 401");
+        for (const secret of ["super-secret-token", "topsecret", "hunter2"]) {
+            expect(payload, `leaked "${secret}"`).to.not.include(secret);
+        }
+    });
+
+    it("uploads logs when no error is captured", async function () {
+        const { logUploader } = createUploaderFixture({
+            uploadEndpoint: receiver!.url
+        });
+
+        await logUploader.uploadLogs();
+        await receiver!.waitForRequests(1);
+
+        expect(decodeUpload(receiver!.requests[0])).to.deep.equal([]);
+    });
+
+    // A window error burst: the second error lands while the first upload is still
+    // in its jitter sleep. It must be delivered in the (single) POST - asserting
+    // the store would pass even if the late error never reached the upload.
+    it("delivers a captured error that arrives while an upload is in flight", async function () {
+        const { logUploader } = createUploaderFixture({
+            uploadEndpoint: receiver!.url,
+            jitterMs: 50
+        });
+
+        const inFlight = logUploader.uploadLogs();
+        logUploader.captureUnhandled(new Error("late failure"), "error");
+        await inFlight;
+        await receiver!.waitForRequests(1);
+
+        expect(receiver!.requests).to.have.length(1);
+        expect(JSON.stringify(decodeUpload(receiver!.requests[0]))).to.include(
+            "late failure"
+        );
+    });
+
+    // A rejection reason whose toString throws must not crash the crash handler;
+    // it still uploads one safe record.
+    it("captures a non-Error reason whose toString throws without itself throwing", async function () {
+        const { logUploader } = createUploaderFixture({
+            uploadEndpoint: receiver!.url
+        });
+        const throwingReason = {
+            toString() {
+                throw new Error("cannot stringify");
+            }
+        };
+
+        logUploader.captureUnhandled(throwingReason, "unhandledrejection");
+        await receiver!.waitForRequests(1);
+
+        expect(JSON.stringify(decodeUpload(receiver!.requests[0]))).to.include(
+            "[unstringifiable rejection reason]"
+        );
+    });
+
+    // An Error whose own name/message/stack/code accessors throw must not escape
+    // the crash handler while it is being encoded for upload.
+    it("captures an Error with throwing accessors without itself throwing", async function () {
+        const { logUploader } = createUploaderFixture({
+            uploadEndpoint: receiver!.url
+        });
+        const hostileError = new Error("boom");
+        for (const field of ["name", "message", "stack", "code"] as const) {
+            Object.defineProperty(hostileError, field, {
+                configurable: true,
+                get() {
+                    throw new Error(`${field} accessor exploded`);
+                }
+            });
+        }
+
+        logUploader.captureUnhandled(hostileError, "error");
+        await receiver!.waitForRequests(1);
+
+        expect(JSON.stringify(decodeUpload(receiver!.requests[0]))).to.include(
+            "[unreadable]"
+        );
+    });
+});

--- a/test/utils/logEncoder.test.ts
+++ b/test/utils/logEncoder.test.ts
@@ -1,0 +1,145 @@
+import { expect } from "chai";
+import { AxiosError } from "axios";
+import { encodeLogEntry } from "@/utils/logging/logEncoder";
+import { LogEntry } from "@/utils/logging/Logger";
+
+const SECRETS = ["Bearer top-secret", "session=cookie-secret", "body-secret"];
+
+// A genuine AxiosError - its toJSON() (invoked by JSON.stringify before any
+// replacer) exposes `config` with the auth header, cookie, and request body.
+function secretAxiosError(): AxiosError {
+    const error = new AxiosError(
+        "Request failed with status code 401",
+        "ERR_BAD_REQUEST"
+    );
+    Object.assign(error, {
+        config: {
+            headers: {
+                Authorization: "Bearer top-secret",
+                Cookie: "session=cookie-secret"
+            },
+            data: JSON.stringify({ password: "body-secret" })
+        }
+    });
+    return error;
+}
+
+function encodeMeta(meta: unknown): string {
+    const entry: LogEntry = {
+        time: "1",
+        level: "error",
+        context: {},
+        sharedContext: {},
+        message: "m",
+        meta: [meta],
+        stack: "s"
+    };
+    return encodeLogEntry(entry);
+}
+
+function expectNoSecrets(encoded: string) {
+    for (const secret of SECRETS) {
+        expect(encoded, `leaked "${secret}"`).to.not.include(secret);
+    }
+}
+
+describe("encodeLogEntry", function () {
+    it("redacts a direct AxiosError but keeps name/message/code", function () {
+        const encoded = encodeMeta({ error: secretAxiosError() });
+        expect(encoded).to.include("AxiosError");
+        expect(encoded).to.include("ERR_BAD_REQUEST");
+        expect(encoded).to.include("Request failed with status code 401");
+        expectNoSecrets(encoded);
+    });
+
+    it("redacts an AxiosError nested in a class instance", function () {
+        class Wrapper {
+            constructor(public error: AxiosError) {}
+        }
+        expectNoSecrets(encodeMeta({ wrap: new Wrapper(secretAxiosError()) }));
+    });
+
+    it("redacts an AxiosError on an enumerable property of a Map", function () {
+        const map = new Map<string, number>([["a", 1]]);
+        Object.assign(map, { leak: secretAxiosError() });
+        expectNoSecrets(encodeMeta({ map }));
+    });
+
+    it("does not slip a raw error out through a non-string Error field getter", function () {
+        const outer = new Error("outer");
+        Object.defineProperty(outer, "message", {
+            configurable: true,
+            get() {
+                return secretAxiosError();
+            }
+        });
+        expectNoSecrets(encodeMeta({ error: outer }));
+    });
+
+    it("neither copies nor invokes an untrusted toJSON that would expose secrets", function () {
+        const secretConfig = secretAxiosError().config;
+        const leaky = { safe: "ok", toJSON: () => secretConfig };
+        const encoded = encodeMeta({ leaky });
+        expect(encoded).to.include("ok");
+        expectNoSecrets(encoded);
+    });
+
+    it("does not invoke an accessor that materializes an error's config", function () {
+        const error = secretAxiosError();
+        const meta = {
+            safe: "ok",
+            get exposed() {
+                return error.config;
+            }
+        };
+        const encoded = encodeMeta(meta);
+        expect(encoded).to.include("[accessor]");
+        expectNoSecrets(encoded);
+    });
+
+    it("drops a function whose toJSON would expose an error", function () {
+        const error = secretAxiosError();
+        const functionValue = Object.assign(() => undefined, {
+            toJSON: () => error.toJSON()
+        });
+        expectNoSecrets(encodeMeta({ functionValue }));
+    });
+
+    it("encodes a circular class instance as [Circular] without throwing", function () {
+        class Cyclic {
+            label = "cyclic";
+            self: unknown;
+            constructor() {
+                this.self = this;
+            }
+        }
+        let encoded = "";
+        expect(() => {
+            encoded = encodeMeta({ c: new Cyclic() });
+        }).to.not.throw();
+        expect(encoded).to.include("[Circular]");
+    });
+
+    it("survives throwing Error accessors without throwing", function () {
+        const hostile = new Error("boom");
+        for (const field of ["name", "message", "stack", "code"] as const) {
+            Object.defineProperty(hostile, field, {
+                configurable: true,
+                get() {
+                    throw new Error(`${field} accessor exploded`);
+                }
+            });
+        }
+        let encoded = "";
+        expect(() => {
+            encoded = encodeMeta({ error: hostile });
+        }).to.not.throw();
+        expect(encoded).to.include("[unreadable]");
+    });
+
+    it("preserves Date as ISO and bigint as a string", function () {
+        const encoded = encodeMeta({ when: new Date(0), big: 10n });
+        expect(encoded).to.include("1970-01-01T00:00:00.000Z");
+        expect(encoded).to.include('"10"');
+    });
+});


### PR DESCRIPTION
## Summary

A TODO-accounting pass over the repo: retire stale TODO comments, reword drifted
ones, remove the dead code they pointed at, and point deferred-test TODOs at their
tracked issues (#351, #352, #353, #391).

One behavioral change: `LogUploader` now captures an unhandled (window) error into
the log store **before** its early-returns, so browser crash context ships with the
uploaded logs. The capture is re-entrancy-safe (`Logger.error` calls back into
`uploadLogs`) and exception-safe (a hostile error graph that fails to encode must
not wedge later uploads). Covered by new unit tests.

Dead code removed — all provably unreachable or uncalled:
- `AStateMachine._clearOutboundMessages`: an unreachable `while (pop())` loop after
  `delete _outboundMessages` (`delete` already zeroes a dynamic array's length),
  plus its debug `console.log` and the now-unused `hardhat/console.sol` import.
- `DisputeVerificationFacet._isCorrectGenesis`: zero callers repo-wide.
- Four commented-out `disputeManager.dispute(...)` sketches referencing a field the
  class does not have.

Rebased onto `dispute` after #397 merged; adopted dispute's `block`→`entry`
validation-strategy refactor at the one overlapping call site.

## Test plan

- `yarn tsc --noEmit -p tsconfig.json` and `-p tsconfig.browser.json` — clean
- `yarn compile` — clean
- `yarn hardhat test --no-compile test/utils/LogUploader.test.ts` — 4 passing. The
  exception-safety guard is mutation-checked: moving the `finally` restore out of the
  guard makes the hostile-error test fail, proving the guard is load-bearing.
- eslint — no new errors versus the `dispute` baseline
