### PR TITLE
refactor(validation): route dispute-strategy deviations through hooks

### DIFF
--- a/src/stateManager/ValidationService.ts
+++ b/src/stateManager/ValidationService.ts
@@ -15,7 +15,6 @@ import AValidationStrategy from "./validationStrategy/AValidationStrategy";
 import type StateManager from "@/stateManager";
 import { LoggerUtils } from "@/utils/LoggerUtils";
 import BlockValidationStrategy from "./validationStrategy/BlockValidationStrategy";
-import DisputeValidationStrategy from "./validationStrategy/DisputeValidationStrategy";
 import EventSyncService from "./EventSyncService";
 
 export enum OnChainPostTiming {
@@ -98,8 +97,7 @@ export default class ValidationService {
         }
 
         if (
-            //TODO - quick hack - later want cleaner code
-            !(strategy instanceof DisputeValidationStrategy) &&
+            strategy.enforcesLiveForkAndOrderingGates &&
             (await this.isDisputedFork(block.forkId, block.channelId))
         ) {
             this.logger.warn("validateBlockConfirmation - fork disputed", {
@@ -114,8 +112,7 @@ export default class ValidationService {
             block.forkId
         );
         if (
-            //TODO - quick hack - later want cleaner code
-            !(strategy instanceof DisputeValidationStrategy) &&
+            strategy.enforcesLiveForkAndOrderingGates &&
             block.height > expectedNextHeight
         ) {
             this.logger.warn(
@@ -146,42 +143,12 @@ export default class ValidationService {
             return await strategy.blockIsNotLinkedAndIsNotFirstBlock(entry);
         }
 
-        // isNextLeader
-        //TODO - quick hack - later want cleaner code
-        if (strategy instanceof DisputeValidationStrategy) {
-            const previousSnapshot = this.storage.getPreviousStateSnapshot(
-                block.coordinates
-            );
-            if (!previousSnapshot) {
-                this.logger.error(
-                    "DISPUTE Strategy -validateBlockConfirmation - missing previous snapshot",
-                    {
-                        strategy: strategy.name,
-                        block: LoggerUtils.getBlockMetadata(block, this.storage)
-                    }
-                );
-                throw new Error(
-                    "Missing previous snapshot for dispute validation strategy"
-                );
-            }
-            const previousState =
-                this.storage.stateMachineStates.getStateMachineState(
-                    previousSnapshot.stateMachineStateHash
-                );
-            if (!previousState) {
-                this.logger.error(
-                    "DISPUTE Strategy -validateBlockConfirmation - missing previous state machine state",
-                    {
-                        strategy: strategy.name,
-                        block: LoggerUtils.getBlockMetadata(block, this.storage)
-                    }
-                );
-                throw new Error(
-                    "Missing previous state machine state for dispute validation strategy"
-                );
-            }
-            await this.diamondStateMachine.setState(previousState);
-        }
+        // isNextLeader - dispute replay must position the state machine at the
+        // block's predecessor first; live pipelines are already positioned.
+        await strategy.prepareStateMachineForLeaderCheck(
+            entry,
+            this.diamondStateMachine
+        );
         const nextLeader = await this.diamondStateMachine.getNextToWrite();
         if (nextLeader !== block.author) {
             this.logger.warn(

--- a/src/stateManager/validationStrategy/AValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/AValidationStrategy.ts
@@ -5,6 +5,7 @@ import {
     MessageBlockStruct
 } from "@typechain-types/contracts/V1/types/DataTypes";
 import type { QueuedBlockEntry } from "@/storage/QueueStorage";
+import type ADiamondStateMachine from "@/ADiamondStateMachine";
 
 export type ParticipantSnapshots = {
     previous: StateSnapshot;
@@ -15,6 +16,17 @@ export default abstract class AValidationStrategy {
     public get name(): string {
         return this.constructor.name;
     }
+
+    /**
+     * Whether this pipeline enforces the live fork/ordering gates - the
+     * disputed-fork check and the not-in-the-future check. Live gossip,
+     * spectate, and calldata pipelines validate in-order blocks and enforce
+     * both. Dispute replay audits a fixed proof out of live order on an
+     * already-disputed fork, so it enforces neither (and never pays for the
+     * disputed-fork lookup). When false, `blockForkIsDisputed` and
+     * `blockIsNotNextAndIsInTheFuture` are never called.
+     */
+    public abstract get enforcesLiveForkAndOrderingGates(): boolean;
 
     public abstract interpretFinalValidationResult(
         blockValidationResult: BlockValidationResult
@@ -96,6 +108,17 @@ export default abstract class AValidationStrategy {
     public abstract blockIsNotLinkedAndIsNotFirstBlock(
         entry: QueuedBlockEntry
     ): Promise<BlockValidationResult>;
+
+    /**
+     * Position the state machine before the next-leader check. Live pipelines
+     * already hold the block's predecessor state (blocks execute in order), so
+     * this is a no-op; dispute replay walks a proof out of live order and must
+     * load the block's previous-snapshot state first.
+     */
+    public abstract prepareStateMachineForLeaderCheck(
+        entry: QueuedBlockEntry,
+        diamondStateMachine: ADiamondStateMachine
+    ): Promise<void>;
 
     public abstract objectiveInvalidTimestampDetected(
         block: Block

--- a/src/stateManager/validationStrategy/BlockValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/BlockValidationStrategy.ts
@@ -14,6 +14,7 @@ import type P2PManager from "@/P2PManager";
 import type BlockQueueManager from "../BlockQueueManager";
 import DisputeManager from "@/disputeManager";
 import { Logger } from "@/utils";
+import type ADiamondStateMachine from "@/ADiamondStateMachine";
 
 export default class BlockValidationStrategy extends AValidationStrategy {
     readonly fraudProofService: FraudProofService;
@@ -31,6 +32,9 @@ export default class BlockValidationStrategy extends AValidationStrategy {
             this.storage,
             this.logger
         );
+    }
+    public get enforcesLiveForkAndOrderingGates(): boolean {
+        return true;
     }
     public async interpretFinalValidationResult(
         blockValidationResult: BlockValidationResult
@@ -256,6 +260,13 @@ export default class BlockValidationStrategy extends AValidationStrategy {
         // Malformed linkage, not a provable fraud proof - drop the sender.
         this.p2pManager.disconnectAndBlacklistPeers(entry.sourcePeers);
         return BlockValidationResult.DISCONNECT;
+    }
+    public async prepareStateMachineForLeaderCheck(
+        _entry: QueuedBlockEntry,
+        _diamondStateMachine: ADiamondStateMachine
+    ): Promise<void> {
+        // Live pipeline: the state machine already holds the predecessor state
+        // (blocks execute in order), so no repositioning is needed.
     }
     public async objectiveInvalidTimestampDetected(
         block: Block

--- a/src/stateManager/validationStrategy/CalldataCommittedStrategy.ts
+++ b/src/stateManager/validationStrategy/CalldataCommittedStrategy.ts
@@ -10,6 +10,7 @@ import AValidationStrategy, {
 import type { QueuedBlockEntry } from "@/storage/QueueStorage";
 import DisputeManager from "@/disputeManager";
 import BlockValidationStrategy from "./BlockValidationStrategy";
+import type ADiamondStateMachine from "@/ADiamondStateMachine";
 
 export default class CalldataCommittedStrategy extends AValidationStrategy {
     constructor(
@@ -17,6 +18,9 @@ export default class CalldataCommittedStrategy extends AValidationStrategy {
         private readonly blockValidationStrategy: BlockValidationStrategy
     ) {
         super();
+    }
+    public get enforcesLiveForkAndOrderingGates(): boolean {
+        return this.blockValidationStrategy.enforcesLiveForkAndOrderingGates;
     }
     public async interpretFinalValidationResult(
         blockValidationResult: BlockValidationResult
@@ -133,6 +137,15 @@ export default class CalldataCommittedStrategy extends AValidationStrategy {
         // otherwise our dispute.StateProof will reveal information for the timeout peer to do a dispute containing a double sign or invalid state transition fraud proof, which when reduce will cancel the timeout
         return this.blockValidationStrategy.blockIsNotLinkedAndIsNotFirstBlock(
             entry
+        );
+    }
+    public async prepareStateMachineForLeaderCheck(
+        entry: QueuedBlockEntry,
+        diamondStateMachine: ADiamondStateMachine
+    ): Promise<void> {
+        return this.blockValidationStrategy.prepareStateMachineForLeaderCheck(
+            entry,
+            diamondStateMachine
         );
     }
     public async objectiveInvalidTimestampDetected(

--- a/src/stateManager/validationStrategy/DisputeValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/DisputeValidationStrategy.ts
@@ -15,6 +15,7 @@ import {
 } from "@typechain-types/contracts/V1/types/DataTypes";
 import { Logger } from "@/utils";
 import { LocalDiamond } from "@typechain-types";
+import type ADiamondStateMachine from "@/ADiamondStateMachine";
 
 export default class DisputeValidationStrategy extends AValidationStrategy {
     readonly fraudProofService: FraudProofService;
@@ -38,6 +39,12 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
             this.storage,
             this.logger
         );
+    }
+
+    // Dispute replay audits a fixed proof out of live order on the disputed
+    // fork, so it enforces neither live gate and skips the disputed-fork lookup.
+    public get enforcesLiveForkAndOrderingGates(): boolean {
+        return false;
     }
 
     private createDisputeInvalidBlockInStateProofApplyFraudProof(
@@ -257,6 +264,8 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
     public async blockForkIsDisputed(
         _entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
+        // Guarded by enforcesLiveForkAndOrderingGates: dispute replay never
+        // reaches the disputed-fork gate (it audits the disputed fork itself).
         throw new Error(
             "DisputeValidationStrategy - blockForkIsDisputed should not be called"
         );
@@ -264,6 +273,8 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
     public async blockIsNotNextAndIsInTheFuture(
         _entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
+        // Guarded by enforcesLiveForkAndOrderingGates: dispute replay never
+        // reaches the future-block gate (it walks a proof out of live order).
         throw new Error(
             "DisputeValidationStrategy - blockIsNotNextAndIsInTheFuture should not be called"
         );
@@ -272,6 +283,42 @@ export default class DisputeValidationStrategy extends AValidationStrategy {
         _entry: QueuedBlockEntry
     ): Promise<BlockValidationResult> {
         return this.handleInvalidBlockStructure();
+    }
+    public async prepareStateMachineForLeaderCheck(
+        entry: QueuedBlockEntry,
+        diamondStateMachine: ADiamondStateMachine
+    ): Promise<void> {
+        // Dispute replay is not positioned at the block's predecessor (it walks
+        // a proof out of live order), so load the previous snapshot's state
+        // before the leader check. A missing snapshot/state is a bug on this
+        // path, not a peer fault - fail loudly rather than mis-proving.
+        const block = entry.block;
+        const previousSnapshot = this.storage.getPreviousStateSnapshot(
+            block.coordinates
+        );
+        if (!previousSnapshot) {
+            this.logger.error(
+                "DISPUTE Strategy - prepareStateMachineForLeaderCheck - missing previous snapshot",
+                { blockHash: block.hash }
+            );
+            throw new Error(
+                "Missing previous snapshot for dispute validation strategy"
+            );
+        }
+        const previousState =
+            this.storage.stateMachineStates.getStateMachineState(
+                previousSnapshot.stateMachineStateHash
+            );
+        if (!previousState) {
+            this.logger.error(
+                "DISPUTE Strategy - prepareStateMachineForLeaderCheck - missing previous state machine state",
+                { blockHash: block.hash }
+            );
+            throw new Error(
+                "Missing previous state machine state for dispute validation strategy"
+            );
+        }
+        await diamondStateMachine.setState(previousState);
     }
     public async objectiveInvalidTimestampDetected(
         block: Block

--- a/src/stateManager/validationStrategy/SpectatingValidationStrategy.ts
+++ b/src/stateManager/validationStrategy/SpectatingValidationStrategy.ts
@@ -13,6 +13,7 @@ import Storage from "@/storage";
 import type P2PManager from "@/P2PManager";
 import type BlockQueueManager from "../BlockQueueManager";
 import { Logger } from "@/utils";
+import type ADiamondStateMachine from "@/ADiamondStateMachine";
 
 export default class SpectatingValidationStrategy extends AValidationStrategy {
     private readonly fraudProofService: FraudProofService;
@@ -29,6 +30,9 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
             this.storage,
             this.logger
         );
+    }
+    public get enforcesLiveForkAndOrderingGates(): boolean {
+        return true;
     }
     public async interpretFinalValidationResult(
         blockValidationResult: BlockValidationResult
@@ -198,6 +202,13 @@ export default class SpectatingValidationStrategy extends AValidationStrategy {
         // Malformed linkage, not a provable fraud proof - drop the sender
         this.p2pManager.disconnectAndBlacklistPeers(entry.sourcePeers);
         return BlockValidationResult.DISCONNECT;
+    }
+    public async prepareStateMachineForLeaderCheck(
+        _entry: QueuedBlockEntry,
+        _diamondStateMachine: ADiamondStateMachine
+    ): Promise<void> {
+        // Spectate sync applies blocks in order, so the state machine already
+        // holds the predecessor state - no repositioning is needed.
     }
     public async objectiveInvalidTimestampDetected(
         _block: Block

--- a/test/unit/ValidationService.test.ts
+++ b/test/unit/ValidationService.test.ts
@@ -1518,6 +1518,60 @@ describe("Unit: ValidationService", function () {
                 "invalidStateTransitionDetected"
             ]);
         });
+
+        it("repositions the state machine to the block's predecessor before the leader check", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 2);
+
+            // a real valid next block, authored off-wire; the observer's live
+            // machine is still positioned at the block's predecessor
+            const { observer, authored, forkId } =
+                await h.transition.authorNextBlockOffWireWait();
+
+            // mis-position the observer's machine at genesis - a different valid
+            // stored state whose next writer differs from the block's leader
+            const { correctLeader, wrongLeader } = await h.execOnHost(
+                observer,
+                async (sm, args) => {
+                    const correctLeader =
+                        await sm.diamondStateMachine.getNextToWrite();
+                    const genesis =
+                        sm.storage.stateSnapshots.getGenesisSnapshotByForkId(
+                            args.forkId
+                        )!;
+                    const genesisState =
+                        sm.storage.stateMachineStates.getStateMachineState(
+                            genesis.stateMachineStateHash
+                        )!;
+                    await sm.diamondStateMachine.setState(genesisState);
+                    const wrongLeader =
+                        await sm.diamondStateMachine.getNextToWrite();
+                    return { correctLeader, wrongLeader };
+                },
+                { forkId }
+            );
+
+            // preconditions that make the preload observable: the block's real
+            // leader is the predecessor's next writer, and genesis names another
+            expect(authored!.author).to.equal(correctLeader);
+            expect(
+                wrongLeader,
+                "genesis must name a different next writer"
+            ).to.not.equal(correctLeader);
+
+            // only prepareStateMachineForLeaderCheck's setState can move the
+            // machine back to the predecessor; without it getNextToWrite returns
+            // wrongLeader and the leader check flags the block instead
+            const r = await h
+                .control(observer)
+                .stub.runBlockValidation(authored!.encodedBlockConfirmation, {
+                    strategy: "dispute"
+                })
+                .request();
+
+            expect(r.resultName).to.equal("SUCCESS");
+            expect(r.firedHooks).to.deep.equal([]);
+        });
     });
 
     // the probe replaces shared live methods (dispute/disconnect/restore) while


### PR DESCRIPTION
## Summary

The shared block-validation pipeline (`ValidationService.validateBlockConfirmation`) branched on `instanceof DisputeValidationStrategy` at three sites — to skip the disputed-fork gate, skip the future-block gate, and preload the predecessor state before the next-leader check. This routes each per-pipeline deviation through the strategy interface instead of a concrete-type check at the call site, matching the "block-validation deviations go through the strategy" convention.

- A new `enforcesLiveForkAndOrderingGates` getter on `AValidationStrategy` gates the two live checks. The live, spectate, and calldata pipelines enforce both; dispute replay returns `false` and skips them, so it never pays for the disputed-fork lookup on the per-block audit path.
- A new `prepareStateMachineForLeaderCheck` hook positions the state machine before the leader check — a no-op for the live and spectate pipelines (already positioned) and the previous-snapshot `setState` for dispute replay.

Behavior is unchanged, and `ValidationService` no longer references the concrete `DisputeValidationStrategy` type.

## Test Plan

- `yarn tsc --noEmit -p tsconfig.json` and `-p tsconfig.browser.json` — pass
- Focused unit suite (`--grep "DisputeValidationStrategy|isDisputedFork|storage interleaving"`) — 18 passing, including a new case that pins the predecessor `setState`: it mis-positions the live state machine and asserts only the preload restores the correct next-leader (mutation-checked by removing the `setState`)
- Dispute-validation e2e (`--grep "E2E: dispute validation"`) — 68 passing