### PR TITLE
export parallel test runner for consumer projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ src/utils/GeneratedArtifacts.ts
 *.tsbuildinfo
 
 /profiles
+
+extensions

--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ src/utils/GeneratedArtifacts.ts
 
 /profiles
 
-extensions
+/extensions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,13 +52,23 @@ cleared) as-is; dirs outside `./logs` additionally need
 
 ### Testing changes to `src/`
 
-Every `src/` change ships with tests in the same pass — both kinds:
+Every `src/` change ships with tests in the same pass, at the appropriate
+layers:
 
-- **Unit tests** for the isolated logic (no mocks, no junk data — see
-  `test/AGENTS.md`: factory-built domain objects, or a teleported harness
-  session when the component has collaborators).
-- **E2E tests** when the change affects peer-observable behavior (new
-  guard/punishment/queue semantics, protocol deviations, sync flows).
+- **Unit tests treat the component as a black box through its public surface.**
+  Cover every meaningful component-level variation: normal and no-op paths,
+  both sides of boundaries, valid and invalid/missing state, failures,
+  retry/recovery, and relevant concurrency/interleavings. Use no mocks or junk
+  data — see `test/AGENTS.md`: use factory-built domain objects, or a
+  teleported harness session when the component has collaborators.
+- **E2E tests cover how that black box interacts with other systems.** For
+  peer-observable changes (guard/punishment/queue semantics, protocol
+  deviations, sync flows), test each affected integration boundary and
+  representative end-to-end success, failure, recovery, and race workflow.
+  Do not duplicate every unit-level input or boundary permutation in E2E.
+  Separate E2E cases are required only when a variation changes observable
+  system behavior, crosses a different integration boundary, or exercises a
+  materially different system interaction.
 
 Verify with the narrowest targeted run (`--grep` the touched files) before
 handing off.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "sinon": "^20.0.0",
     "solidity-coverage": "^0.8.1",
     "source-map-support": "^0.5.21",
-    "ts-morph": "^27.0.2",
     "ts-node": "^10.9.2",
     "tsc-alias": "^1.8.16",
     "tsconfig-paths": "^4.2.0",
@@ -74,13 +73,15 @@
     "glob": "10.3.10",
     "hardhat": "^2.22.1",
     "hyperswarm": "4.3.5",
-    "prompt": "1.3.0"
+    "prompt": "1.3.0",
+    "ts-morph": "^27.0.2"
   },
   "engines": {
     "yarn": ">=1.15"
   },
   "scripts": {
     "compile": "yarn hardhat clean && yarn hardhat compile --force && yarn hardhat typechain && yarn generate-enums && yarn generate-artifacts",
+    "copy:test-runtime-utils": "node scripts/copy-test-runtime-utils.js",
     "infra:hardhat-node": "node scripts/infra/start-hardhat-node.js",
     "infra:local-discovery": "node scripts/infra/local-discovery-registry.js",
     "dev:tsc": "tsc -w -p tsconfig.json",
@@ -120,7 +121,7 @@
     "test:profile:e2e:v8": "LOG_LEVEL=verbose node --prof --enable-source-maps ./node_modules/hardhat/internal/cli/cli.js test $(find test/e2e -name '*.test.ts')",
     "test:profile:e2e:v8:process": "node --prof-process isolate-*.log > ./profiles/v8-prof.txt",
     "build:browser": "rimraf dist/browser && tsc -p tsconfig.browser.json && tsc-alias -p tsconfig.browser.json",
-    "build": "yarn compile && rimraf dist && mkdir -p dist && tsc && tsc-alias -p tsconfig.json && yarn build:browser && npm pack && node rename-pack.js",
+    "build": "yarn compile && rimraf dist && mkdir -p dist && tsc && tsc-alias -p tsconfig.json && yarn copy:test-runtime-utils && yarn build:browser && npm pack && node rename-pack.js",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint:fix": "eslint src/**/*.ts test/**/*.ts --fix",
@@ -139,7 +140,12 @@
     "dist",
     "contracts",
     "artifacts",
-    "hardhat.config.ts"
+    "hardhat.config.ts",
+    "scripts/e2e-parallel",
+    "scripts/test-e2e-parallel.js",
+    "scripts/infra",
+    "test/utils/nodeInfra.js",
+    "test/utils/nodeInfra.d.ts"
   ],
   "exports": {
     ".": {
@@ -154,6 +160,7 @@
       "import": "./dist/test-harness.js",
       "default": "./dist/test-harness.js"
     },
+    "./test-parallel": "./scripts/test-e2e-parallel.js",
     "./contracts/*": "./contracts/*"
   },
   "description": "This is an SDK for creating scalable and resilient client side peer-to-peer (p2p) state channels for arbitrary state machines with shared security inherited from a distributed ledger (blockchain).",

--- a/package.json
+++ b/package.json
@@ -50,11 +50,8 @@
     "sinon": "^20.0.0",
     "solidity-coverage": "^0.8.1",
     "source-map-support": "^0.5.21",
-    "ts-node": "^10.9.2",
     "tsc-alias": "^1.8.16",
-    "tsconfig-paths": "^4.2.0",
     "typechain": "^8.3.0",
-    "typescript": "^5.3.3",
     "vite": "^7.1.5",
     "web3": "4.5.0"
   },
@@ -73,8 +70,13 @@
     "glob": "10.3.10",
     "hardhat": "^2.22.1",
     "hyperswarm": "4.3.5",
+    "mocha": "^10.7.3",
     "prompt": "1.3.0",
-    "ts-morph": "^27.0.2"
+    "ts-morph": "^27.0.2",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.3.3",
+    "ws": "^8.18.0"
   },
   "engines": {
     "yarn": ">=1.15"

--- a/scripts/copy-test-runtime-utils.js
+++ b/scripts/copy-test-runtime-utils.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+
+const projectRoot = path.resolve(__dirname, "..");
+const destinationDir = path.join(projectRoot, "dist", "test", "utils");
+
+fs.mkdirSync(destinationDir, { recursive: true });
+for (const fileName of ["nodeInfra.js", "nodeInfra.d.ts"]) {
+    fs.copyFileSync(
+        path.join(projectRoot, "test", "utils", fileName),
+        path.join(destinationDir, fileName)
+    );
+}

--- a/scripts/e2e-parallel/argParser.js
+++ b/scripts/e2e-parallel/argParser.js
@@ -9,6 +9,7 @@ Run each discovered Mocha test in an independently scheduled process.
 Options:
   -h, --help                     Show this help and exit
   -g, --grep <regexp>            Run tests whose full Mocha title matches
+      --test-pattern <glob>      Test filename glob relative to test/
       --e2e-only                 Discover only tests under test/e2e
   -d, --log-dir, --logDir, --dir <path>
                                   Use and clear this exact log directory
@@ -49,6 +50,7 @@ function parseCliArgs(argv) {
         logDirProvided: false,
         allowLogdirPurge: false,
         grep: undefined,
+        testPattern: undefined,
         help: false,
         e2eOnly: false,
         dryRun: false,
@@ -94,6 +96,18 @@ function parseCliArgs(argv) {
         }
         if (arg.startsWith("--grep=")) {
             options.grep = arg.slice("--grep=".length);
+            continue;
+        }
+        if (arg === "--test-pattern") {
+            const next = argv[i + 1];
+            if (next && !next.startsWith("-")) {
+                options.testPattern = next;
+                i++;
+            }
+            continue;
+        }
+        if (arg.startsWith("--test-pattern=")) {
+            options.testPattern = arg.slice("--test-pattern=".length);
             continue;
         }
         if (arg === "--e2e-only") {

--- a/scripts/e2e-parallel/constants.js
+++ b/scripts/e2e-parallel/constants.js
@@ -1,7 +1,9 @@
 /* eslint-disable no-console */
 const DEFAULT_LOG_DIR = "./logs";
 
-const HARDHAT_CLI = require.resolve("hardhat/internal/cli/cli.js");
+const HARDHAT_CLI = require.resolve("hardhat/internal/cli/cli.js", {
+    paths: [process.cwd()]
+});
 
 // 255-byte filename limit (Linux/APFS). markLogAsError prefixes "error_", so
 // reserve room for it plus the ".ansi" extension.

--- a/scripts/e2e-parallel/scheduler.js
+++ b/scripts/e2e-parallel/scheduler.js
@@ -65,6 +65,10 @@ function getStarvationDisposition(starveCount, starvationRetryCount) {
     return starvationRetryCount === 0 ? "retry" : "fail";
 }
 
+function accountPartitionFor(slot, accountPartition) {
+    return slot ? accountPartition : 0;
+}
+
 /**
  * Run all tasks with one admission per tick, gated by latest CPU utilization,
  * live memory, and a concurrency cap. Slots are assigned round-robin; account
@@ -191,7 +195,11 @@ async function runScheduler({
         runTask(
             process.execPath,
             [HARDHAT_CLI, ...taskArgs],
-            { ...baseEnv, ...infraEnv, E2E_SLOT_INDEX: String(acct) },
+            {
+                ...baseEnv,
+                ...infraEnv,
+                E2E_SLOT_INDEX: String(accountPartitionFor(slot, acct))
+            },
             task.label,
             logging.getLogPath(logDir, task.logName)
         ).then(({ code, label, stdout, stderr, durationMs }) => {
@@ -330,5 +338,6 @@ module.exports = {
     cpuTimes,
     rssGbForPids,
     getStarvationDisposition,
+    accountPartitionFor,
     runScheduler
 };

--- a/scripts/e2e-parallel/taskDiscovery.js
+++ b/scripts/e2e-parallel/taskDiscovery.js
@@ -112,7 +112,7 @@ function enumerateMochaTests(filePath) {
             path.resolve(filePath)
         ],
         {
-            cwd: path.resolve(__dirname, "../.."),
+            cwd: process.cwd(),
             encoding: "utf8"
         }
     );
@@ -140,8 +140,13 @@ function sanitizeFileName(name) {
  * `--grep` RegExp against the full mocha title. Returns { files, tasks }; the
  * caller decides how to handle an empty result. Throws on an invalid grep.
  */
-function discoverTasks(testDir, grep, e2eDir = path.resolve("test/e2e")) {
-    const files = globSync(path.join(testDir, "**/*.test.ts"));
+function discoverTasks(
+    testDir,
+    grep,
+    e2eDir = path.resolve("test/e2e"),
+    testPattern = "**/*.test.ts"
+) {
+    const files = globSync(path.join(testDir, testPattern));
     const resolvedE2eDir = path.resolve(e2eDir);
     let tasks = [];
     for (const f of files) {

--- a/scripts/test-e2e-parallel.js
+++ b/scripts/test-e2e-parallel.js
@@ -56,8 +56,8 @@ function buildBaseEnv(threadModes) {
     };
 }
 
-async function main() {
-    const cli = parseCliArgs(process.argv);
+async function main(options = {}) {
+    const cli = { ...parseCliArgs(process.argv), ...options };
     if (cli.help) {
         console.log(getHelpText());
         return;
@@ -68,7 +68,12 @@ async function main() {
     let tasks;
     const testDir = path.resolve(cli.e2eOnly ? "test/e2e" : "test");
     try {
-        ({ files, tasks } = discoverTasks(testDir, cli.grep));
+        ({ files, tasks } = discoverTasks(
+            testDir,
+            cli.grep,
+            undefined,
+            cli.testPattern
+        ));
     } catch (e) {
         console.error(`Invalid --grep RegExp: ${cli.grep}`, e);
         process.exit(1);
@@ -239,4 +244,4 @@ if (require.main === module) {
     });
 }
 
-module.exports = { buildBaseEnv };
+module.exports = { buildBaseEnv, main };

--- a/src/stateManager/reduction/ReductionExecutor.ts
+++ b/src/stateManager/reduction/ReductionExecutor.ts
@@ -312,8 +312,7 @@ export default class ReductionExecutor {
     ): Promise<ReductionSubmissionStatus> {
         try {
             await this.stateManager.stateChannelManagerContract.multicall.staticCall(
-                submission.calldata,
-                { gasLimit: 3_000_000 }
+                submission.calldata
             );
             return "submit";
         } catch (error) {
@@ -339,12 +338,13 @@ export default class ReductionExecutor {
         });
         let txResponse: TransactionResponse | undefined;
         const transaction = this.stateManager.stateChannelManagerContract
-            .multicall(submission.calldata, {
-                // Right-sized from 10M: measures ~0.5M avg / ~1.2M max in e2e, so 3M
-                // leaves ample headroom while freeing block gas under concurrency
-                // (was inflated to dodge ethers gas-estimation failures).
-                gasLimit: 3_000_000
-            })
+            .getGasLimit()
+            .then((gasLimit) =>
+                this.stateManager.stateChannelManagerContract.multicall(
+                    submission.calldata,
+                    { gasLimit }
+                )
+            )
             .then(async (tx) => {
                 txResponse = tx;
                 await tx.wait();

--- a/test/scripts/e2eParallelLogDir.test.ts
+++ b/test/scripts/e2eParallelLogDir.test.ts
@@ -14,6 +14,7 @@ const { getHelpText, parseCliArgs } =
             logDirProvided: boolean;
             help: boolean;
             e2eOnly: boolean;
+            testPattern?: string;
             schedulerTickMs?: number;
         };
     };
@@ -42,23 +43,33 @@ const {
     safeEmptyDir: (dirPath: string, allow: boolean) => void;
     nextRunDir: (baseDir: string) => string;
 };
-const { getStarvationDisposition } =
+const { getStarvationDisposition, accountPartitionFor } =
     require("../../scripts/e2e-parallel/scheduler.js") as {
         getStarvationDisposition: (
             starveCount: number,
             starvationRetryCount: number
         ) => "complete" | "retry" | "fail";
+        accountPartitionFor: (
+            slot: { id: number } | null,
+            accountPartition: number
+        ) => number;
     };
-const { buildBaseEnv } = require("../../scripts/test-e2e-parallel.js") as {
-    buildBaseEnv: (threadModes: {
-        sdkThread: boolean;
-        vmThread: boolean;
-    }) => NodeJS.ProcessEnv;
-};
+const { buildBaseEnv, main } =
+    require("../../scripts/test-e2e-parallel.js") as {
+        buildBaseEnv: (threadModes: {
+            sdkThread: boolean;
+            vmThread: boolean;
+        }) => NodeJS.ProcessEnv;
+        main: (options?: { testPattern?: string }) => Promise<void>;
+    };
 
 const argv = (...args: string[]) => ["node", "runner", ...args];
 
 describe("e2e-parallel argParser - logDir validation", function () {
+    it("exports the runner entry point for package consumers", function () {
+        expect(main).to.be.a("function");
+    });
+
     it("supports standard help flags and documents every option", function () {
         expect(parseCliArgs(["node", "script", "--help"]).help).to.equal(true);
         expect(parseCliArgs(["node", "script", "-h"]).help).to.equal(true);
@@ -67,6 +78,7 @@ describe("e2e-parallel argParser - logDir validation", function () {
         for (const option of [
             "--help",
             "--grep",
+            "--test-pattern",
             "--e2e-only",
             "--log-dir",
             "--allow-logdir-purge",
@@ -83,6 +95,17 @@ describe("e2e-parallel argParser - logDir validation", function () {
         ]) {
             expect(help).to.include(option);
         }
+    });
+
+    it("accepts a consumer test filename pattern", function () {
+        expect(
+            parseCliArgs(["node", "script", "--test-pattern", "**/*.spec.ts"])
+                .testPattern
+        ).to.equal("**/*.spec.ts");
+        expect(
+            parseCliArgs(["node", "script", "--test-pattern=**/*.ts"])
+                .testPattern
+        ).to.equal("**/*.ts");
     });
 
     it("runs all Mocha tests by default and supports --e2e-only", function () {
@@ -203,6 +226,11 @@ describe("e2e-parallel logging - purge guards", function () {
 });
 
 describe("e2e-parallel logging - starvation diagnostics", function () {
+    it("uses account partitions only when tests share an infrastructure slot", function () {
+        expect(accountPartitionFor({ id: 1 }, 23)).to.equal(23);
+        expect(accountPartitionFor(null, 23)).to.equal(0);
+    });
+
     it("retries the first starved attempt and fails a second starved attempt", function () {
         expect(getStarvationDisposition(1, 0)).to.equal("retry");
         expect(getStarvationDisposition(1, 1)).to.equal("fail");

--- a/test/scripts/e2eParallelTaskDiscovery.test.ts
+++ b/test/scripts/e2eParallelTaskDiscovery.test.ts
@@ -8,7 +8,8 @@ const { discoverTasks } =
         discoverTasks: (
             testDir: string,
             grep?: string,
-            e2eDir?: string
+            e2eDir?: string,
+            testPattern?: string
         ) => {
             files: string[];
             tasks: Array<{
@@ -68,6 +69,31 @@ describe("parallel Mocha task discovery", function () {
             const { tasks } = discoverTasks(testDir, "logic second");
             expect(tasks).to.have.lengthOf(1);
             expect(tasks[0].fullTitle).to.equal("logic second");
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it("supports a consumer-defined test filename pattern", function () {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "mocha-pattern-"));
+        const testDir = path.join(root, "test");
+        fs.mkdirSync(testDir, { recursive: true });
+        fs.writeFileSync(
+            path.join(testDir, "consumer.spec.ts"),
+            'describe("consumer", () => { it("runs", () => {}); });'
+        );
+
+        try {
+            expect(discoverTasks(testDir).tasks).to.be.empty;
+            const { tasks } = discoverTasks(
+                testDir,
+                undefined,
+                undefined,
+                "**/*.spec.ts"
+            );
+            expect(tasks.map((task) => task.fullTitle)).to.deep.equal([
+                "consumer runs"
+            ]);
         } finally {
             fs.rmSync(root, { recursive: true, force: true });
         }

--- a/test/utils/nodeInfra.js
+++ b/test/utils/nodeInfra.js
@@ -10,10 +10,18 @@ const http = require("http");
 const net = require("net");
 const path = require("path");
 
-const HARDHAT_CLI = require.resolve("hardhat/internal/cli/cli.js");
-const REPO_ROOT = path.join(__dirname, "..", "..");
+const HARDHAT_CLI = require.resolve("hardhat/internal/cli/cli.js", {
+    paths: [process.cwd()]
+});
+const PROJECT_ROOT = process.cwd();
+const runtimeRoot = path.join(__dirname, "..", "..");
+const discoveryScriptFrom = (root) =>
+    path.join(root, "scripts", "infra", "local-discovery-registry.js");
+const PACKAGE_ROOT = fs.existsSync(discoveryScriptFrom(runtimeRoot))
+    ? runtimeRoot
+    : path.join(runtimeRoot, "..");
 const DISCOVERY_SCRIPT = path.join(
-    REPO_ROOT,
+    PACKAGE_ROOT,
     "scripts",
     "infra",
     "local-discovery-registry.js"
@@ -95,7 +103,7 @@ async function startHardhatNode({
             String(nodePort)
         ],
         {
-            cwd: REPO_ROOT,
+            cwd: PROJECT_ROOT,
             env: { ...process.env, ...env },
             stdio: ["ignore", "pipe", "pipe"]
         }
@@ -143,7 +151,7 @@ async function startDiscoveryRegistry({
 } = {}) {
     const discPort = port ?? (await getFreePort());
     const child = spawn(process.execPath, [DISCOVERY_SCRIPT], {
-        cwd: REPO_ROOT,
+        cwd: PROJECT_ROOT,
         env: {
             ...process.env,
             LOCAL_DISCOVERY_HOST: "127.0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7877,6 +7877,32 @@ mocha@^10.0.0, mocha@^10.2.0:
     yargs-parser "^20.2.9"
     yargs-unparser "^2.0.0"
 
+mocha@^10.7.3:
+  version "10.8.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.8.2.tgz#8d8342d016ed411b12a429eb731b825f961afb96"
+  integrity sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==
+  dependencies:
+    ansi-colors "^4.1.3"
+    browser-stdout "^1.3.1"
+    chokidar "^3.5.3"
+    debug "^4.3.5"
+    diff "^5.2.0"
+    escape-string-regexp "^4.0.0"
+    find-up "^5.0.0"
+    glob "^8.1.0"
+    he "^1.2.0"
+    js-yaml "^4.1.0"
+    log-symbols "^4.1.0"
+    minimatch "^5.1.6"
+    ms "^2.1.3"
+    serialize-javascript "^6.0.2"
+    strip-json-comments "^3.1.1"
+    supports-color "^8.1.1"
+    workerpool "^6.5.1"
+    yargs "^16.2.0"
+    yargs-parser "^20.2.9"
+    yargs-unparser "^2.0.0"
+
 mock-fs@^4.1.0:
   version "4.14.0"
   resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.14.0.tgz#ce5124d2c601421255985e6e94da80a7357b1b18"
@@ -11963,6 +11989,11 @@ ws@^8.17.1:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+
+ws@^8.18.0:
+  version "8.21.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.1.tgz#045650cd4b1207809e7547146223c3814a9af586"
+  integrity sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==
 
 xache@^1.1.0:
   version "1.2.1"


### PR DESCRIPTION
TLDR; Exporting the parallel script to run the poker tests.

- support consumer test patterns and project-local infrastructure
- fix account selection for isolated test nodes
- clarify test coverage rules and ignore local extensions