### PR TITLE
refactor(clock): extract the resync tolerance predicate and cover it with tests

### DIFF
--- a/src/Clock.ts
+++ b/src/Clock.ts
@@ -1,5 +1,18 @@
 import { ethers } from "ethers";
 
+// The latest block's timestamp trails chain time by up to one block interval,
+// so a skew within one averageBlockTime is explained by block production alone,
+// not by a wrong local clock. One interval is the tightest threshold that still
+// covers that natural lag: below it we would chase block quantization (and each
+// correction re-syncs recursively), above it we would tolerate real skew. Hence
+// 1x, not 2x.
+export function isClockSkewBeyondBlockInterval(
+    differenceSeconds: number,
+    averageBlockTimeSeconds: number
+): boolean {
+    return Math.abs(differenceSeconds) > averageBlockTimeSeconds;
+}
+
 class Clock {
     private static instance: Clock | undefined;
     private static initialization: Promise<void> | undefined;
@@ -96,17 +109,11 @@ class Clock {
         const pastTimestamp = pastBlock.timestamp;
 
         this.averageBlockTime = (latestTimestamp - pastTimestamp) / blockCnt;
-        // console.log(
-        //     `Average block time calculated: ${this.averageBlockTime}s over ${blockCnt} blocks`,
-        //     `past block timestamp: ${pastTimestamp}, latest block timestamp: ${latestTimestamp}`,
-        //     `current time: ${currentTime}, difference: ${difference}s`
-        // );
         if (!this.averageBlockTime) {
             this.clockAdjustmentSeconds += difference;
             return;
         }
-        //TODO - think - should it be 2* or 1* or something else?
-        if (Math.abs(difference) > this.averageBlockTime) {
+        if (isClockSkewBeyondBlockInterval(difference, this.averageBlockTime)) {
             this.clockAdjustmentSeconds += difference;
             await this.syncClock(); // Recursively call syncClock until condition is satisfied
         }

--- a/src/Clock.ts
+++ b/src/Clock.ts
@@ -1,13 +1,16 @@
 import { ethers } from "ethers";
 
-// Re-adjust only when local time and the latest block timestamp disagree by more
-// than one averageBlockTime. One interval, not two: averageBlockTime is the
-// trailing mean gap, so a smaller disagreement is the ordinary "no block yet"
-// lag rather than clock skew, and correcting there chases block quantization.
-// Known limit: the trailing mean does not bound the currently open gap, so an
-// unusually late block still reads as a disagreement and snaps local time back
-// to that block's timestamp. Narrowing that needs an asymmetric or gap-aware
-// rule — a behaviour change, out of scope for this decision record.
+// Tolerance policy for syncClock: re-adjust only when local time and the latest
+// block timestamp disagree by more than one averageBlockTime. The predicate
+// cannot tell real skew from ordinary "no block yet" lag, so this is a budget
+// for undetected skew, not a classifier. One interval and not two because both
+// avoid correcting when simply no block has landed, but 1x leaves less real skew
+// uncorrected, and an occasional needless correction costs less than running on
+// a wrong clock.
+// Known limit: averageBlockTime is a trailing mean and does not bound the gap
+// still open after the latest block, so an unusually late block reads as a
+// disagreement and pulls local time back to that block. Narrowing that needs an
+// asymmetric or gap-aware rule — a behaviour change, out of scope here.
 export function isBeyondBlockIntervalTolerance(
     differenceSeconds: number,
     averageBlockTimeSeconds: number

--- a/src/Clock.ts
+++ b/src/Clock.ts
@@ -1,12 +1,14 @@
 import { ethers } from "ethers";
 
-// The latest block's timestamp trails chain time by up to one block interval,
-// so a skew within one averageBlockTime is explained by block production alone,
-// not by a wrong local clock. One interval is the tightest threshold that still
-// covers that natural lag: below it we would chase block quantization (and each
-// correction re-syncs recursively), above it we would tolerate real skew. Hence
-// 1x, not 2x.
-export function isClockSkewBeyondBlockInterval(
+// Re-adjust only when local time and the latest block timestamp disagree by more
+// than one averageBlockTime. One interval, not two: averageBlockTime is the
+// trailing mean gap, so a smaller disagreement is the ordinary "no block yet"
+// lag rather than clock skew, and correcting there chases block quantization.
+// Known limit: the trailing mean does not bound the currently open gap, so an
+// unusually late block still reads as a disagreement and snaps local time back
+// to that block's timestamp. Narrowing that needs an asymmetric or gap-aware
+// rule — a behaviour change, out of scope for this decision record.
+export function isBeyondBlockIntervalTolerance(
     differenceSeconds: number,
     averageBlockTimeSeconds: number
 ): boolean {
@@ -113,7 +115,7 @@ class Clock {
             this.clockAdjustmentSeconds += difference;
             return;
         }
-        if (isClockSkewBeyondBlockInterval(difference, this.averageBlockTime)) {
+        if (isBeyondBlockIntervalTolerance(difference, this.averageBlockTime)) {
             this.clockAdjustmentSeconds += difference;
             await this.syncClock(); // Recursively call syncClock until condition is satisfied
         }

--- a/test/Clock.test.ts
+++ b/test/Clock.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { BrowserProvider } from "ethers";
 import { ethers, network } from "hardhat";
 
-import Clock from "@/Clock";
+import Clock, { isClockSkewBeyondBlockInterval } from "@/Clock";
 
 // A second real ethers provider over the same in-process hardhat network:
 // distinct instance, live chain reads, no mocking.
@@ -73,5 +73,38 @@ describe("Clock", () => {
         ).to.equal(true);
         const time = await Clock.getBlockchainTime();
         expect(time.blockNumber).to.be.greaterThanOrEqual(0);
+    });
+});
+
+describe("Clock resync threshold", () => {
+    it("holds the clock when local and chain time agree", () => {
+        expect(isClockSkewBeyondBlockInterval(0, 12)).to.equal(false);
+    });
+
+    it("holds the clock when the chain leads by less than one block interval", () => {
+        expect(isClockSkewBeyondBlockInterval(11, 12)).to.equal(false);
+    });
+
+    it("holds the clock when the chain lags by less than one block interval", () => {
+        expect(isClockSkewBeyondBlockInterval(-11, 12)).to.equal(false);
+    });
+
+    it("holds the clock when the skew is exactly one block interval", () => {
+        expect(isClockSkewBeyondBlockInterval(12, 12)).to.equal(false);
+        expect(isClockSkewBeyondBlockInterval(-12, 12)).to.equal(false);
+    });
+
+    it("resyncs when the chain leads by more than one block interval", () => {
+        expect(isClockSkewBeyondBlockInterval(13, 12)).to.equal(true);
+    });
+
+    it("resyncs when the chain lags by more than one block interval", () => {
+        expect(isClockSkewBeyondBlockInterval(-13, 12)).to.equal(true);
+    });
+
+    it("compares against a fractional block interval", () => {
+        // averageBlockTime comes from a division, so it is rarely a whole second.
+        expect(isClockSkewBeyondBlockInterval(2.5, 2.5)).to.equal(false);
+        expect(isClockSkewBeyondBlockInterval(2.6, 2.5)).to.equal(true);
     });
 });

--- a/test/Clock.test.ts
+++ b/test/Clock.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { BrowserProvider } from "ethers";
 import { ethers, network } from "hardhat";
 
-import Clock, { isClockSkewBeyondBlockInterval } from "@/Clock";
+import Clock, { isBeyondBlockIntervalTolerance } from "@/Clock";
 
 // A second real ethers provider over the same in-process hardhat network:
 // distinct instance, live chain reads, no mocking.
@@ -78,33 +78,33 @@ describe("Clock", () => {
 
 describe("Clock resync threshold", () => {
     it("holds the clock when local and chain time agree", () => {
-        expect(isClockSkewBeyondBlockInterval(0, 12)).to.equal(false);
+        expect(isBeyondBlockIntervalTolerance(0, 12)).to.equal(false);
     });
 
     it("holds the clock when the chain leads by less than one block interval", () => {
-        expect(isClockSkewBeyondBlockInterval(11, 12)).to.equal(false);
+        expect(isBeyondBlockIntervalTolerance(11, 12)).to.equal(false);
     });
 
     it("holds the clock when the chain lags by less than one block interval", () => {
-        expect(isClockSkewBeyondBlockInterval(-11, 12)).to.equal(false);
+        expect(isBeyondBlockIntervalTolerance(-11, 12)).to.equal(false);
     });
 
-    it("holds the clock when the skew is exactly one block interval", () => {
-        expect(isClockSkewBeyondBlockInterval(12, 12)).to.equal(false);
-        expect(isClockSkewBeyondBlockInterval(-12, 12)).to.equal(false);
+    it("holds the clock when the disagreement is exactly one block interval", () => {
+        expect(isBeyondBlockIntervalTolerance(12, 12)).to.equal(false);
+        expect(isBeyondBlockIntervalTolerance(-12, 12)).to.equal(false);
     });
 
     it("resyncs when the chain leads by more than one block interval", () => {
-        expect(isClockSkewBeyondBlockInterval(13, 12)).to.equal(true);
+        expect(isBeyondBlockIntervalTolerance(13, 12)).to.equal(true);
     });
 
     it("resyncs when the chain lags by more than one block interval", () => {
-        expect(isClockSkewBeyondBlockInterval(-13, 12)).to.equal(true);
+        expect(isBeyondBlockIntervalTolerance(-13, 12)).to.equal(true);
     });
 
     it("compares against a fractional block interval", () => {
         // averageBlockTime comes from a division, so it is rarely a whole second.
-        expect(isClockSkewBeyondBlockInterval(2.5, 2.5)).to.equal(false);
-        expect(isClockSkewBeyondBlockInterval(2.6, 2.5)).to.equal(true);
+        expect(isBeyondBlockIntervalTolerance(2.5, 2.5)).to.equal(false);
+        expect(isBeyondBlockIntervalTolerance(2.6, 2.5)).to.equal(true);
     });
 });


### PR DESCRIPTION
## Summary

`Clock.syncClock` decides whether to re-adjust the local clock by comparing the
local/chain timestamp difference against `averageBlockTime`. That comparison
carried an open question — `//TODO - think - should it be 2* or 1* or something
else?` — which had never been decided and had no test coverage.

This settles it at **one** interval, which is the existing behaviour. **No
behaviour change**: the predicate is byte-for-byte the same comparison, just
moved.

- Extracts the comparison into a pure exported
  `isBeyondBlockIntervalTolerance(differenceSeconds, averageBlockTimeSeconds)`,
  leaving `syncClock` a thin async wrapper, so the decision is unit testable
  with synthetic inputs.
- Records the reasoning next to the predicate as a **tolerance policy**: the
  comparison cannot tell real clock skew from ordinary "no block yet" lag, so
  the threshold is a budget for undetected skew rather than a classifier. One
  interval and not two because both avoid correcting when no block has simply
  landed, but 1x leaves less real skew uncorrected.
- Documents a real limit that the code does **not** handle, rather than
  papering over it: `averageBlockTime` is a trailing mean over the last ≤10 gaps
  and does not bound the gap still open after the latest block. An unusually
  late block therefore reads as a disagreement and pulls local time back to that
  block's timestamp. Narrowing that needs an asymmetric or gap-aware rule — a
  behaviour change, deliberately out of scope here and tracked separately.
- Adds 7 unit tests: both sides of the boundary, both signs, the exact-boundary
  case, zero difference, and a fractional interval.
- Drops a commented-out debug `console.log` block from `syncClock` (the repo
  bans `console.*`). Called out explicitly rather than removed silently.

Unchanged on purpose: the `blockCnt === 0` and `!this.averageBlockTime` early
returns keep their current semantics, so a zero average block time still adjusts
once without recursing.

Stacked on #424 so it can run on the distributed pool; no code dependency, and
GitHub will auto-retarget as the lower PRs land.

## Test Plan

- `yarn tsc --noEmit -p tsconfig.json` — clean
- `yarn tsc --noEmit -p tsconfig.browser.json` — clean
- Distributed pool, `--test-pattern 'Clock.test.ts'` — **11/11 passing**
- **Mutation check:** flipping the predicate's `>` to `>=` fails exactly the two
  boundary tests (`holds the clock when the disagreement is exactly one block
  interval`, `compares against a fractional block interval`) and passes the
  other 9 — confirming the new tests pin the boundary rather than just running.

External review run before raising: 3 rounds, 2 findings fixed, final round
clean.