### PR TITLE
fix(test-runner): give each worker its own delta archive path

### DIFF
--- a/scripts/e2e-parallel/distributed/artifactTransfer.js
+++ b/scripts/e2e-parallel/distributed/artifactTransfer.js
@@ -65,23 +65,32 @@ async function sendBundle(
     ) {
         throw new Error("Worker requested a file outside the offered manifest");
     }
-    const delta = await buildDeltaBundle(manifest, need.changed, archivePath);
-    onNeed({ ...need, ...delta });
-    await peer.send("BUNDLE_META", {
-        manifest: { ...wireManifest, ...delta }
-    });
-    let sequence = 0;
-    let byteCount = 0;
-    for await (const chunk of fs.createReadStream(archivePath, {
-        highWaterMark: chunkBytes
-    })) {
-        byteCount += chunk.length;
-        await peer.send("BUNDLE_CHUNK", { sequence: sequence++ }, chunk);
+    // Each peer gets its own delta file. Workers are onboarded concurrently and
+    // a shared path would be rebuilt underneath another peer's in-flight read,
+    // producing an archive that still matches its own manifest checksum but is
+    // truncated gzip.
+    const deltaPath = `${archivePath}.${crypto.randomUUID()}`;
+    try {
+        const delta = await buildDeltaBundle(manifest, need.changed, deltaPath);
+        onNeed({ ...need, ...delta });
+        await peer.send("BUNDLE_META", {
+            manifest: { ...wireManifest, ...delta }
+        });
+        let sequence = 0;
+        let byteCount = 0;
+        for await (const chunk of fs.createReadStream(deltaPath, {
+            highWaterMark: chunkBytes
+        })) {
+            byteCount += chunk.length;
+            await peer.send("BUNDLE_CHUNK", { sequence: sequence++ }, chunk);
+        }
+        await peer.send("BUNDLE_END", {
+            byteCount,
+            sha256: delta.archiveSha256
+        });
+    } finally {
+        fs.rmSync(deltaPath, { force: true });
     }
-    await peer.send("BUNDLE_END", {
-        byteCount,
-        sha256: delta.archiveSha256
-    });
     return waitForIdleMessage(
         peer,
         "PREPARED",

--- a/test/scripts/e2eParallelRuntimeBundle.test.ts
+++ b/test/scripts/e2eParallelRuntimeBundle.test.ts
@@ -4,6 +4,7 @@ import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { createSocketPair } from "../fixtures/distributed/testTransport";
 
 const {
     buildRuntimeBundle,
@@ -13,6 +14,13 @@ const {
     extractRuntimeBundle,
     assertCompatible
 } = require("../../scripts/e2e-parallel/distributed/runtimeExtractor.js");
+const {
+    ProtocolPeer
+} = require("../../scripts/e2e-parallel/distributed/protocol.js");
+const {
+    sendBundle,
+    receiveBundle
+} = require("../../scripts/e2e-parallel/distributed/artifactTransfer.js");
 
 function initializeRepository(root: string): void {
     fs.mkdirSync(root, { recursive: true });
@@ -196,12 +204,15 @@ describe("distributed source workspace", function () {
         }
     });
 
-    it("keeps concurrent delta bundles intact when each target path is distinct", async function () {
-        const root = fs.mkdtempSync(
-            path.join(os.tmpdir(), "delta-concurrent-")
-        );
+    it("leaves the caller's archive untouched and delivers a valid bundle to each concurrent peer", async function () {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "send-bundle-"));
         const project = path.join(root, "project");
         const archive = path.join(root, "transfer", "source.tgz");
+        const openPairs: Array<{ close: () => Promise<void> }> = [];
+        const limits = {
+            maxCompressedBytes: 64 * 1024 * 1024,
+            maxExpandedBytes: 256 * 1024 * 1024
+        };
         try {
             initializeRepository(project);
             fs.writeFileSync(
@@ -229,39 +240,85 @@ describe("distributed source workspace", function () {
             const changed = manifest.files.map(
                 (entry: { path: string }) => entry.path
             );
+            const archiveBefore = crypto
+                .createHash("sha256")
+                .update(fs.readFileSync(archive))
+                .digest("hex");
 
-            // One delta per peer, mirroring sendBundle. A shared target path
-            // lets one build truncate an archive another peer is still reading.
-            const deltas = await Promise.all(
-                Array.from({ length: 6 }, (_unused, index) =>
-                    buildDeltaBundle(
-                        manifest,
-                        changed,
-                        `${archive}.peer-${index}`
-                    ).then((delta: { archiveSha256: string }) => ({
-                        delta,
-                        deltaPath: `${archive}.peer-${index}`
-                    }))
-                )
+            // Two peers onboarded at once, both handed the same archive path —
+            // exactly how the orchestrator drives sendBundle.
+            const transfers = await Promise.all(
+                [0, 1].map(async (index) => {
+                    const pair = await createSocketPair();
+                    openPairs.push(pair);
+                    const sender = new ProtocolPeer(pair.client);
+                    const receiver = new ProtocolPeer(pair.server);
+                    const receivedPath = path.join(
+                        root,
+                        `received-${index}.tgz`
+                    );
+                    const delivered = new Promise<Record<string, unknown>>(
+                        (resolve, reject) => {
+                            receiver.on(
+                                "message",
+                                (message: {
+                                    kind: string;
+                                    header: Record<string, unknown>;
+                                }) => {
+                                    if (message.kind === "WORKSPACE_OFFER") {
+                                        receiver
+                                            .send(
+                                                "WORKSPACE_NEED",
+                                                {},
+                                                Buffer.from(
+                                                    JSON.stringify({
+                                                        changed,
+                                                        deleted: []
+                                                    })
+                                                )
+                                            )
+                                            .catch(reject);
+                                    } else if (message.kind === "BUNDLE_META") {
+                                        receiveBundle(
+                                            receiver,
+                                            receivedPath,
+                                            limits,
+                                            resolve,
+                                            message,
+                                            reject
+                                        );
+                                    }
+                                }
+                            );
+                        }
+                    );
+                    await sendBundle(sender, archive, manifest, 16 * 1024);
+                    return { receivedPath, delivered: await delivered };
+                })
             );
 
-            for (const { delta, deltaPath } of deltas) {
-                const written = crypto
-                    .createHash("sha256")
-                    .update(fs.readFileSync(deltaPath))
-                    .digest("hex");
-                expect(written).to.equal(delta.archiveSha256);
+            // The shared path holds the full bundle the caller built; sendBundle
+            // must not write through it.
+            const archiveAfter = crypto
+                .createHash("sha256")
+                .update(fs.readFileSync(archive))
+                .digest("hex");
+            expect(
+                archiveAfter,
+                "sendBundle wrote through the caller's archive path"
+            ).to.equal(archiveBefore);
+
+            // Each peer's archive must be intact gzip, not merely checksum-consistent.
+            for (const [index, transfer] of transfers.entries()) {
                 await extractRuntimeBundle(
-                    deltaPath,
-                    path.join(root, path.basename(deltaPath, ".tgz")),
-                    { ...manifest, ...delta },
-                    {
-                        maxCompressedBytes: 8 * 1024 * 1024,
-                        maxExpandedBytes: 32 * 1024 * 1024
-                    }
+                    transfer.receivedPath,
+                    path.join(root, `extracted-${index}`),
+                    { ...manifest, ...transfer.delivered },
+                    limits
                 );
             }
         } finally {
+            for (const pair of openPairs) await pair.close();
             fs.rmSync(root, { recursive: true, force: true });
         }
     });

--- a/test/scripts/e2eParallelRuntimeBundle.test.ts
+++ b/test/scripts/e2eParallelRuntimeBundle.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { execFileSync } from "child_process";
+import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -190,6 +191,76 @@ describe("distributed source workspace", function () {
                 error = caught as Error;
             }
             expect(error?.message).to.include("checksum");
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it("keeps concurrent delta bundles intact when each target path is distinct", async function () {
+        const root = fs.mkdtempSync(
+            path.join(os.tmpdir(), "delta-concurrent-")
+        );
+        const project = path.join(root, "project");
+        const archive = path.join(root, "transfer", "source.tgz");
+        try {
+            initializeRepository(project);
+            fs.writeFileSync(
+                path.join(project, "package.json"),
+                JSON.stringify({
+                    name: "project",
+                    scripts: { compile: "true" }
+                })
+            );
+            const runner = path.join(
+                project,
+                "scripts",
+                "e2e-parallel",
+                "distributed"
+            );
+            fs.mkdirSync(runner, { recursive: true });
+            fs.writeFileSync(path.join(runner, "worker.js"), "// worker\n");
+            for (let index = 0; index < 40; index++) {
+                fs.writeFileSync(
+                    path.join(project, `file-${index}.js`),
+                    `module.exports = ${index};\n`.repeat(400)
+                );
+            }
+            const manifest = await buildRuntimeBundle(project, archive);
+            const changed = manifest.files.map(
+                (entry: { path: string }) => entry.path
+            );
+
+            // One delta per peer, mirroring sendBundle. A shared target path
+            // lets one build truncate an archive another peer is still reading.
+            const deltas = await Promise.all(
+                Array.from({ length: 6 }, (_unused, index) =>
+                    buildDeltaBundle(
+                        manifest,
+                        changed,
+                        `${archive}.peer-${index}`
+                    ).then((delta: { archiveSha256: string }) => ({
+                        delta,
+                        deltaPath: `${archive}.peer-${index}`
+                    }))
+                )
+            );
+
+            for (const { delta, deltaPath } of deltas) {
+                const written = crypto
+                    .createHash("sha256")
+                    .update(fs.readFileSync(deltaPath))
+                    .digest("hex");
+                expect(written).to.equal(delta.archiveSha256);
+                await extractRuntimeBundle(
+                    deltaPath,
+                    path.join(root, path.basename(deltaPath, ".tgz")),
+                    { ...manifest, ...delta },
+                    {
+                        maxCompressedBytes: 8 * 1024 * 1024,
+                        maxExpandedBytes: 32 * 1024 * 1024
+                    }
+                );
+            }
         } finally {
             fs.rmSync(root, { recursive: true, force: true });
         }


### PR DESCRIPTION
## Summary

Stacked on #421.

A distributed run against a multi-worker pool fails with:

```
Worker <name> could not prepare the workspace: zlib: unexpected end of file
```

`sendBundle` builds the delta archive into a single shared path — `archivePath` is created once in `scripts/test-e2e-parallel.js` and passed to every peer — and then streams that same file to the worker. Workers are onboarded concurrently from independent lease handlers, so one peer's `buildDeltaBundle` rewrites the file while another peer's `createReadStream` is still consuming it.

The result is nasty to diagnose: the archive stays consistent with the manifest built alongside it, so the `BUNDLE_END` byte-count and sha256 check passes on the wire *and* the extractor's own `sha256File` check passes. The corruption only surfaces afterwards, as a zlib error during extraction, with nothing pointing back at the transfer.

This gives each `sendBundle` call its own delta file derived from the shared path, and removes it in a `finally`. Putting it inside `sendBundle` rather than at the call site means every caller is covered.

Ruled out while diagnosing:
- **Bundle creation** — a bundle built locally from the same tree is valid gzip, lists 614 entries and extracts cleanly.
- **Size limits** — `maxCompressedBytes` is 2 GB; the transfer was well under 1 MB.
- **Protocol version mismatch** — reproduced with a workspace whose only changes were outside `scripts/`.

Scope note: this was reproduced during an initial full workspace sync on a ten-worker pool, where the archive is largest and the race window widest. Once workers hold a cached workspace the transfers are small deltas and the window narrows considerably, so it will not reproduce on every run. It is a genuine concurrent write to a file another peer is reading either way.

## Test Plan

- New test in `test/scripts/e2eParallelRuntimeBundle.test.ts` builds six delta bundles concurrently to distinct target paths and asserts that each archive's bytes match the sha256 its own build reported, and that each extracts cleanly.
- `yarn test:parallel:distributed --test-pattern 'scripts/e2eParallelRuntimeBundle.test.ts'` — 3 passing, run across a multi-worker pool.
- `yarn tsc --noEmit -p tsconfig.json` — clean.
- Full distributed suite on this branch's stack — 867 passing / 0 failing on one run, and 865 / 3 on another. All three failures pass when re-run in isolation and carry load signatures (`RaceConditionDisputeEvidencePeriodExpired`, and a run whose peak memory exceeded the pool's configured bound), so they read as starvation rather than regressions.
