### PR TITLE
feat(contracts): report what the inbound-blocks check compared when it rejects

### DIFF
--- a/contracts/V1/StateChannelDiamondProxy/DisputeVerificationFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeVerificationFacet.sol
@@ -304,7 +304,7 @@ contract DisputeVerificationFacet is StateChannelCommon {
         );
         //verify inbound message blocks
         (bool inboundMessageBlocksValid, bytes32 runningInboundHash, uint256 breakIndex, uint8 failureReason) =
-        _walkInboundMessageBlocks(
+        _verifyInboundMessageBlocks(
             latestStateSnapshot.snapshotData.latestInboundMessageBlockHash,
             reducedOutput.latestInboundMessageBlockHash,
             inboundMessageBlocks

--- a/contracts/V1/StateChannelDiamondProxy/DisputeVerificationFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeVerificationFacet.sol
@@ -303,13 +303,22 @@ contract DisputeVerificationFacet is StateChannelCommon {
             ErrorInvalidLatestState()
         );
         //verify inbound message blocks
+        (bool inboundMessageBlocksValid, bytes32 runningInboundHash, uint256 breakIndex, uint8 failureReason) =
+        _walkInboundMessageBlocks(
+            latestStateSnapshot.snapshotData.latestInboundMessageBlockHash,
+            reducedOutput.latestInboundMessageBlockHash,
+            inboundMessageBlocks
+        );
         require(
-            _verifyInboundMessageBlocks(
+            inboundMessageBlocksValid,
+            ErrorDisputeInboundMessageBlocksInvalid(
                 latestStateSnapshot.snapshotData.latestInboundMessageBlockHash,
                 reducedOutput.latestInboundMessageBlockHash,
-                inboundMessageBlocks
-            ),
-            ErrorDisputeInboundMessageBlocksInvalid()
+                runningInboundHash,
+                breakIndex,
+                inboundMessageBlocks.length,
+                failureReason
+            )
         );
 
         address[] memory removals = reducedOutput.selfRemovals;

--- a/contracts/V1/StateChannelDiamondProxy/Errors.sol
+++ b/contracts/V1/StateChannelDiamondProxy/Errors.sol
@@ -56,7 +56,29 @@ error ErrorDisputeStateMachineJoiningFailed();
 error ErrorDisputeStateMachineSlashingFailed();
 error ErrorDisputeStateMachineRemovingFailed();
 error ErrorDisputeStateMachineInboundProcessingFailed();
-error ErrorDisputeInboundMessageBlocksInvalid();
+// Why the inbound walk rejected the chain. Plain `uint8` constants rather than
+// an enum on purpose: `scripts/generate-enums.ts` numbers the generated TS
+// enums by discovery order, so adding an enum here would silently renumber
+// FraudProofType and DisputeFraudProofType.
+uint8 constant INBOUND_FAILURE_HASH_LINK = 0;
+uint8 constant INBOUND_FAILURE_HEIGHT_SEQUENCE = 1;
+uint8 constant INBOUND_FAILURE_FINAL_TARGET = 2;
+
+/// `submittedSnapshotInboundHash` is where the submitted snapshot said the
+/// inbound chain starts, `expectedTargetInboundHash` where reduce() said it
+/// ends, and `runningInboundHash` how far the walk actually got. `breakIndex`
+/// is the block that failed, or `submittedBlockCount` for a final-target
+/// mismatch. `failureReason` is one of the INBOUND_FAILURE_* constants — a
+/// hash link and a height sequence both break at a block index, and without it
+/// the two are indistinguishable.
+error ErrorDisputeInboundMessageBlocksInvalid(
+    bytes32 submittedSnapshotInboundHash,
+    bytes32 expectedTargetInboundHash,
+    bytes32 runningInboundHash,
+    uint256 breakIndex,
+    uint256 submittedBlockCount,
+    uint8 failureReason
+);
 error ErrorInvalidLatestState();
 
 //FraudProofs

--- a/contracts/V1/StateChannelDiamondProxy/StateChannelCommon.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateChannelCommon.sol
@@ -450,20 +450,10 @@ contract StateChannelCommon is StateChannelManagerStorage, StateChannelManagerEv
             return false;
         }
 
-        return _verifyInboundMessageBlocks(
+        (bool isValid,,,) = _verifyInboundMessageBlocks(
             latestStateSnapshot.snapshotData.latestInboundMessageBlockHash,
             dispute.input.latestInboundMessageBlockHash,
             inboundMessageBlocks
-        );
-    }
-
-    function _verifyInboundMessageBlocks(
-        bytes32 previousInboundMessageBlockHash,
-        bytes32 latestInboundMessageBlockHash,
-        MessageBlock[] memory inboundMessageBlocks
-    ) internal pure returns (bool) {
-        (bool isValid,,,) = _walkInboundMessageBlocks(
-            previousInboundMessageBlockHash, latestInboundMessageBlockHash, inboundMessageBlocks
         );
         return isValid;
     }
@@ -475,7 +465,7 @@ contract StateChannelCommon is StateChannelManagerStorage, StateChannelManagerEv
     /// `inboundMessageBlocks.length` for a final-target mismatch;
     /// `failureReason` is one of the INBOUND_FAILURE_* constants and is only
     /// meaningful when `isValid` is false.
-    function _walkInboundMessageBlocks(
+    function _verifyInboundMessageBlocks(
         bytes32 previousInboundMessageBlockHash,
         bytes32 latestInboundMessageBlockHash,
         MessageBlock[] memory inboundMessageBlocks

--- a/contracts/V1/StateChannelDiamondProxy/StateChannelCommon.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateChannelCommon.sol
@@ -462,20 +462,47 @@ contract StateChannelCommon is StateChannelManagerStorage, StateChannelManagerEv
         bytes32 latestInboundMessageBlockHash,
         MessageBlock[] memory inboundMessageBlocks
     ) internal pure returns (bool) {
+        (bool isValid,,,) = _walkInboundMessageBlocks(
+            previousInboundMessageBlockHash, latestInboundMessageBlockHash, inboundMessageBlocks
+        );
+        return isValid;
+    }
+
+    /// Walks the inbound chain and reports where and why it stopped, so a
+    /// caller that reverts can say what was compared instead of only that it
+    /// failed. `runningInboundMessageBlockHash` is the head the walk had
+    /// reached; `breakIndex` is the block that failed, or
+    /// `inboundMessageBlocks.length` for a final-target mismatch;
+    /// `failureReason` is one of the INBOUND_FAILURE_* constants and is only
+    /// meaningful when `isValid` is false.
+    function _walkInboundMessageBlocks(
+        bytes32 previousInboundMessageBlockHash,
+        bytes32 latestInboundMessageBlockHash,
+        MessageBlock[] memory inboundMessageBlocks
+    )
+        internal
+        pure
+        returns (bool isValid, bytes32 runningInboundMessageBlockHash, uint256 breakIndex, uint8 failureReason)
+    {
         uint256 lastHeight;
         bool hasLastHeight;
         for (uint256 i = 0; i < inboundMessageBlocks.length; i++) {
             if (previousInboundMessageBlockHash != inboundMessageBlocks[i].previousBlockHash) {
-                return false;
+                return (false, previousInboundMessageBlockHash, i, INBOUND_FAILURE_HASH_LINK);
             }
             if (hasLastHeight && inboundMessageBlocks[i].blockHeight != lastHeight + 1) {
-                return false;
+                return (false, previousInboundMessageBlockHash, i, INBOUND_FAILURE_HEIGHT_SEQUENCE);
             }
             previousInboundMessageBlockHash = keccak256(abi.encode(inboundMessageBlocks[i]));
             lastHeight = inboundMessageBlocks[i].blockHeight;
             hasLastHeight = true;
         }
-        return previousInboundMessageBlockHash == latestInboundMessageBlockHash;
+        return (
+            previousInboundMessageBlockHash == latestInboundMessageBlockHash,
+            previousInboundMessageBlockHash,
+            inboundMessageBlocks.length,
+            INBOUND_FAILURE_FINAL_TARGET
+        );
     }
 
     function _applyInboundMessages(

--- a/test/V1/StateChannelDiamondProxy/DisputeVerificationFacet.t.sol
+++ b/test/V1/StateChannelDiamondProxy/DisputeVerificationFacet.t.sol
@@ -64,13 +64,13 @@ contract DisputeExpiryGuardHarness is DisputeFraudProofFacet, DisputeVerificatio
 }
 
 /// Exposes the internal inbound walk so its report can be asserted directly.
-contract InboundWalkHarness is StateChannelCommon {
-    function walk(
+contract InboundVerificationHarness is StateChannelCommon {
+    function verifyInboundMessageBlocks(
         bytes32 previousInboundMessageBlockHash,
         bytes32 latestInboundMessageBlockHash,
         MessageBlock[] memory inboundMessageBlocks
     ) external pure returns (bool, bytes32, uint256, uint8) {
-        return _walkInboundMessageBlocks(
+        return _verifyInboundMessageBlocks(
             previousInboundMessageBlockHash, latestInboundMessageBlockHash, inboundMessageBlocks
         );
     }
@@ -79,7 +79,7 @@ contract InboundWalkHarness is StateChannelCommon {
 // test naming: test_<targetFunction>_<property>
 contract DisputeVerificationFacetTest is DiamondHarness {
     StateChannelManagerProxy internal diamond;
-    InboundWalkHarness internal walkHarness;
+    InboundVerificationHarness internal verificationHarness;
 
     bytes32 internal constant CHANNEL_ID = keccak256("dv-channel");
     bytes32 internal constant FORK_ID = keccak256("dv-fork");
@@ -87,7 +87,7 @@ contract DisputeVerificationFacetTest is DiamondHarness {
 
     function setUp() public {
         diamond = deployDiamond();
-        walkHarness = new InboundWalkHarness();
+        verificationHarness = new InboundVerificationHarness();
     }
 
     // reduce() must not OOB-panic when dispute.input.onChainSlashes.length exceeds
@@ -644,21 +644,21 @@ contract DisputeVerificationFacetTest is DiamondHarness {
 
     // ---- inbound message block walk ----
 
-    function test_walkInboundMessageBlocks_linkedChainMatchingTarget_isValid() public {
+    function test_verifyInboundMessageBlocks_linkedChainMatchingTarget_isValid() public {
         MessageBlock[] memory blocks = _linkedInboundBlocks(SNAPSHOT_HEAD, 3, 0);
         bytes32 target = _chainHead(blocks);
 
-        (bool isValid,,,) = walkHarness.walk(SNAPSHOT_HEAD, target, blocks);
+        (bool isValid,,,) = verificationHarness.verifyInboundMessageBlocks(SNAPSHOT_HEAD, target, blocks);
 
         assertTrue(isValid);
     }
 
-    function test_walkInboundMessageBlocks_firstBlockNotChainedToSnapshotHead_reportsHashLinkAtZero() public {
+    function test_verifyInboundMessageBlocks_firstBlockNotChainedToSnapshotHead_reportsHashLinkAtZero() public {
         MessageBlock[] memory blocks = _linkedInboundBlocks(SNAPSHOT_HEAD, 2, 0);
         blocks[0].previousBlockHash = keccak256("not the snapshot head");
 
         (bool isValid, bytes32 runningHash, uint256 breakIndex, uint8 reason) =
-            walkHarness.walk(SNAPSHOT_HEAD, _chainHead(blocks), blocks);
+            verificationHarness.verifyInboundMessageBlocks(SNAPSHOT_HEAD, _chainHead(blocks), blocks);
 
         assertFalse(isValid);
         assertEq(breakIndex, 0);
@@ -666,13 +666,13 @@ contract DisputeVerificationFacetTest is DiamondHarness {
         assertEq(reason, INBOUND_FAILURE_HASH_LINK);
     }
 
-    function test_walkInboundMessageBlocks_midChainLinkBroken_reportsHashLinkAtBreakIndex() public {
+    function test_verifyInboundMessageBlocks_midChainLinkBroken_reportsHashLinkAtBreakIndex() public {
         MessageBlock[] memory blocks = _linkedInboundBlocks(SNAPSHOT_HEAD, 3, 0);
         bytes32 headBeforeBreak = keccak256(abi.encode(blocks[0]));
         blocks[1].previousBlockHash = keccak256("wrong link");
 
         (bool isValid, bytes32 runningHash, uint256 breakIndex, uint8 reason) =
-            walkHarness.walk(SNAPSHOT_HEAD, _chainHead(blocks), blocks);
+            verificationHarness.verifyInboundMessageBlocks(SNAPSHOT_HEAD, _chainHead(blocks), blocks);
 
         assertFalse(isValid);
         assertEq(breakIndex, 1);
@@ -683,13 +683,13 @@ contract DisputeVerificationFacetTest is DiamondHarness {
     // the case the reason code exists for: hashes chain correctly, so a report
     // without a reason looks like a consistent chain that broke for no visible
     // cause. Only the height sequence is wrong.
-    function test_walkInboundMessageBlocks_skippedHeight_reportsHeightSequenceWithIntactHashLink() public {
+    function test_verifyInboundMessageBlocks_skippedHeight_reportsHeightSequenceWithIntactHashLink() public {
         MessageBlock[] memory blocks = _linkedInboundBlocks(SNAPSHOT_HEAD, 3, 0);
         bytes32 headBeforeBreak = keccak256(abi.encode(blocks[0]));
         blocks[1].blockHeight = blocks[0].blockHeight + 2;
 
         (bool isValid, bytes32 runningHash, uint256 breakIndex, uint8 reason) =
-            walkHarness.walk(SNAPSHOT_HEAD, _chainHead(blocks), blocks);
+            verificationHarness.verifyInboundMessageBlocks(SNAPSHOT_HEAD, _chainHead(blocks), blocks);
 
         assertFalse(isValid);
         assertEq(breakIndex, 1);
@@ -700,12 +700,12 @@ contract DisputeVerificationFacetTest is DiamondHarness {
         assertEq(runningHash, blocks[1].previousBlockHash);
     }
 
-    function test_walkInboundMessageBlocks_allLinkedButWrongTarget_reportsFinalTargetAtBlockCount() public {
+    function test_verifyInboundMessageBlocks_allLinkedButWrongTarget_reportsFinalTargetAtBlockCount() public {
         MessageBlock[] memory blocks = _linkedInboundBlocks(SNAPSHOT_HEAD, 3, 0);
         bytes32 computedHead = _chainHead(blocks);
 
         (bool isValid, bytes32 runningHash, uint256 breakIndex, uint8 reason) =
-            walkHarness.walk(SNAPSHOT_HEAD, keccak256("some other target"), blocks);
+            verificationHarness.verifyInboundMessageBlocks(SNAPSHOT_HEAD, keccak256("some other target"), blocks);
 
         assertFalse(isValid);
         assertEq(breakIndex, blocks.length);
@@ -713,13 +713,13 @@ contract DisputeVerificationFacetTest is DiamondHarness {
         assertEq(reason, INBOUND_FAILURE_FINAL_TARGET);
     }
 
-    function test_walkInboundMessageBlocks_noBlocks_comparesSnapshotHeadAgainstTarget() public {
+    function test_verifyInboundMessageBlocks_noBlocks_comparesSnapshotHeadAgainstTarget() public {
         MessageBlock[] memory blocks = new MessageBlock[](0);
 
         (bool matching,, uint256 matchingBreakIndex, uint8 matchingReason) =
-            walkHarness.walk(SNAPSHOT_HEAD, SNAPSHOT_HEAD, blocks);
+            verificationHarness.verifyInboundMessageBlocks(SNAPSHOT_HEAD, SNAPSHOT_HEAD, blocks);
         (bool mismatched, bytes32 runningHash,, uint8 mismatchedReason) =
-            walkHarness.walk(SNAPSHOT_HEAD, keccak256("other"), blocks);
+            verificationHarness.verifyInboundMessageBlocks(SNAPSHOT_HEAD, keccak256("other"), blocks);
 
         assertTrue(matching);
         assertEq(matchingBreakIndex, blocks.length);

--- a/test/V1/StateChannelDiamondProxy/DisputeVerificationFacet.t.sol
+++ b/test/V1/StateChannelDiamondProxy/DisputeVerificationFacet.t.sol
@@ -6,7 +6,12 @@ import {DisputeFraudProofFacet} from "../../../contracts/V1/StateChannelDiamondP
 import {DisputeVerificationFacet} from "../../../contracts/V1/StateChannelDiamondProxy/DisputeVerificationFacet.sol";
 import {StateProofFacet} from "../../../contracts/V1/StateChannelDiamondProxy/StateProofFacet.sol";
 import {UtilityFacet} from "../../../contracts/V1/StateChannelDiamondProxy/UtilityFacet.sol";
+import {StateChannelCommon} from "../../../contracts/V1/StateChannelDiamondProxy/StateChannelCommon.sol";
 import {
+    ErrorDisputeInboundMessageBlocksInvalid,
+    INBOUND_FAILURE_FINAL_TARGET,
+    INBOUND_FAILURE_HASH_LINK,
+    INBOUND_FAILURE_HEIGHT_SEQUENCE,
     RaceConditionDisputeKillPeriodExpired,
     RaceConditionDisputeTimeoutWindowCreatedTooEarly
 } from "../../../contracts/V1/StateChannelDiamondProxy/Errors.sol";
@@ -58,15 +63,31 @@ contract DisputeExpiryGuardHarness is DisputeFraudProofFacet, DisputeVerificatio
     }
 }
 
+/// Exposes the internal inbound walk so its report can be asserted directly.
+contract InboundWalkHarness is StateChannelCommon {
+    function walk(
+        bytes32 previousInboundMessageBlockHash,
+        bytes32 latestInboundMessageBlockHash,
+        MessageBlock[] memory inboundMessageBlocks
+    ) external pure returns (bool, bytes32, uint256, uint8) {
+        return _walkInboundMessageBlocks(
+            previousInboundMessageBlockHash, latestInboundMessageBlockHash, inboundMessageBlocks
+        );
+    }
+}
+
 // test naming: test_<targetFunction>_<property>
 contract DisputeVerificationFacetTest is DiamondHarness {
     StateChannelManagerProxy internal diamond;
+    InboundWalkHarness internal walkHarness;
 
     bytes32 internal constant CHANNEL_ID = keccak256("dv-channel");
     bytes32 internal constant FORK_ID = keccak256("dv-fork");
+    bytes32 internal constant SNAPSHOT_HEAD = keccak256("dv-inbound-head");
 
     function setUp() public {
         diamond = deployDiamond();
+        walkHarness = new InboundWalkHarness();
     }
 
     // reduce() must not OOB-panic when dispute.input.onChainSlashes.length exceeds
@@ -619,5 +640,146 @@ contract DisputeVerificationFacetTest is DiamondHarness {
             keccak256(abi.encode(snapshot.snapshotData)), reducedOutput, snapshot, encodedState, inboundMessageBlocks
         );
         return abi.decode(encodedModifiedState, (MathState)).participants;
+    }
+
+    // ---- inbound message block walk ----
+
+    function test_walkInboundMessageBlocks_linkedChainMatchingTarget_isValid() public {
+        MessageBlock[] memory blocks = _linkedInboundBlocks(SNAPSHOT_HEAD, 3, 0);
+        bytes32 target = _chainHead(blocks);
+
+        (bool isValid,,,) = walkHarness.walk(SNAPSHOT_HEAD, target, blocks);
+
+        assertTrue(isValid);
+    }
+
+    function test_walkInboundMessageBlocks_firstBlockNotChainedToSnapshotHead_reportsHashLinkAtZero() public {
+        MessageBlock[] memory blocks = _linkedInboundBlocks(SNAPSHOT_HEAD, 2, 0);
+        blocks[0].previousBlockHash = keccak256("not the snapshot head");
+
+        (bool isValid, bytes32 runningHash, uint256 breakIndex, uint8 reason) =
+            walkHarness.walk(SNAPSHOT_HEAD, _chainHead(blocks), blocks);
+
+        assertFalse(isValid);
+        assertEq(breakIndex, 0);
+        assertEq(runningHash, SNAPSHOT_HEAD);
+        assertEq(reason, INBOUND_FAILURE_HASH_LINK);
+    }
+
+    function test_walkInboundMessageBlocks_midChainLinkBroken_reportsHashLinkAtBreakIndex() public {
+        MessageBlock[] memory blocks = _linkedInboundBlocks(SNAPSHOT_HEAD, 3, 0);
+        bytes32 headBeforeBreak = keccak256(abi.encode(blocks[0]));
+        blocks[1].previousBlockHash = keccak256("wrong link");
+
+        (bool isValid, bytes32 runningHash, uint256 breakIndex, uint8 reason) =
+            walkHarness.walk(SNAPSHOT_HEAD, _chainHead(blocks), blocks);
+
+        assertFalse(isValid);
+        assertEq(breakIndex, 1);
+        assertEq(runningHash, headBeforeBreak);
+        assertEq(reason, INBOUND_FAILURE_HASH_LINK);
+    }
+
+    // the case the reason code exists for: hashes chain correctly, so a report
+    // without a reason looks like a consistent chain that broke for no visible
+    // cause. Only the height sequence is wrong.
+    function test_walkInboundMessageBlocks_skippedHeight_reportsHeightSequenceWithIntactHashLink() public {
+        MessageBlock[] memory blocks = _linkedInboundBlocks(SNAPSHOT_HEAD, 3, 0);
+        bytes32 headBeforeBreak = keccak256(abi.encode(blocks[0]));
+        blocks[1].blockHeight = blocks[0].blockHeight + 2;
+
+        (bool isValid, bytes32 runningHash, uint256 breakIndex, uint8 reason) =
+            walkHarness.walk(SNAPSHOT_HEAD, _chainHead(blocks), blocks);
+
+        assertFalse(isValid);
+        assertEq(breakIndex, 1);
+        assertEq(reason, INBOUND_FAILURE_HEIGHT_SEQUENCE);
+        // the hash link at the break is intact - this is exactly what a bare
+        // (runningHash, breakIndex) report could not distinguish
+        assertEq(runningHash, headBeforeBreak);
+        assertEq(runningHash, blocks[1].previousBlockHash);
+    }
+
+    function test_walkInboundMessageBlocks_allLinkedButWrongTarget_reportsFinalTargetAtBlockCount() public {
+        MessageBlock[] memory blocks = _linkedInboundBlocks(SNAPSHOT_HEAD, 3, 0);
+        bytes32 computedHead = _chainHead(blocks);
+
+        (bool isValid, bytes32 runningHash, uint256 breakIndex, uint8 reason) =
+            walkHarness.walk(SNAPSHOT_HEAD, keccak256("some other target"), blocks);
+
+        assertFalse(isValid);
+        assertEq(breakIndex, blocks.length);
+        assertEq(runningHash, computedHead);
+        assertEq(reason, INBOUND_FAILURE_FINAL_TARGET);
+    }
+
+    function test_walkInboundMessageBlocks_noBlocks_comparesSnapshotHeadAgainstTarget() public {
+        MessageBlock[] memory blocks = new MessageBlock[](0);
+
+        (bool matching,, uint256 matchingBreakIndex, uint8 matchingReason) =
+            walkHarness.walk(SNAPSHOT_HEAD, SNAPSHOT_HEAD, blocks);
+        (bool mismatched, bytes32 runningHash,, uint8 mismatchedReason) =
+            walkHarness.walk(SNAPSHOT_HEAD, keccak256("other"), blocks);
+
+        assertTrue(matching);
+        assertEq(matchingBreakIndex, blocks.length);
+        assertEq(matchingReason, INBOUND_FAILURE_FINAL_TARGET);
+        assertFalse(mismatched);
+        assertEq(runningHash, SNAPSHOT_HEAD);
+        assertEq(mismatchedReason, INBOUND_FAILURE_FINAL_TARGET);
+    }
+
+    // proves the walk's report actually reaches the revert payload callers decode
+    function test_reduceOutputToSnapshotData_unlinkedInboundBlocks_revertsCarryingComparedHashes() public {
+        MathState memory state;
+        state.participants = _participants();
+        state.balances = new uint256[](state.participants.length);
+        bytes memory encodedState = abi.encode(state);
+
+        StateSnapshot memory snapshot;
+        snapshot.snapshotData.stateMachineStateHash = keccak256(encodedState);
+        snapshot.snapshotData.latestInboundMessageBlockHash = SNAPSHOT_HEAD;
+
+        MessageBlock[] memory blocks = _linkedInboundBlocks(SNAPSHOT_HEAD, 2, 0);
+        blocks[0].previousBlockHash = keccak256("not the snapshot head");
+
+        ReduceOutput memory reducedOutput;
+        reducedOutput.latestInboundMessageBlockHash = keccak256("target");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ErrorDisputeInboundMessageBlocksInvalid.selector,
+                SNAPSHOT_HEAD,
+                reducedOutput.latestInboundMessageBlockHash,
+                SNAPSHOT_HEAD,
+                uint256(0),
+                uint256(blocks.length),
+                INBOUND_FAILURE_HASH_LINK
+            )
+        );
+        diamond.reduceOutputToSnapshotData(
+            keccak256(abi.encode(snapshot.snapshotData)), reducedOutput, snapshot, encodedState, blocks
+        );
+    }
+
+    /// `count` blocks each chained to the previous, heights ascending from
+    /// `firstHeight`, the first anchored to `startHash`.
+    function _linkedInboundBlocks(bytes32 startHash, uint256 count, uint256 firstHeight)
+        internal
+        pure
+        returns (MessageBlock[] memory blocks)
+    {
+        blocks = new MessageBlock[](count);
+        bytes32 runningHash = startHash;
+        for (uint256 i = 0; i < count; i++) {
+            blocks[i].previousBlockHash = runningHash;
+            blocks[i].blockHeight = firstHeight + i;
+            blocks[i].timestamp = 1000 + i;
+            runningHash = keccak256(abi.encode(blocks[i]));
+        }
+    }
+
+    function _chainHead(MessageBlock[] memory blocks) internal pure returns (bytes32 head) {
+        head = blocks.length == 0 ? bytes32(0) : keccak256(abi.encode(blocks[blocks.length - 1]));
     }
 }


### PR DESCRIPTION
## Summary

`ErrorDisputeInboundMessageBlocksInvalid` carried no arguments, so off-chain all
we had was the error name. Two opposite causes produce it:

- the chain's reduction target moved between `compute()` and submission — our
  candidate went stale through no fault of our own; or
- our own supplied blocks never linked — our local view diverged.

They call for opposite responses, and the name alone cannot tell them apart.

This makes the check report what it compared:

```solidity
error ErrorDisputeInboundMessageBlocksInvalid(
    bytes32 submittedSnapshotInboundHash,  // where the submitted snapshot said the chain starts
    bytes32 expectedTargetInboundHash,     // where reduce() said it ends
    bytes32 runningInboundHash,            // how far the walk actually got
    uint256 breakIndex,                    // the block that failed, or submittedBlockCount
    uint256 submittedBlockCount,
    uint8   failureReason                  // INBOUND_FAILURE_*
);
```

`failureReason` earns its place: a broken hash link and a broken height sequence
stop at the *same* index, and in the height case the running head and the
block's `previousBlockHash` still match — so without it the log shows a
consistent-looking chain that broke for no visible reason.

It is a `uint8` with named constants rather than an enum on purpose.
`scripts/generate-enums.ts` numbers the generated TS enums by discovery order
(`(i+1)*100`), and `src/types/sol-enums.ts` is tracked — a new enum in a file
sorting before `ProofTypes.sol` would have silently renumbered `FraudProofType`
and `DisputeFraudProofType`.

No block heights are added to the payload: the submitter already holds the
blocks, and the off-chain log records each block's height and
`previousBlockHash`, so the heights around `breakIndex` are already available.
That also keeps the added bytecode small — see the size note below.

There is now a single `_verifyInboundMessageBlocks`, which always returns the
full report `(bool isValid, bytes32 runningInboundMessageBlockHash, uint256
breakIndex, uint8 failureReason)`. `reduceOutputToSnapshotData` forwards the
whole report into `ErrorDisputeInboundMessageBlocksInvalid`, while
`_isDataLinkedToDisputeInput` destructures only `isValid` and discards the rest.
The bool-only wrapper that used to sit in front of the walk is gone; it cost
nothing to remove, as the optimizer had already inlined it (bytecode is
byte-identical).

## Test Plan

- `yarn compile` — clean
- `yarn tsc --noEmit` on `tsconfig.json` and `tsconfig.browser.json` — clean
- `forge test --match-path test/V1/StateChannelDiamondProxy/DisputeVerificationFacet.t.sol`
  — **32 passing** (was 25)
- `forge test` (full) — **52 passing**

Seven new forge cases, via an `InboundVerificationHarness` exposing the internal
check:

- valid chain matching the target
- first block not anchored to the snapshot head → `breakIndex 0`, hash-link
- mid-chain link break → `breakIndex 1`, running head = hash of block 0
- **skipped height** → height-sequence reason, and asserts the hash link at the
  break is *intact* — pinning exactly the ambiguity `failureReason` removes
- all blocks linked but wrong target → `breakIndex == submittedBlockCount`
- empty block array boundary
- plus one driving the real revert through `reduceOutputToSnapshotData` with
  `vm.expectRevert(abi.encodeWithSelector(...))`, so the payload is proven
  end-to-end and not only at the helper

## Reviewer notes

**Breaking ABI change.** The selector moves from `0x4b021fb0` to `0x3a7249bd`.
An SDK built before this change, pointed at a chain running these contracts,
will fail `parseError` and log no error name at all — strictly less than today.
Contracts and SDK should ship together. Tests never catch this because they
deploy fresh contracts every run.

**Contract size.** `DisputeVerificationFacet` goes from 24783 to 24866 bytes
against the 24576 EIP-170 limit. It was **already over** before this change —
measured with a clean compile of the base contracts — so this is not a new
regression, but it moves the wrong way on a facet that already cannot deploy to
mainnet. `StateChannelManagerProxy`, `DisputeFraudProofFacet` and `LocalDiamond`
are over the limit on `dispute` too.

**Known gap.** Only the reduction path gets this evidence. The same check also
runs through `_isDataLinkedToDisputeInput`, whose two callers
(`DisputeVerificationFacet.isDisputeOutputCorrect`,
`DisputeFraudProofFacet._handleDisputeInvalidOutputState`) still turn a failure
into a bare `false`. Those must keep returning false rather than reverting, so
surfacing detail there needs a different mechanism — an event for the
fraud-proof path, and a return-shape change for the `staticCall` path. Left for
a follow-up rather than widened into this PR.

