### PR TITLE
chore(contracts): remove unused outbound messages event

### DIFF
--- a/contracts/V1/StateChannelDiamondProxy/StateSnapshotFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateSnapshotFacet.sol
@@ -113,9 +113,8 @@ contract StateSnapshotFacet is StateChannelCommon {
         StateSnapshot[] memory milestoneSnapshots,
         StateSnapshot memory thresholdStateSnapshot
     ) internal returns (bool) {
-        bool isValid = StateChannelManagerProxy(address(this)).verifyMilestones(
-            forkId, milestoneProofs, milestoneSnapshots, thresholdStateSnapshot
-        );
+        bool isValid = StateChannelManagerProxy(address(this))
+            .verifyMilestones(forkId, milestoneProofs, milestoneSnapshots, thresholdStateSnapshot);
         return isValid;
     }
 
@@ -140,8 +139,6 @@ contract StateSnapshotFacet is StateChannelCommon {
                 bool isEqual = stateMachineImplementation.areBalancesEqual(totalWithdrawals, totalDeposits);
                 require(isLessThan || isEqual, CantWithdrawMoreThanDeposits());
             }
-            // TODO - this event is not used
-            emit OutboundMessagesProcessed(channelId, outboundMessageBlocks[i], block.timestamp, totalWithdrawals);
         }
         cb.totalWithdrawals = totalWithdrawals;
         cb.latestOutboundMessageBlockHeight = newSnapshotData.latestOutboundMessageBlockHeight;

--- a/contracts/V1/StateChannelManagerEvents.sol
+++ b/contracts/V1/StateChannelManagerEvents.sol
@@ -46,8 +46,4 @@ interface StateChannelManagerEvents {
     event DisputeKilled(bytes32 indexed channelId, bytes32 forkId, address disputer, bytes32 disputeHash);
 
     event InboundMessagesProcessed(bytes32 indexed channelId, MessageBlock messageBlock);
-
-    event OutboundMessagesProcessed(
-        bytes32 indexed channelId, MessageBlock messageBlock, uint256 timestamp, Balance totalWithdrawals
-    );
 }

--- a/test/e2e/E2E-StateSnapshots.test.ts
+++ b/test/e2e/E2E-StateSnapshots.test.ts
@@ -40,6 +40,30 @@ describe("E2E: State Snapshots", function () {
             10000,
             { mode: "atLeast" }
         );
+        await h.event.waitForEventCounts(
+            "onWithdrawalsUpdated",
+            h.peers.map((peer) => ({ peerId: peer.index, expectedCount: 1 })),
+            10000,
+            { mode: "atLeast" }
+        );
+        const channelBalanceAfter = await h.channelManager.getChannelBalance(
+            h.channelId
+        );
+        const totalWithdrawals = channelBalanceAfter.totalWithdrawals;
+        expect(channelBalanceAfter.latestOutboundMessageBlockHeight).to.equal(
+            h.context.lastMilestoneSnapshot!.snapshotData
+                .latestOutboundMessageBlockHeight
+        );
+        for (const peer of h.peers) {
+            const call = peer.eventSpies.onWithdrawalsUpdated?.lastCall;
+            expect(call).to.not.be.undefined;
+            const [eventChannelId, eventTotalWithdrawals] = call!.args;
+            expect(eventChannelId).to.equal(h.channelId);
+            expect(eventTotalWithdrawals.amount).to.equal(
+                totalWithdrawals.amount
+            );
+            expect(eventTotalWithdrawals.data).to.equal(totalWithdrawals.data);
+        }
         await h.assert.snapshot.withdrawalDeltaMatchesExpected();
         await h.assert.snapshot.verifyOnChainChannelBalanceInvariant();
         await h.assert.snapshot.snapshotMatchesLocal();


### PR DESCRIPTION
## Summary

Removes the `OutboundMessagesProcessed` event, which has no consumers and carried a `// TODO - this event is not used` marker at its only emit site.

Stacked on #423, which is stacked on #421. The stacking is only so this branch can be exercised on the distributed test pool; there is no code dependency, and the base can be retargeted once the branches below land.

Removal rather than wiring it up, because everything the event reports is already mirrored by another path:

- `totalWithdrawals` reaches the local EVM mirror through `WithdrawalsUpdated`, handled in `LocalDiamond`.
- `latestOutboundMessageBlockHeight` reaches it through the snapshot path.

Its three siblings — `WithdrawalsUpdated`, `ChannelStorageCleared` and `InboundMessagesProcessed` — are all wired into `EventHandlerHooks` and `EventSyncService`. This one appears in none of them, only in the generated ABI. It also emitted an entire `MessageBlock` memory struct once per outbound block, so removing it saves gas for data the peer already holds.

A repo-wide tombstone audit found no hand-written consumer anywhere. The only remaining occurrences in the downstream consumer repositories are generated ABI and typechain output, which regenerate.

This is an ABI change: the event disappears from the contract ABI.

The reflowed `_verifyMilestones` hunk is `forge fmt` output from the pre-commit hook, not an intentional change — the file was not format-clean on the base.

## Test Plan

- `test/e2e/E2E-StateSnapshots.test.ts` gains assertions covering the two paths that justify the removal — that `WithdrawalsUpdated` reaches every peer with the correctly accumulated `totalWithdrawals`, and that `latestOutboundMessageBlockHeight` is updated to match the milestone snapshot.
- Mutation-checked, both against the distributed pool: removing the `WithdrawalsUpdated` emit fails exactly one test, and removing the `latestOutboundMessageBlockHeight` assignment fails exactly one test. Restored, the file is back to 8 passing.
- `yarn test:parallel:distributed --test-pattern 'e2e/E2E-StateSnapshots.test.ts'` — 8 passing.
- Full distributed suite on this exact head — **865 passing / 3 failing**. There is no green full-suite run for this SHA. The three failures are `E2E-Spectate` "Spectator promoted to participant via joinChannel", `E2E-Spectate` "Spectator promoted to participant joinChannel survives dispute on reduced fork", and `selfRemoval` "dispute.input.selfRemoval = true; honest disputer voluntarily exits". All three pass when re-run in isolation, and they carry starvation signatures — the selfRemoval case fails on `RaceConditionDisputeEvidencePeriodExpired`, a wall-clock window, on a run whose peak memory exceeded the pool's configured bound. None of them touch the code this PR changes, but they are reported as failures rather than waved away.
- `yarn compile`, `yarn tsc --noEmit` for both `tsconfig.json` and `tsconfig.browser.json` — clean.
- `forge test` — 58 passing / 0 failing.
