### PR TITLE
speed up harness test setup

### DIFF
--- a/scripts/V1/deploy.ts
+++ b/scripts/V1/deploy.ts
@@ -201,6 +201,8 @@ export type DeployFullStackParams = {
     consumerFacetArgs?: any[];
     timeConfig?: TimeConfig;
     disputeExecutionGasLimit?: number;
+    /** Reuse already-deployed config-independent facets (see `deploy`). */
+    facetAddresses?: string[];
 };
 
 export async function deploy(
@@ -208,9 +210,15 @@ export async function deploy(
     consumerFacetAddress: string,
     signer: Signer,
     timeConfigOverrides?: TimeConfig,
-    disputeExecutionGasLimit: number = DEFAULT_DISPUTE_EXECUTION_GAS_LIMIT
+    disputeExecutionGasLimit: number = DEFAULT_DISPUTE_EXECUTION_GAS_LIMIT,
+    // The dispute/verification facets are stateless and config-independent:
+    // a caller that already deployed them (or found them cached on the node)
+    // passes their addresses to skip the redeploy — only the proxy carries
+    // timeConfig/gas-limit state.
+    existingFacetAddresses?: string[]
 ): Promise<{ address: string; contract: StateChannelManagerProxy }> {
-    const facetAddresses = await deployFacets(signer);
+    const facetAddresses =
+        existingFacetAddresses ?? (await deployFacets(signer));
     const timeConfig = getTimeConfig(timeConfigOverrides);
     return await deployArtifact<StateChannelManagerProxy>(
         StateChannelManagerProxyArtifact,
@@ -240,7 +248,8 @@ export async function deployFullStack(
         stateMachineArgs,
         consumerFacetArgs,
         timeConfig,
-        disputeExecutionGasLimit
+        disputeExecutionGasLimit,
+        facetAddresses
     } = params;
 
     const stateMachinePromise = deployArtifact(stateMachineArtifact, signer, {
@@ -259,7 +268,8 @@ export async function deployFullStack(
         consumerFacetAddress,
         signer,
         timeConfig,
-        disputeExecutionGasLimit
+        disputeExecutionGasLimit,
+        facetAddresses
     );
 }
 

--- a/scripts/e2e-parallel/scheduler.js
+++ b/scripts/e2e-parallel/scheduler.js
@@ -146,38 +146,34 @@ async function runScheduler({
     const launch = (task, seq) => {
         running++;
         const acct = freeAccounts.shift();
-        const slot =
-            task.isE2E && slotCount > 0 ? slots[(seq - 1) % slotCount] : null;
+        // Every task is OFFERED a slot's infra; nothing is classified up front.
+        // The harness uses PROVIDER_URL when present (and reuses that node's
+        // already-deployed manager); tests that want their own chain simply
+        // ignore it and keep hardhat's in-process network.
+        const slot = slotCount > 0 ? slots[(seq - 1) % slotCount] : null;
         const where = slot ? `slot ${slot.id}/${slotCount}` : "in-process";
 
-        let taskArgs = task.args;
-        let infraEnv;
-        if (slot) {
-            taskArgs = [
-                task.args[0],
-                "--network",
-                "localhost",
-                ...task.args.slice(1)
-            ];
-            infraEnv = {
-                PROVIDER_URL: slot.nodeUrl,
-                HARDHAT_NODE_URL: slot.nodeUrl,
-                LOCAL_DISCOVERY_REGISTRY_URL: slot.discoveryUrl,
-                E2E_MANAGER_CACHE_DIR: slot.cacheDir,
-                E2E_INTERVAL_MINING: "1"
-            };
-        } else {
-            // Plain in-process Hardhat tests rely on automining: their setup
-            // helpers return deployed contracts for immediate use. Harness
-            // tests self-provision an interval-mined node when they need one.
-            infraEnv = {
-                PROVIDER_URL: undefined,
-                HARDHAT_NODE_URL: undefined,
-                LOCAL_DISCOVERY_REGISTRY_URL: undefined,
-                E2E_MANAGER_CACHE_DIR: undefined,
-                E2E_INTERVAL_MINING: undefined
-            };
-        }
+        // The task's own hardhat network stays untouched (default = in-process
+        // and automining), so tests that use it are unaffected by the offer.
+        // E2E_INTERVAL_MINING is deliberately NOT set: the slot node is
+        // already interval-mined by the runner, and setting it here would
+        // switch the in-process network out of automine for tests that need it.
+        const taskArgs = task.args;
+        const infraEnv = slot
+            ? {
+                  PROVIDER_URL: slot.nodeUrl,
+                  HARDHAT_NODE_URL: slot.nodeUrl,
+                  LOCAL_DISCOVERY_REGISTRY_URL: slot.discoveryUrl,
+                  E2E_MANAGER_CACHE_DIR: slot.cacheDir,
+                  E2E_INTERVAL_MINING: undefined
+              }
+            : {
+                  PROVIDER_URL: undefined,
+                  HARDHAT_NODE_URL: undefined,
+                  LOCAL_DISCOVERY_REGISTRY_URL: undefined,
+                  E2E_MANAGER_CACHE_DIR: undefined,
+                  E2E_INTERVAL_MINING: undefined
+              };
 
         logging.admission({
             seq,

--- a/scripts/test-e2e-parallel.js
+++ b/scripts/test-e2e-parallel.js
@@ -96,15 +96,12 @@ async function main(options = {}) {
     }
 
     // ---- resolve config ----
-    // TODO: Classify tasks by infrastructure needs instead of directory. Some
-    // non-E2E tests use the shared harness and could reuse slots, while plain
-    // unit/contract tests still require an isolated in-process Hardhat node.
-    const hasE2ETasks = tasks.some((task) => task.isE2E);
+    // Slots are provisioned unconditionally and offered to every task; no
+    // task is classified by directory or source. A test uses the shared node
+    // (via PROVIDER_URL) or ignores it and keeps hardhat's in-process network.
     const requestedSlotCount = cli.slots ?? DEFAULT_SLOTS;
-    const slotCount = hasE2ETasks
-        ? Math.min(requestedSlotCount, MAX_SLOTS_FROM_POOL)
-        : 0;
-    if (hasE2ETasks && requestedSlotCount > slotCount) {
+    const slotCount = Math.min(requestedSlotCount, MAX_SLOTS_FROM_POOL);
+    if (requestedSlotCount > slotCount) {
         console.log(
             `slots clamped to ${slotCount} (account pool allows ${MAX_SLOTS_FROM_POOL})`
         );

--- a/src/evm/EvmFactory.ts
+++ b/src/evm/EvmFactory.ts
@@ -5,6 +5,7 @@ import { CONSOLE_ADDRESS, createConsolePrecompile } from "./ConsolePrecompile";
 import type { Logger } from "@/utils";
 import { toEthereumJsEvmAddress } from "@/utils";
 import { importModuleFromManifest } from "@platform/moduleLoader";
+import { installEvmJumpdestCache } from "@platform/evmJumpdestCache";
 
 export type EvmCustomPrecompileManifest<TOptions = unknown> = {
     address: Address | string;
@@ -60,6 +61,9 @@ export async function createEvm(
         }
     ];
 
+    // See TODO(evm-upgrade) in ContractExecutor: v10 still re-scans per call,
+    // so the cache is the fix regardless of the package version.
+    installEvmJumpdestCache();
     const evm = await EVM.create({
         ...evmOptions,
         customPrecompiles

--- a/src/evm/browser/evmJumpdestCache.ts
+++ b/src/evm/browser/evmJumpdestCache.ts
@@ -1,0 +1,10 @@
+/**
+ * Browser twin of the node jumpdest cache: a no-op. The node patch reaches
+ * the interpreter through an absolute dist path, which bundlers cannot
+ * resolve; browser contract execution is not on the hot path this cache
+ * exists for.
+ */
+export function installEvmJumpdestCache(): void {}
+
+/** Mirrors the node twin's counters; always zero since nothing is cached. */
+export const evmJumpdestCacheStats = { analyses: 0, hits: 0 };

--- a/src/evm/contractExecutor/ContractExecutor.ts
+++ b/src/evm/contractExecutor/ContractExecutor.ts
@@ -10,12 +10,12 @@ import AContractExecutor, {
 } from "./AContractExecutor";
 import { LoggerUtils } from "@/utils/LoggerUtils";
 
-// TODO(evm-upgrade): profiling shows the @ethereumjs/evm 3.x interpreter
-// dominates CPU under load — Interpreter._getValidJumpDests re-scans the full
-// contract bytecode on EVERY message call (no code-hash cache), which is ~25%
-// of all EVM time for large viaIR facets behind a diamond. Try upgrading
-// @ethereumjs/evm (newer majors restructured jumpdest/opcode caching) or add
-// a code-keyed jumpdest cache.
+// Jumpdest scan cost: profiling showed Interpreter._getValidJumpDests
+// re-scanning the full contract bytecode on EVERY message call at ~25% of all
+// EVM CPU for large viaIR facets behind a diamond. Verified that
+// @ethereumjs/evm 10.x still re-scans per call (analysis is only skipped for
+// jump-free code), so upgrading does not fix it — the code-keyed cache in
+// @platform/evmJumpdestCache (installed by createEvm) does.
 export default class ContractExecutor extends AContractExecutor {
     private readonly evm: EVM;
     private readonly logger?: Logger;

--- a/src/evm/node/evmJumpdestCache.ts
+++ b/src/evm/node/evmJumpdestCache.ts
@@ -1,0 +1,81 @@
+import * as path from "node:path";
+
+type JumpdestAnalysis = {
+    jumps: Uint8Array;
+    pushes: Record<number, bigint>;
+    opcodesCached: unknown[];
+};
+
+type InterpreterInternals = {
+    /** `opcodes` is the STABLE active table; `getActiveOpcodes()` rebuilds it. */
+    _evm: { readonly opcodes: object };
+    _getValidJumpDests(code: Uint8Array): JumpdestAnalysis;
+};
+
+/** Miss/hit counters for the cache's component test and diagnostics. */
+export const evmJumpdestCacheStats = { analyses: 0, hits: 0 };
+
+let isInstalled = false;
+
+/**
+ * Installs a code-keyed cache for @ethereumjs/evm's jumpdest analysis.
+ *
+ * The 3.x (and 10.x) interpreter re-scans the FULL contract bytecode on every
+ * message call (`_getValidJumpDests`) — profiling showed this at ~25% of all
+ * EVM CPU for large viaIR facets behind a diamond, where every transition and
+ * view call re-analyzes the same deployed code. The state manager returns the
+ * same code buffer instance across calls, so caching by (EVM instance, code
+ * reference) turns the repeat scans into WeakMap hits. Same reference means
+ * same bytes (deployed code is never mutated), and keying per EVM keeps each
+ * cache tied to that EVM's opcode table. A fresh buffer simply misses and
+ * re-analyzes — never wrong, at worst the old cost.
+ *
+ * The Interpreter class is not part of the package's `exports`; the absolute
+ * dist path (which `exports` does not gate) is the supported escape hatch for
+ * this node-only patch. The browser twin is a no-op.
+ */
+export function installEvmJumpdestCache(): void {
+    if (isInstalled) return;
+    isInstalled = true;
+
+    const interpreterPath = path.join(
+        path.dirname(require.resolve("@ethereumjs/evm")),
+        "interpreter.js"
+    );
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { Interpreter } = require(interpreterPath) as {
+        Interpreter: { prototype: InterpreterInternals };
+    };
+
+    // Keyed by the ACTIVE OPCODE TABLE object, which the EVM replaces on a
+    // hardfork change — so a hardfork switch starts a fresh cache generation
+    // instead of serving stale opcode data.
+    const cachesByOpcodes = new WeakMap<
+        object,
+        WeakMap<Uint8Array, JumpdestAnalysis>
+    >();
+    const original = Interpreter.prototype._getValidJumpDests;
+    Interpreter.prototype._getValidJumpDests = function (
+        this: InterpreterInternals,
+        code: Uint8Array
+    ): JumpdestAnalysis {
+        // The `opcodes` GETTER returns the current table object and is stable
+        // within a hardfork; `getActiveOpcodes()` would rebuild it on every
+        // call, making each lookup a fresh key and every call a miss.
+        const opcodes = this._evm.opcodes;
+        let byCode = cachesByOpcodes.get(opcodes);
+        if (!byCode) {
+            byCode = new WeakMap();
+            cachesByOpcodes.set(opcodes, byCode);
+        }
+        const cached = byCode.get(code);
+        if (cached) {
+            evmJumpdestCacheStats.hits += 1;
+            return cached;
+        }
+        evmJumpdestCacheStats.analyses += 1;
+        const analysis = original.call(this, code);
+        byCode.set(code, analysis);
+        return analysis;
+    };
+}

--- a/test/evm/EvmJumpdestCache.test.ts
+++ b/test/evm/EvmJumpdestCache.test.ts
@@ -1,0 +1,115 @@
+import { expect } from "chai";
+import type { EVM } from "@ethereumjs/evm";
+import { Address, hexToBytes } from "@ethereumjs/util";
+
+import { createEvm } from "@/evm/EvmFactory";
+import { evmJumpdestCacheStats } from "@platform/evmJumpdestCache";
+import { createLogger } from "@/utils";
+
+const logger = createLogger({}, {}, { level: "error" });
+const CODE_ADDRESS = new Address(
+    hexToBytes("0x00000000000000000000000000000000000000aa")
+);
+
+/**
+ * Runtime code exercising a JUMP (so jumpdest analysis runs) and PUSH0 (0x5f),
+ * which is INVALID before Shanghai and valid from Shanghai on — the observable
+ * difference used to prove the cache follows the active hardfork.
+ *
+ *   PUSH1 0x04  JUMP  INVALID  JUMPDEST  PUSH0  POP  STOP
+ */
+const PUSH0_AFTER_JUMP = hexToBytes("0x600456fe5b5f5000");
+
+async function runCode(evm: EVM): Promise<{ failed: boolean }> {
+    const result = await evm.runCall({
+        to: CODE_ADDRESS,
+        gasLimit: BigInt(1_000_000),
+        data: new Uint8Array()
+    });
+    return { failed: Boolean(result.execResult.exceptionError) };
+}
+
+async function installCode(evm: EVM, code: Uint8Array): Promise<void> {
+    await evm.stateManager.putContractCode(CODE_ADDRESS, code);
+}
+
+/** Analyses performed (cache misses) while running `body`. */
+async function countAnalyses(body: () => Promise<void>): Promise<number> {
+    const before = evmJumpdestCacheStats.analyses;
+    await body();
+    return evmJumpdestCacheStats.analyses - before;
+}
+
+describe("EVM jumpdest cache (component)", function () {
+    it("analyzes once and then hits the cache for the same stored code", async function () {
+        const evm = await createEvm({}, logger);
+        await installCode(evm, PUSH0_AFTER_JUMP);
+
+        let first: { failed: boolean } | undefined;
+        let second: { failed: boolean } | undefined;
+        const firstAnalyses = await countAnalyses(async () => {
+            first = await runCode(evm);
+        });
+        const secondAnalyses = await countAnalyses(async () => {
+            second = await runCode(evm);
+        });
+
+        // The first execution analyzes; the second must add ZERO analyses —
+        // this fails if the cache key is unstable (e.g. rebuilt per call).
+        expect(firstAnalyses).to.equal(1);
+        expect(secondAnalyses).to.equal(0);
+        expect(second).to.deep.equal(first);
+    });
+
+    it("executes distinct code buffers independently", async function () {
+        const evm = await createEvm({}, logger);
+        // Code WITH a jump destination vs code whose jump lands on INVALID.
+        const badJump = hexToBytes("0x600456fefe5f5000");
+        await installCode(evm, PUSH0_AFTER_JUMP);
+        const good = await runCode(evm);
+        await installCode(evm, badJump);
+        const bad = await runCode(evm);
+
+        expect(good.failed).to.equal(false);
+        // A jump into a non-JUMPDEST byte is an invalid jump.
+        expect(bad.failed).to.equal(true);
+    });
+
+    it("keeps separate EVM instances independent", async function () {
+        const first = await createEvm({}, logger);
+        const second = await createEvm({}, logger);
+        await installCode(first, PUSH0_AFTER_JUMP);
+        await installCode(second, PUSH0_AFTER_JUMP);
+
+        expect(await runCode(first)).to.deep.equal(await runCode(second));
+    });
+
+    it("follows the active hardfork after it changes, for the same code reference", async function () {
+        // PUSH0 is invalid on Paris and valid from Shanghai: if the cache
+        // survived the hardfork switch, the second run would reuse Paris
+        // opcode data and still fail. Hardfork names are passed as strings
+        // because the EVM bundles its own @ethereumjs/common copy, whose enum
+        // is a different (incompatible) type from the top-level package's.
+        // Drive the EVM's own `common` (the same object a caller-provided
+        // one becomes), so the hardforkChanged path under test is identical.
+        const evm = await createEvm({}, logger);
+        evm.common.setHardfork("paris");
+        await installCode(evm, PUSH0_AFTER_JUMP);
+
+        let onParis: { failed: boolean } | undefined;
+        let onShanghai: { failed: boolean } | undefined;
+        await countAnalyses(async () => {
+            onParis = await runCode(evm);
+        });
+        evm.common.setHardfork("shanghai");
+        const afterSwitchAnalyses = await countAnalyses(async () => {
+            onShanghai = await runCode(evm);
+        });
+
+        // The hardfork switch invalidates the entry: the same code reference
+        // is analyzed again against the new opcode table.
+        expect(afterSwitchAnalyses).to.equal(1);
+        expect(onParis!.failed).to.equal(true);
+        expect(onShanghai!.failed).to.equal(false);
+    });
+});

--- a/test/evm/RuntimeChainContext.test.ts
+++ b/test/evm/RuntimeChainContext.test.ts
@@ -65,9 +65,13 @@ describe("RuntimeChainContext", () => {
                     channel.port2,
                     {
                         config: createConfig({
-                            PROVIDER_URL:
-                                process.env.PROVIDER_URL ??
-                                "http://127.0.0.1:18545"
+                            // Deliberately unreachable: this case asserts that
+                            // a failed chain connection is reported and the
+                            // host provider destroyed. It must NOT pick up an
+                            // ambient PROVIDER_URL — the runner offers every
+                            // task a live node, which would make startup
+                            // succeed and the assertions below meaningless.
+                            PROVIDER_URL: "http://127.0.0.1:1"
                         }),
                         scm,
                         stateMachine,

--- a/test/fixtures/PeerTestHarness.ts
+++ b/test/fixtures/PeerTestHarness.ts
@@ -41,8 +41,9 @@ import SyncCoordinator from "@test/utils/SyncCoordinator";
 import type { RemoteRpcProxyType } from "@/rpc/RemoteRpcProxy";
 import type { RpcRequestOptions } from "@/rpc/RpcHandler";
 import path from "node:path";
-import fs from "node:fs";
 import { createHash } from "node:crypto";
+import { deployFacets } from "../../scripts/V1/deploy";
+import { resolveOrDeployShared } from "../harness/core/deploymentCache";
 import HarnessControlRpc from "./customRpc/harnessControl/HarnessControlRpc";
 import type { CustomRpcManifest } from "@/rpc/registry";
 import type StateManager from "@/stateManager/StateManager";
@@ -441,53 +442,56 @@ export class PeerTestHarness<
                 JSON.stringify({
                     tc: sortedTc,
                     sm: String(stateMachineGasLimit),
-                    de: String(disputeExecutionGasLimit)
+                    de: String(disputeExecutionGasLimit),
+                    // Consumer-side identity (e.g. poker's maxPlayers): a
+                    // stack built with different parameters must never be
+                    // served from this cache.
+                    cs: deployment.getDeploymentCacheKeyFragment?.() ?? ""
                 })
             )
             .digest("hex")
             .slice(0, 16);
 
-        // Candidate A: explicit env var — validate strictly.
-        const explicitAddress = process.env.E2E_REUSE_MANAGER_ADDRESS;
-        if (explicitAddress && !ethers.isAddress(explicitAddress)) {
-            throw new Error(
-                `E2E_REUSE_MANAGER_ADDRESS is not a valid EVM address: ${explicitAddress}`
-            );
-        }
-
-        // Candidate B: per-slot cache dir marker file.
         const cacheDir = process.env.E2E_MANAGER_CACHE_DIR;
-        const markerPath = cacheDir
-            ? path.join(cacheDir, `${deployKey}.addr`)
-            : undefined;
-        let cachedAddress: string | undefined;
-        if (markerPath) {
-            try {
-                const raw = fs.readFileSync(markerPath, "utf8").trim();
-                if (ethers.isAddress(raw)) {
-                    cachedAddress = raw;
+
+        const hasCode = async (address: string): Promise<boolean> => {
+            if (!ethers.isAddress(address)) return false;
+            const code = await this.provider.getCode(address);
+            return Boolean(code) && code !== "0x";
+        };
+
+        // The dispute/verification facets are stateless and identical for
+        // every configuration, so one deployment per node serves every test:
+        // the marker cache deploys them once and later tests reuse them.
+        const facetResolution = await resolveOrDeployShared({
+            cacheDir,
+            markerName: "scm-facets.json",
+            validate: async (stored) => {
+                try {
+                    const parsed = JSON.parse(stored) as unknown;
+                    if (!Array.isArray(parsed) || parsed.length === 0) {
+                        return false;
+                    }
+                    const checks = await Promise.all(
+                        parsed.map((address) => hasCode(String(address)))
+                    );
+                    return checks.every(Boolean);
+                } catch {
+                    return false;
                 }
-                // Malformed marker → ignore, deploy fresh (no throw).
-            } catch {
-                // File not present or unreadable → no candidate.
-            }
-        }
+            },
+            deploy: async () =>
+                JSON.stringify(await deployFacets(deployerSigner)),
+            logger: this.logger
+        });
+        const facetAddresses = JSON.parse(facetResolution.value) as string[];
 
-        // A takes precedence over B.
-        const candidateAddress = explicitAddress || cachedAddress;
-        const candidateSource = explicitAddress ? "explicit env" : "cache";
-
-        let channelManagerAddress: string;
-        if (candidateAddress) {
-            const code = await this.provider.getCode(candidateAddress);
-            if (code && code !== "0x") {
-                channelManagerAddress = candidateAddress;
-                this.logger.debug(
-                    `Reusing deployed StateChannelManager at ${channelManagerAddress} (${candidateSource})`
-                );
-            } else {
-                // Node is fresh — candidate address is stale, deploy anew.
-                channelManagerAddress = await deployment.deployOnChainContracts(
+        const scmResolution = await resolveOrDeployShared({
+            cacheDir,
+            markerName: `${deployKey}.addr`,
+            validate: hasCode,
+            deploy: async () => {
+                const deployedAddress = await deployment.deployOnChainContracts(
                     {
                         signer: deployerSigner,
                         stateMachineGasLimit:
@@ -495,37 +499,22 @@ export class PeerTestHarness<
                         disputeExecutionGasLimit:
                             this.options.disputeExecutionGasLimit!,
                         timeConfig: this.options.timeConfig as TimeConfig,
-                        harnessConfig: this.harnessConfig
+                        harnessConfig: this.harnessConfig,
+                        facetAddresses
                     }
                 );
                 this.logger.debug(
-                    `Deployed StateChannelManager at ${channelManagerAddress}`
+                    `Deployed StateChannelManager at ${deployedAddress}`
                 );
-            }
-        } else {
-            channelManagerAddress = await deployment.deployOnChainContracts({
-                signer: deployerSigner,
-                stateMachineGasLimit: this.options.stateMachineGasLimit!,
-                disputeExecutionGasLimit:
-                    this.options.disputeExecutionGasLimit!,
-                timeConfig: this.options.timeConfig as TimeConfig,
-                harnessConfig: this.harnessConfig
-            });
+                return deployedAddress;
+            },
+            logger: this.logger
+        });
+        const channelManagerAddress = scmResolution.value;
+        if (scmResolution.source === "cache") {
             this.logger.debug(
-                `Deployed StateChannelManager at ${channelManagerAddress}`
+                `Reusing deployed StateChannelManager at ${channelManagerAddress} (cache)`
             );
-        }
-
-        // Write marker so subsequent tests on the same slot node can reuse.
-        if (cacheDir && markerPath) {
-            try {
-                fs.mkdirSync(cacheDir, { recursive: true });
-                fs.writeFileSync(markerPath, channelManagerAddress);
-            } catch (err) {
-                this.logger.debug(
-                    `Failed to write manager cache marker (non-fatal): ${err}`
-                );
-            }
         }
 
         // Wrap like the SDK wraps its own contracts: converts ethers `Result`s

--- a/test/harness/core/defaultMathHarnessDeployment.ts
+++ b/test/harness/core/defaultMathHarnessDeployment.ts
@@ -20,7 +20,8 @@ export async function deployDefaultMathOnChainContracts(
         stateMachineArgs: [params.stateMachineGasLimit],
         consumerFacetArgs: [],
         timeConfig: params.timeConfig,
-        disputeExecutionGasLimit: params.disputeExecutionGasLimit
+        disputeExecutionGasLimit: params.disputeExecutionGasLimit,
+        facetAddresses: params.facetAddresses
     });
 
     return deployment.address;

--- a/test/harness/core/deploymentCache.ts
+++ b/test/harness/core/deploymentCache.ts
@@ -1,0 +1,54 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import type { Logger } from "@/utils";
+
+export type SharedDeploymentResolution = {
+    value: string;
+    source: "cache" | "deployed";
+};
+
+/**
+ * Resolve a node-scoped shared deployment through a marker file: reuse a valid
+ * marker, otherwise deploy and publish one for everyone after us.
+ *
+ * Deliberately lock-free. Concurrent first callers for the same key may each
+ * deploy a copy — but they run at the same time and would otherwise WAIT the
+ * same duration anyway, so coordinating them saves nothing while adding lock
+ * ownership, heartbeat, and takeover failure modes. Each caller uses the
+ * address it deployed; the marker keeps whichever landed last, and every later
+ * caller reuses that one. The runner resets the cache dir on every node
+ * (re)boot, so a marker can never describe a wiped chain.
+ */
+export async function resolveOrDeployShared(options: {
+    cacheDir: string | undefined;
+    markerName: string;
+    /** Confirms a stored value still matches the live node (e.g. has code). */
+    validate: (stored: string) => Promise<boolean>;
+    deploy: () => Promise<string>;
+    logger: Logger;
+}): Promise<SharedDeploymentResolution> {
+    const { cacheDir, markerName, validate, deploy, logger } = options;
+    if (!cacheDir) {
+        return { value: await deploy(), source: "deployed" };
+    }
+    const markerPath = path.join(cacheDir, markerName);
+
+    try {
+        const stored = fs.readFileSync(markerPath, "utf8").trim();
+        if (stored.length > 0 && (await validate(stored))) {
+            return { value: stored, source: "cache" };
+        }
+    } catch {
+        // Missing or unreadable marker → deploy below.
+    }
+
+    const value = await deploy();
+    try {
+        fs.mkdirSync(cacheDir, { recursive: true });
+        fs.writeFileSync(markerPath, value);
+    } catch (error) {
+        logger.debug(`Failed to write deployment marker (non-fatal): ${error}`);
+    }
+    return { value, source: "deployed" };
+}

--- a/test/harness/core/types.ts
+++ b/test/harness/core/types.ts
@@ -64,6 +64,8 @@ export type HarnessDeploymentParams = {
     disputeExecutionGasLimit: number;
     timeConfig: TimeConfig;
     harnessConfig: Partial<Config>;
+    /** Node-cached config-independent SCM facets to reuse (see `deploy`). */
+    facetAddresses?: string[];
 };
 
 export type HarnessOnChainContractsDeploymentParams = HarnessDeploymentParams;
@@ -73,6 +75,13 @@ export type HarnessLocalStateMachineDeploymentParams = HarnessDeploymentParams;
 export type HarnessDeploymentConfig<
     TContract extends AStateMachineContract = AStateMachineContract
 > = {
+    /**
+     * Extra identity for the deployed stack, folded into the node-level
+     * deployment cache key. MUST include every consumer-side parameter baked
+     * into the deployed state machine (e.g. poker's maxPlayers) — otherwise a
+     * cache hit could hand back a stack built with different parameters.
+     */
+    getDeploymentCacheKeyFragment?: () => string;
     /**
      * Deploy the on-chain state machine implementation, facets, and manager,
      * then return the deployed manager address.

--- a/test/unit/DeploymentCache.test.ts
+++ b/test/unit/DeploymentCache.test.ts
@@ -1,0 +1,111 @@
+import { expect } from "chai";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { resolveOrDeployShared } from "@test/harness/core/deploymentCache";
+import { createLogger } from "@/utils";
+
+function createTempCacheDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), "deploy-cache-"));
+}
+
+const logger = createLogger({}, {}, { level: "error" });
+
+describe("resolveOrDeployShared (component)", function () {
+    it("deploys once and serves every later caller from the marker", async function () {
+        const cacheDir = createTempCacheDir();
+        let deployCount = 0;
+        const run = () =>
+            resolveOrDeployShared({
+                cacheDir,
+                markerName: "thing.addr",
+                validate: async (stored) => stored.startsWith("0x"),
+                deploy: async () => {
+                    deployCount += 1;
+                    return "0xabc";
+                },
+                logger
+            });
+
+        const first = await run();
+        const second = await run();
+        const third = await run();
+
+        expect(first).to.deep.equal({ value: "0xabc", source: "deployed" });
+        expect(second).to.deep.equal({ value: "0xabc", source: "cache" });
+        expect(third).to.deep.equal({ value: "0xabc", source: "cache" });
+        expect(deployCount).to.equal(1);
+    });
+
+    it("gives concurrent first callers a usable value each, then caches for the rest", async function () {
+        const cacheDir = createTempCacheDir();
+        let deployCount = 0;
+        const run = () =>
+            resolveOrDeployShared({
+                cacheDir,
+                markerName: "race.addr",
+                validate: async (stored) => stored.startsWith("0x"),
+                deploy: async () => {
+                    deployCount += 1;
+                    await new Promise((resolve) => setTimeout(resolve, 200));
+                    // A distinct address per deployment, like a real deploy.
+                    return `0xrace${deployCount}`;
+                },
+                logger
+            });
+
+        const concurrent = await Promise.all([run(), run(), run()]);
+
+        // Concurrent first callers may each deploy (they run at the same time
+        // and would otherwise wait just as long) — every caller still gets a
+        // real deployed value, and nothing is corrupted.
+        expect(deployCount).to.be.greaterThan(0);
+        for (const entry of concurrent) {
+            expect(entry.value.startsWith("0xrace")).to.equal(true);
+            expect(entry.source).to.equal("deployed");
+        }
+        // Whichever landed last is published, and later callers reuse it.
+        const published = fs
+            .readFileSync(path.join(cacheDir, "race.addr"), "utf8")
+            .trim();
+        const later = await run();
+        expect(later).to.deep.equal({ value: published, source: "cache" });
+    });
+
+    it("redeploys when the stored value no longer validates", async function () {
+        const cacheDir = createTempCacheDir();
+        fs.writeFileSync(path.join(cacheDir, "stale.addr"), "not-an-address");
+        let deployCount = 0;
+
+        const result = await resolveOrDeployShared({
+            cacheDir,
+            markerName: "stale.addr",
+            // e.g. the node was wiped, so the stored address has no code.
+            validate: async (stored) => stored.startsWith("0x"),
+            deploy: async () => {
+                deployCount += 1;
+                return "0x123";
+            },
+            logger
+        });
+
+        expect(result).to.deep.equal({ value: "0x123", source: "deployed" });
+        expect(deployCount).to.equal(1);
+        // The fresh value replaced the stale marker.
+        expect(
+            fs.readFileSync(path.join(cacheDir, "stale.addr"), "utf8")
+        ).to.equal("0x123");
+    });
+
+    it("deploys directly when no cache dir is configured", async function () {
+        const result = await resolveOrDeployShared({
+            cacheDir: undefined,
+            markerName: "ignored.addr",
+            validate: async () => true,
+            deploy: async () => "0x789",
+            logger
+        });
+        expect(result).to.deep.equal({ value: "0x789", source: "deployed" });
+    });
+});

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -23,6 +23,7 @@
             "@platform/LocalDiscoveryServer": [
                 "src/utils/browser/LocalDiscoveryServer"
             ],
+            "@platform/evmJumpdestCache": ["src/evm/browser/evmJumpdestCache"],
             "@platform/moduleLoader": [
                 "src/utils/moduleLoader/browser/importModuleFromManifest"
             ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
             "@platform/LocalDiscoveryServer": [
                 "src/utils/node/LocalDiscoveryServer"
             ],
+            "@platform/evmJumpdestCache": ["src/evm/node/evmJumpdestCache"],
             "@platform/moduleLoader": [
                 "src/utils/moduleLoader/node/importModuleFromManifest"
             ],


### PR DESCRIPTION
shared nodes, cached deploys, EVM jumpdest cache (will do a PR to @ethereumjs directly, if accepted we'll use that) 

- offer every task a slot node instead of classifying by directory, so harness tests reuse one node's deployed manager rather than booting a private node and redeploying per test
- cache the manager and facet deployments per node behind a config-keyed marker; consumers add their own key fragment for baked-in parameters
- cache @ethereumjs/evm jumpdest analysis per (opcode table, code), which was ~25% of EVM CPU; keyed so a hardfork change invalidates it
- pin the startup-failure test to an unreachable URL now that a live node is always offered

