### PR TITLE
fix(workers): let workers drain on dispose instead of force-stopping

### DIFF
--- a/src/Holepunch.ts
+++ b/src/Holepunch.ts
@@ -13,22 +13,9 @@ class Holepunch {
     p2pManager: P2PManager;
     topics: Buffer[] = [];
     connectionCount = 0;
+    private readonly isBrowserRuntime: boolean;
     constructor(p2pManager: P2PManager) {
         this.p2pManager = p2pManager;
-        const setup = () => {
-            this.swarm.removeAllListeners(["connection"]); // since hyperwarm is injected into the runtime, creating a new Holepunch object still holds the same refrence to hyperwarm
-            this.swarm.on("connection", (socket: any, info: any) => {
-                this.p2pManager.logger.info("New holepunch peer connection", {
-                    connectionCount: ++this.connectionCount,
-                    transportType: "HOLEPUNCH"
-                });
-                this.p2pManager.logger.debug("Holepunch peer info", {
-                    peerInfo: info
-                });
-                new HolepunchTransport(socket, info, this.p2pManager);
-            });
-            this.rejoinTopics();
-        };
 
         // `window` is absent in a Web Worker, so RUN_SDK_IN_THREAD (Holepunch
         // running inside the SDK's browser worker) must also detect the worker
@@ -36,29 +23,52 @@ class Holepunch {
         // `@hyperswarm/dht` throws "not supported in browsers". Mirrors
         // isWorkerRuntime() in WebRTCSetup/connection/WebRTCProvider.ts.
         const browserGlobal = globalThis as any;
-        const isBrowserRuntime =
+        this.isBrowserRuntime =
             typeof window !== "undefined" ||
             (typeof browserGlobal.WorkerGlobalScope !== "undefined" &&
                 browserGlobal instanceof browserGlobal.WorkerGlobalScope);
-        if (isBrowserRuntime) {
+        if (this.isBrowserRuntime) {
             this.p2pManager.logger.info("Using browser Hyperswarm relay");
             p2pManager.preferredTransport = TransportType.WEBRTC;
             const relayerUrls = config.HOLEPUNCH_RELAYER_URLS;
             const relayerUpdateCallback = () => {
                 const swarm = HolepunchRelay.getInstance().getSwarm();
                 this.swarm = browserGlobal.Hyperswarm || swarm;
-                setup();
+                this.setupSwarm();
             };
             HolepunchRelay.init(
                 relayerUrls,
                 relayerUpdateCallback,
                 this.p2pManager.logger
             );
-        } else {
-            // @ts-ignore
-            this.swarm = global.Hyperswarm || new Hyperswarm();
-            setup();
         }
+        // Node: the swarm is created lazily on the first join(). An eagerly
+        // created Hyperswarm owns a live DHT socket (native utp udp/poll
+        // handles) even when the local debug transport is active and no topic
+        // is ever joined — and unclosed native handles abort worker teardown
+        // at uv_loop_close (see evm/node/workerShutdown.ts).
+    }
+
+    private setupSwarm() {
+        this.swarm.removeAllListeners(["connection"]); // since hyperwarm is injected into the runtime, creating a new Holepunch object still holds the same refrence to hyperwarm
+        this.swarm.on("connection", (socket: any, info: any) => {
+            this.p2pManager.logger.info("New holepunch peer connection", {
+                connectionCount: ++this.connectionCount,
+                transportType: "HOLEPUNCH"
+            });
+            this.p2pManager.logger.debug("Holepunch peer info", {
+                peerInfo: info
+            });
+            new HolepunchTransport(socket, info, this.p2pManager);
+        });
+        this.rejoinTopics();
+    }
+
+    private ensureNodeSwarm() {
+        if (this.swarm || this.isBrowserRuntime) return;
+        // @ts-ignore
+        this.swarm = global.Hyperswarm || new Hyperswarm();
+        this.setupSwarm();
     }
     //Mark resources for garbage collection
     public async dispose() {
@@ -72,6 +82,7 @@ class Holepunch {
         }
     }
     public async join(topic: Buffer) {
+        this.ensureNodeSwarm();
         this.topics.push(topic);
         this.swarm.join(topic, {
             server: true,

--- a/src/P2PManager.ts
+++ b/src/P2PManager.ts
@@ -248,6 +248,9 @@ class P2PManager<TCustomRpc extends MainRpcService = MainRpcService>
         }
     }
     public async tryOpenConnectionToChannel(channelId: string) {
+        // TODO: Give Holepunch and LocalDiscoveryServer the same lifecycle API
+        // and inject the selected backend so P2PManager does not know which
+        // discovery implementation it is using.
         if (config.DEBUG_LOCAL_TRANSPORT) {
             // In the browser there's no harness fixture to drive discovery, so
             // form the local mesh here via the relay hub. In node the harness

--- a/src/evm/EvmDiamondStateMachine.ts
+++ b/src/evm/EvmDiamondStateMachine.ts
@@ -540,7 +540,7 @@ class EvmDiamondStateMachine extends ADiamondStateMachine {
             };
             worker.postMessage(bootstrap, [transferablePort]);
             clientPort = localPort;
-            onClose = () => worker.terminate();
+            onClose = () => worker.shutdown();
         } else {
             const channel = createRuntimeChannel();
             clientPort = channel.port1;

--- a/src/evm/contractExecutor/WorkerContractExecutor.ts
+++ b/src/evm/contractExecutor/WorkerContractExecutor.ts
@@ -12,10 +12,8 @@ import type {
     WorkerCustomPrecompile,
     WorkerResponseMessage
 } from "./worker/protocol";
-import {
-    createContractExecutorWorker,
-    type WorkerLike
-} from "@platform/contractExecutorWorkerRuntime";
+import { createContractExecutorWorker } from "@platform/contractExecutorWorkerRuntime";
+import type { WorkerLike } from "./types";
 import { LoggerUtils } from "@/utils/LoggerUtils";
 
 type ContractExecutorOperation =
@@ -129,7 +127,7 @@ export default class WorkerContractExecutor extends AContractExecutor {
                 new Error("Contract executor worker disposed"),
                 false
             );
-            await this.worker.terminate?.();
+            await this.worker.shutdown?.();
         }
     }
 
@@ -147,6 +145,11 @@ export default class WorkerContractExecutor extends AContractExecutor {
     }
 
     private request(message: ContractExecutorRequestPayload) {
+        if (this.disposed && message.type !== "dispose") {
+            return Promise.reject(
+                new Error("Contract executor worker disposed")
+            );
+        }
         const request = {
             type: "request" as const,
             requestId: this.nextRequestId++,

--- a/src/evm/contractExecutor/browser/ContractExecutorWorkerEntry.ts
+++ b/src/evm/contractExecutor/browser/ContractExecutorWorkerEntry.ts
@@ -12,5 +12,6 @@ startContractExecutorWorkerHost(
         globalThis.onmessage = (event: MessageEvent<WorkerRequestMessage>) => {
             handler(event.data);
         };
-    }
+    },
+    () => globalThis.close()
 );

--- a/src/evm/contractExecutor/browser/ContractExecutorWorkerRuntime.ts
+++ b/src/evm/contractExecutor/browser/ContractExecutorWorkerRuntime.ts
@@ -2,11 +2,7 @@ import type {
     WorkerRequestMessage,
     WorkerResponseMessage
 } from "../worker/protocol";
-
-export type WorkerLike = {
-    postMessage(message: WorkerRequestMessage): void;
-    terminate?: () => Promise<unknown> | unknown;
-};
+import type { WorkerLike } from "../types";
 
 export type ContractExecutorWorkerMessageHandler = (
     message: WorkerResponseMessage
@@ -40,5 +36,8 @@ export function createContractExecutorWorker(
             new Error("Contract executor worker message could not be cloned")
         );
     };
-    return worker;
+    return {
+        postMessage: (message) => worker.postMessage(message),
+        shutdown: async () => worker.terminate()
+    };
 }

--- a/src/evm/contractExecutor/node/ContractExecutorWorkerEntry.ts
+++ b/src/evm/contractExecutor/node/ContractExecutorWorkerEntry.ts
@@ -15,5 +15,8 @@ startContractExecutorWorkerHost(
     (response: WorkerHostMessage) => port.postMessage(response),
     (handler: (message: WorkerRequestMessage) => void) => {
         port.on("message", handler);
-    }
+    },
+    // Close the port so the drained loop can exit naturally (see
+    // workerShutdown.ts for why the loop must never be force-stopped).
+    () => port.close()
 );

--- a/src/evm/contractExecutor/node/ContractExecutorWorkerRuntime.ts
+++ b/src/evm/contractExecutor/node/ContractExecutorWorkerRuntime.ts
@@ -3,15 +3,12 @@ import * as fs from "node:fs";
 import { Worker } from "node:worker_threads";
 import { resolveWorkerResourceLimits } from "../../node/workerResourceLimits";
 import { instrumentWorkerStartup } from "../../node/workerStartupTiming";
+import { createWorkerShutdown } from "../../node/workerShutdown";
+import type { WorkerLike } from "../types";
 import type {
     WorkerRequestMessage,
     WorkerResponseMessage
 } from "../worker/protocol";
-
-export type WorkerLike = {
-    postMessage(message: WorkerRequestMessage): void;
-    terminate?: () => Promise<unknown> | unknown;
-};
 
 export type ContractExecutorWorkerMessageHandler = (
     message: WorkerResponseMessage
@@ -44,7 +41,8 @@ export function createContractExecutorWorker(
         execArgv,
         resourceLimits: resolveWorkerResourceLimits("vm")
     });
-    let terminating = false;
+    const shutdownWorker = createWorkerShutdown(worker);
+    let shuttingDown = false;
     instrumentWorkerStartup(
         worker,
         "vm",
@@ -55,15 +53,15 @@ export function createContractExecutorWorker(
     worker.on("message", onMessage);
     worker.on("error", onError);
     worker.on("exit", (code: number) => {
-        if (!terminating && code !== 0) {
+        if (!shuttingDown && code !== 0) {
             onError(new Error(`Contract executor worker exited with ${code}`));
         }
     });
     return {
         postMessage: (message) => worker.postMessage(message),
-        terminate: () => {
-            terminating = true;
-            return worker.terminate();
+        shutdown: async () => {
+            shuttingDown = true;
+            await shutdownWorker();
         }
     };
 }

--- a/src/evm/contractExecutor/types.ts
+++ b/src/evm/contractExecutor/types.ts
@@ -14,7 +14,7 @@ export type {
 
 export type WorkerLike = {
     postMessage(message: WorkerRequestMessage): void;
-    terminate?: () => Promise<unknown> | unknown;
+    shutdown?: () => Promise<void>;
 };
 
 export type ContractExecutorWorkerMessageHandler = (

--- a/src/evm/contractExecutor/worker/ContractExecutorWorkerHostCore.ts
+++ b/src/evm/contractExecutor/worker/ContractExecutorWorkerHostCore.ts
@@ -124,11 +124,15 @@ class ContractExecutorWorkerHost {
 
     start(
         post: (response: WorkerHostMessage) => void,
-        onMessage: (handler: (message: WorkerRequestMessage) => void) => void
+        onMessage: (handler: (message: WorkerRequestMessage) => void) => void,
+        onDisposed?: () => void
     ): void {
         onMessage((message) => {
             if (message.type !== "request") return;
-            void this.handleRequest(message).then(post);
+            void this.handleRequest(message).then((response) => {
+                post(response);
+                if (message.payload.type === "dispose") onDisposed?.();
+            });
         });
 
         post({ type: "ready" });
@@ -137,7 +141,8 @@ class ContractExecutorWorkerHost {
 
 export function startContractExecutorWorkerHost(
     post: (response: WorkerHostMessage) => void,
-    onMessage: (handler: (message: WorkerRequestMessage) => void) => void
+    onMessage: (handler: (message: WorkerRequestMessage) => void) => void,
+    onDisposed?: () => void
 ): void {
-    new ContractExecutorWorkerHost().start(post, onMessage);
+    new ContractExecutorWorkerHost().start(post, onMessage, onDisposed);
 }

--- a/src/evm/node/workerCpuProfiler.ts
+++ b/src/evm/node/workerCpuProfiler.ts
@@ -4,11 +4,11 @@ import * as path from "node:path";
 // Env-gated V8 CPU profiler for worker threads (diagnostics only). Enabled by
 // setting SCP_CPU_PROFILE_DIR; profiles land there as .cpuprofile files.
 //
-// Worker threads are force-terminated by the test harness, so a profile that
-// only writes on clean exit would be lost. Instead the profile is flushed in
+// A failed worker may still require forced shutdown, so a profile that only
+// writes on clean exit could be lost. Instead the profile is flushed in
 // chunks (SCP_CPU_PROFILE_FLUSH_MS, default 5s) and once more on
 // uncaughtException — the event-loop starvation watchdog throws, so the chunk
-// containing the stall is written before the parent terminates the thread.
+// containing the stall is written before the worker exits.
 export function startCpuProfilerIfEnabled(label: string): void {
     const dir = process.env.SCP_CPU_PROFILE_DIR;
     if (!dir) return;

--- a/src/evm/node/workerShutdown.ts
+++ b/src/evm/node/workerShutdown.ts
@@ -1,0 +1,20 @@
+import { Worker } from "node:worker_threads";
+
+// Workers exit by draining naturally: after replying to dispose the worker
+// closes every handle it still holds (see closeWorkerBootstrapPort) and the
+// thread ends once the last close callback has run. Nothing may force-stop a
+// worker loop — parent-side terminate(), worker-side process.exit(), or
+// exiting the process while a worker thread is still alive all abort the
+// whole process with "uv_loop_close() while having open handles" when close
+// callbacks are pending (observed on Node 22.12 and 22.17 under
+// parallel-test load). That is also why this wait has no timeout: abandoning
+// a live worker only converts a slow drain into that abort at process exit,
+// while a genuinely stuck drain surfaces here as a visible hang that names
+// the leaking teardown.
+export function createWorkerShutdown(worker: Worker): () => Promise<void> {
+    return () =>
+        new Promise<void>((resolve) => {
+            if (worker.threadId === -1) return resolve();
+            worker.once("exit", () => resolve());
+        });
+}

--- a/src/evm/p2pRuntime/P2pRuntimeClient.ts
+++ b/src/evm/p2pRuntime/P2pRuntimeClient.ts
@@ -250,11 +250,11 @@ class P2pRuntimeClient<T = ethers.Contract> {
         if (this.disposed) return;
         // Send the dispose request before flipping `disposed` so it isn't
         // rejected by the guard in `request` — the host needs it to gracefully
-        // close its transport/timers before the worker is terminated.
+        // close its transport/timers before the worker exits.
         try {
             // Disposal owns its cleanup bounds. The generic request timeout can
-            // otherwise terminate a worker while provider/DHT handles are still
-            // closing, which makes Node abort in uv_loop_close().
+            // otherwise force shutdown while provider/DHT handles are still
+            // closing, which can make Node abort in uv_loop_close().
             await this.request<void>({ type: "dispose" }, { timeoutMs: null });
         } catch {
             // The host may already be gone; proceed with local teardown.

--- a/src/evm/p2pRuntime/P2pRuntimeHost.ts
+++ b/src/evm/p2pRuntime/P2pRuntimeHost.ts
@@ -15,7 +15,7 @@ import {
     getErrorPeerAddress,
     Type
 } from "@/utils";
-import { config } from "@/utils/config";
+import { config, isNodeRuntime } from "@/utils/config";
 import { LoggerUtils } from "@/utils/LoggerUtils";
 import MainRpcService from "@/rpc/MainRpcService";
 import { resolveCustomRpcConstructor } from "@/rpc/resolveCustomRpcManifest";
@@ -39,6 +39,7 @@ import {
 
 import type { HostHandlerExecutionContext } from "./HostHandlerExecutionContext";
 import type { Logger } from "@/utils/logging/Logger";
+import { LocalDiscoveryServer } from "@/utils";
 import type {
     HostRpcRequest,
     RuntimeClientRequest,
@@ -65,6 +66,8 @@ export interface HostContext {
      * thread runs exactly one peer's host, so no disambiguation is needed.
      */
     handlerExecutionContext?: HostHandlerExecutionContext;
+    /** Release worker-only bootstrap resources after replying to dispose. */
+    onDisposed?: () => void | Promise<void>;
 }
 
 /** Live runtime graph while the host is running. */
@@ -240,6 +243,16 @@ export async function startP2pRuntimeHost<
             // removing listeners first leaves eth_unsubscribe requests that
             // destroy then rejects as unhandled.
             if (!Clock.ownsProvider(provider)) await provider.destroy();
+            // TODO: Delegate cleanup through the shared Holepunch/local
+            // discovery lifecycle API once the backend is injected.
+            if (
+                ctx.onDisposed &&
+                config.DEBUG_LOCAL_TRANSPORT &&
+                isNodeRuntime() &&
+                config.LOCAL_DISCOVERY_REGISTRY_URL
+            ) {
+                await LocalDiscoveryServer.cleanup();
+            }
         }
     };
 
@@ -399,6 +412,7 @@ export async function startP2pRuntimeHost<
         const handleRequest = async (
             request: RuntimeClientRequest
         ): Promise<void> => {
+            const shouldCloseAfterResponse = request.type === "dispose";
             try {
                 let result: unknown;
                 switch (request.type) {
@@ -612,6 +626,10 @@ export async function startP2pRuntimeHost<
                     ok: false,
                     error: serializeError(error)
                 });
+            }
+            if (shouldCloseAfterResponse) {
+                port.close();
+                await ctx.onDisposed?.();
             }
         };
 

--- a/src/evm/p2pRuntime/browser/P2pRuntimeWorkerRuntime.ts
+++ b/src/evm/p2pRuntime/browser/P2pRuntimeWorkerRuntime.ts
@@ -6,12 +6,22 @@ import type {
 import { adaptPort } from "./P2pRuntimeChannel";
 
 export function createP2pRuntimeWorker(): P2pRuntimeWorker {
-    return new Worker(
+    const worker = new Worker(
         new URL("../worker/P2pRuntimeWorkerEntry.js", import.meta.url),
         {
             type: "module"
         }
-    ) as unknown as P2pRuntimeWorker;
+    );
+    return {
+        postMessage: (value, transfer) => {
+            if (transfer) {
+                worker.postMessage(value, transfer as Transferable[]);
+                return;
+            }
+            worker.postMessage(value);
+        },
+        shutdown: async () => worker.terminate()
+    };
 }
 
 /**
@@ -31,6 +41,11 @@ export function onWorkerBootstrap(
     scope.addEventListener("message", (event: MessageEvent) => {
         handler(event.data as WorkerBootstrapMessage);
     });
+}
+
+/** Close a disposed browser worker after its response has been posted. */
+export function closeWorkerBootstrapPort(): void {
+    self.close();
 }
 
 /** Adapt the transferred raw port to the platform-neutral surface. */

--- a/src/evm/p2pRuntime/node/P2pRuntimeWorkerRuntime.ts
+++ b/src/evm/p2pRuntime/node/P2pRuntimeWorkerRuntime.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import { resolveWorkerResourceLimits } from "../../node/workerResourceLimits";
 import { instrumentWorkerStartup } from "../../node/workerStartupTiming";
 import { startCpuProfilerIfEnabled } from "../../node/workerCpuProfiler";
+import { createWorkerShutdown } from "../../node/workerShutdown";
 import type {
     P2pRuntimeWorker,
     RuntimePort,
@@ -43,6 +44,7 @@ export function createP2pRuntimeWorker(): P2pRuntimeWorker {
         execArgv,
         resourceLimits: resolveWorkerResourceLimits("sdk")
     });
+    const shutdownWorker = createWorkerShutdown(worker);
     instrumentWorkerStartup(
         worker,
         "sdk",
@@ -50,7 +52,13 @@ export function createP2pRuntimeWorker(): P2pRuntimeWorker {
             ? "ts-node-swc-transpile-only"
             : "compiled-js"
     );
-    return worker as unknown as P2pRuntimeWorker;
+    return {
+        postMessage: (value, transfer) =>
+            worker.postMessage(value, transfer as readonly MessagePort[]),
+        shutdown: async () => {
+            await shutdownWorker();
+        }
+    };
 }
 
 /**
@@ -67,7 +75,55 @@ export function onWorkerBootstrap(
         );
     }
     startCpuProfilerIfEnabled("sdk");
-    parentPort.on("message", (data) => handler(data as WorkerBootstrapMessage));
+    parentPort.once("message", (data) =>
+        handler(data as WorkerBootstrapMessage)
+    );
+}
+
+/** Initiate closing a lingering handle; the loop drain awaits completion. */
+function closeHandle(handle: any): void {
+    // Sockets and streams (provider keep-alive sockets, torn-transport WS).
+    if (typeof handle.destroy === "function") return void handle.destroy();
+    // Timers — clearTimeout accepts a Timeout from setInterval too.
+    if (typeof handle.refresh === "function") return clearTimeout(handle);
+    // Servers, message ports, and other closeables.
+    if (typeof handle.close === "function") return void handle.close();
+    handle.unref?.();
+}
+
+/**
+ * Close the worker's remaining handles after disposal so its event loop can
+ * drain and the thread exits on its own (see workerShutdown.ts for why the
+ * loop must never be force-stopped).
+ */
+export async function closeWorkerBootstrapPort(): Promise<void> {
+    const port = parentPort;
+    if (!port) return;
+
+    // The worker realm is disposed, but torn-down transports/providers can
+    // leave referenced handles behind (idle keep-alive sockets, reconnect
+    // timers of a cut connection, …). Any one of them stalls the drain — and
+    // with it the whole teardown — so close everything still keeping the loop
+    // alive except stdio and the bootstrap port itself. Iterate: a close
+    // callback may schedule follow-up work that arms new handles.
+    const keep = new Set<unknown>([
+        process.stdout,
+        process.stderr,
+        process.stdin,
+        port
+    ]);
+    for (let pass = 0; pass < 10; pass++) {
+        const held = (process as any)
+            ._getActiveHandles()
+            .filter(
+                (handle: any) =>
+                    !keep.has(handle) && handle.hasRef?.() !== false
+            );
+        if (held.length === 0) break;
+        held.forEach(closeHandle);
+        await new Promise((resolve) => setImmediate(resolve));
+    }
+    port.close();
 }
 
 /** Adapt the transferred raw port to the platform-neutral surface. */

--- a/src/evm/p2pRuntime/types.ts
+++ b/src/evm/p2pRuntime/types.ts
@@ -73,7 +73,7 @@ export interface RuntimeRequest<TType extends string = string> {
  */
 export interface P2pRuntimeWorker {
     postMessage(value: unknown, transfer?: unknown[]): void;
-    terminate(): unknown;
+    shutdown(): Promise<void>;
 }
 
 /** `Omit` that distributes over unions (preserves discriminated members). */

--- a/src/evm/p2pRuntime/worker/startP2pRuntimeWorker.ts
+++ b/src/evm/p2pRuntime/worker/startP2pRuntimeWorker.ts
@@ -3,7 +3,8 @@ import { createConfig } from "@/utils/config";
 import {
     onWorkerBootstrap,
     adaptTransferredPort,
-    onUnhandledWorkerError
+    onUnhandledWorkerError,
+    closeWorkerBootstrapPort
 } from "@platform/p2pRuntimeWorkerRuntime";
 import { startP2pRuntimeHost, serializeError } from "../P2pRuntimeHost";
 
@@ -30,7 +31,8 @@ export function startP2pRuntimeWorker(): void {
         });
 
         await startP2pRuntimeHost(runtimePort, payload, {
-            threadLabel: "sdk"
+            threadLabel: "sdk",
+            onDisposed: closeWorkerBootstrapPort
         });
     });
 }

--- a/src/utils/logging/node/NodeLogger.ts
+++ b/src/utils/logging/node/NodeLogger.ts
@@ -171,7 +171,7 @@ export class NodeLogger extends Logger {
                 // Report the running event-loop-delay peak for this thread to the
                 // parallel test runner (a ##E2E_TIMING## marker on stdout, which
                 // it prints per test). Emit on each increase because SDK/VM worker
-                // threads are force-terminated. Enabled whenever the event-loop
+                // threads may exit before the next sample. Enabled whenever the event-loop
                 // monitor threshold is configured (tests only), so production is
                 // unaffected.
                 const emitTiming =

--- a/src/utils/node/LocalDiscoveryServer.ts
+++ b/src/utils/node/LocalDiscoveryServer.ts
@@ -1060,7 +1060,15 @@ export class LocalDiscoveryServer {
         });
 
         // 2. Close all discovery connections (outgoing from peers)
-        this.activeDiscoveryConnections.forEach((ws) => ws.terminate());
+        this.activeDiscoveryConnections.forEach((ws) => {
+            if (ws.readyState === WebSocket.CLOSED) return;
+            closePromises.push(
+                new Promise<void>((resolve) => {
+                    ws.once("close", () => resolve());
+                    ws.terminate();
+                })
+            );
+        });
         this.activeDiscoveryConnections.clear();
 
         for (const timer of this.pendingTimers) {

--- a/test/e2e/E2E-WorkerShutdown.test.ts
+++ b/test/e2e/E2E-WorkerShutdown.test.ts
@@ -1,0 +1,18 @@
+import { expect } from "chai";
+
+import { MathTestSession as TestSession } from "@test/harness";
+
+describe("E2E: worker shutdown", function () {
+    it("drains and tears down multiple threaded peers promptly", async function () {
+        const harness = TestSession.getHarness();
+        await harness.lifecycle.start(3, 1, {
+            configOverrides: { RUN_SDK_IN_THREAD: true }
+        });
+
+        const startedAt = Date.now();
+        await harness.cleanup();
+
+        expect(Date.now() - startedAt).to.be.lessThan(5_000);
+        expect(harness.peers.length).to.equal(0);
+    });
+});

--- a/test/evm/WorkerContractExecutor.test.ts
+++ b/test/evm/WorkerContractExecutor.test.ts
@@ -103,6 +103,25 @@ describe("WorkerContractExecutor", function () {
         await executor.dispose();
     });
 
+    it("should reject calls immediately after disposal", async function () {
+        const executor = await createContractExecutorFactory({
+            dedicatedThread: true
+        });
+        await executor.dispose();
+
+        try {
+            await executor.executeCall(
+                "0x",
+                "0x0000000000000000000000000000000000000001"
+            );
+            expect.fail("executeCall should reject after disposal");
+        } catch (error) {
+            expect((error as Error).message).to.equal(
+                "Contract executor worker disposed"
+            );
+        }
+    });
+
     for (const dedicatedThread of [false, true]) {
         it(`should serialize simulations with local writes (${dedicatedThread ? "worker" : "inline"})`, async function () {
             const customAddress = Address.fromString(

--- a/test/evm/workerShutdown.test.ts
+++ b/test/evm/workerShutdown.test.ts
@@ -1,0 +1,76 @@
+import { expect } from "chai";
+import { Worker } from "node:worker_threads";
+
+import { createWorkerShutdown } from "@/evm/node/workerShutdown";
+
+/** Worker that closes its port on request, draining its loop naturally. */
+function createDrainingWorker(): Worker {
+    return new Worker(
+        `
+            const { parentPort } = require("node:worker_threads");
+            parentPort.once("message", () => parentPort.close());
+        `,
+        { eval: true }
+    );
+}
+
+describe("workerShutdown", function () {
+    it("resolves once the worker drains its loop and exits", async function () {
+        const worker = createDrainingWorker();
+        const shutdown = createWorkerShutdown(worker);
+
+        worker.postMessage("dispose");
+        await shutdown();
+
+        expect(worker.threadId).to.equal(-1);
+    });
+
+    it("resolves immediately for an already-exited worker", async function () {
+        const worker = new Worker(
+            `const { parentPort } = require("node:worker_threads"); parentPort.close();`,
+            { eval: true }
+        );
+        await new Promise<void>((resolve) =>
+            worker.once("exit", () => resolve())
+        );
+
+        await createWorkerShutdown(worker)();
+        expect(worker.threadId).to.equal(-1);
+    });
+
+    it("waits for a slow drain instead of abandoning the worker", async function () {
+        const worker = new Worker(
+            `
+                const { parentPort } = require("node:worker_threads");
+                parentPort.once("message", () =>
+                    setTimeout(() => parentPort.close(), 200)
+                );
+            `,
+            { eval: true }
+        );
+        const shutdown = createWorkerShutdown(worker);
+
+        worker.postMessage("dispose");
+        await shutdown();
+
+        expect(worker.threadId).to.equal(-1);
+    });
+
+    it("completes concurrent shutdowns independently", async function () {
+        const workers = Array.from({ length: 10 }, () =>
+            createDrainingWorker()
+        );
+
+        await Promise.all(
+            workers.map((worker) => {
+                const shutdown = createWorkerShutdown(worker);
+                worker.postMessage("dispose");
+                return shutdown();
+            })
+        );
+
+        expect(workers.every((worker) => worker.threadId === -1)).to.equal(
+            true
+        );
+    });
+});


### PR DESCRIPTION
- worker-side process.exit() / parent-side terminate() abort the whole process with "uv_loop_close() while having open handles" when close callbacks are still pending; workers now close their ports after replying to dispose and exit naturally, and the parent awaits that exit without a timeout (abandoning a live worker just moves the abort to process exit)
- the sdk worker closes every handle still referencing its loop (sockets, timers, servers) before closing the bootstrap port
- create Hyperswarm lazily on first join so debug-transport peers never own the native utp handles that tripped the same assert
- reject executor calls after disposal; cover the shutdown helper, post-dispose rejection, and threaded-peer teardown in unit + e2e
