### PR TITLE
(fix) a byzantine dispute uploader can brick an honest peer

### DIFF
--- a/contracts/V1/StateChannelDiamondProxy/DisputeFraudProofFacet.sol
+++ b/contracts/V1/StateChannelDiamondProxy/DisputeFraudProofFacet.sol
@@ -86,6 +86,9 @@ contract DisputeFraudProofFacet is StateChannelCommon {
         if (proofType == DisputeFraudProofType.DisputeBlockAuthorNotParticipant) {
             return _handleDisputeBlockAuthorNotParticipant;
         }
+        if (proofType == DisputeFraudProofType.DisputeInboundAnchorBehindLatestState) {
+            return _handleDisputeInboundAnchorBehindLatestState;
+        }
         return _handleInvalidDisputeFraudProofType;
     }
 
@@ -244,6 +247,18 @@ contract DisputeFraudProofFacet is StateChannelCommon {
         if (_hasDisputeReason(dispute.input, proof.latestStateSnapshot)) {
             return _invalid();
         }
+        return _valid(dispute.input.disputer);
+    }
+
+    function _handleDisputeInboundAnchorBehindLatestState(bytes memory encodedFraudProof, Dispute memory dispute)
+        internal
+        pure
+        returns (address)
+    {
+        DisputeInboundAnchorBehindLatestState memory proof =
+            abi.decode(encodedFraudProof, (DisputeInboundAnchorBehindLatestState));
+
+        if (!_isDisputeInboundAnchorBehindLatestState(dispute, proof.latestStateSnapshot)) return _invalid();
         return _valid(dispute.input.disputer);
     }
 

--- a/contracts/V1/StateChannelDiamondProxy/LocalDiamond.sol
+++ b/contracts/V1/StateChannelDiamondProxy/LocalDiamond.sol
@@ -422,6 +422,14 @@ contract LocalDiamond is StateChannelManagerProxy {
         return _hasDisputeReason(input, latestStateSnapshot);
     }
 
+    function isDisputeInboundAnchorBehindLatestState(Dispute memory dispute, StateSnapshot memory latestStateSnapshot)
+        public
+        pure
+        returns (bool)
+    {
+        return _isDisputeInboundAnchorBehindLatestState(dispute, latestStateSnapshot);
+    }
+
     function getUnfinalizedBlockConfirmationsFromStateProof(StateProof memory stateProof)
         public
         pure

--- a/contracts/V1/StateChannelDiamondProxy/StateChannelCommon.sol
+++ b/contracts/V1/StateChannelDiamondProxy/StateChannelCommon.sol
@@ -362,21 +362,6 @@ contract StateChannelCommon is StateChannelManagerStorage, StateChannelManagerEv
         return previousBlockHash == upperSnapshot.latestOutboundMessageBlockHash;
     }
 
-    function _isSnapshotLinkedToLatestBlock(Dispute memory dispute, StateSnapshot memory latestStateSnapshot)
-        internal
-        pure
-        returns (bool)
-    {
-        bytes32 snapshotHash = keccak256(abi.encode(latestStateSnapshot));
-
-        (bool hasBlock, Block memory latestBlock) = _getLatestBlock(dispute.input.stateProof);
-        if (hasBlock) {
-            return latestBlock.stateSnapshotHash == snapshotHash;
-        }
-
-        return dispute.input.forkId == keccak256(abi.encode(latestStateSnapshot.snapshotData));
-    }
-
     function _isSnapshotLinkedToBlock(Block memory blockData, StateSnapshot memory stateSnapshot)
         internal
         pure

--- a/contracts/V1/StateChannelDiamondProxy/utils/DisputeUtils.sol
+++ b/contracts/V1/StateChannelDiamondProxy/utils/DisputeUtils.sol
@@ -146,6 +146,39 @@ function _hasDisputeReason(DisputeInput memory input, StateSnapshot memory lates
         input.timeout.participant != address(0) || hasValidOnChainSlash || input.selfRemoval || isForcedInboundMessage;
 }
 
+function _isSnapshotLinkedToLatestBlock(Dispute memory dispute, StateSnapshot memory latestStateSnapshot)
+    pure
+    returns (bool)
+{
+    bytes32 snapshotHash = keccak256(abi.encode(latestStateSnapshot));
+
+    (bool hasBlock, Block memory latestBlock) = _getLatestBlock(dispute.input.stateProof);
+    if (hasBlock) {
+        return latestBlock.stateSnapshotHash == snapshotHash;
+    }
+
+    return dispute.input.forkId == keccak256(abi.encode(latestStateSnapshot.snapshotData));
+}
+
+function _isDisputeInboundAnchorBehindLatestState(Dispute memory dispute, StateSnapshot memory latestStateSnapshot)
+    pure
+    returns (bool)
+{
+    // pin latestStateSnapshot to dispute.input.latestStateSnapshotHash -> both
+    // heights come from the signed dispute, so a supplied latestStateSnapshot
+    // can't frame an honest disputer
+    if (keccak256(abi.encode(latestStateSnapshot)) != dispute.input.latestStateSnapshotHash) return false;
+    if (!_isSnapshotLinkedToLatestBlock(dispute, latestStateSnapshot)) return false;
+
+    uint256 snapshotHeight = latestStateSnapshot.snapshotData.latestInboundMessageBlockHeight;
+    bytes32 snapshotInboundHash = latestStateSnapshot.snapshotData.latestInboundMessageBlockHash;
+    if (dispute.input.lastInboundMessageBlockHeight < snapshotHeight) return true;
+    // equal heights but a different latestInboundMessageBlockHash -> a block the
+    // walk from snapshotData.latestInboundMessageBlockHash never reaches
+    return dispute.input.lastInboundMessageBlockHeight == snapshotHeight
+        && dispute.input.latestInboundMessageBlockHash != snapshotInboundHash;
+}
+
 function _hasStateProofHeaderMismatch(Dispute memory dispute) pure returns (bool) {
     bytes32 channelId = dispute.input.channelId;
     bytes32 forkId = dispute.input.forkId;

--- a/contracts/V1/types/DisputeFraudProofTypes.sol
+++ b/contracts/V1/types/DisputeFraudProofTypes.sol
@@ -20,7 +20,8 @@ contract DisputeFraudProofTypes {
         DisputeStateProofHeaderMismatch memory q,
         DisputeInboundHashNotInChain memory r,
         DisputeInvalidBlockStructure memory s,
-        DisputeBlockAuthorNotParticipant memory t
+        DisputeBlockAuthorNotParticipant memory t,
+        DisputeInboundAnchorBehindLatestState memory u
     ) {}
 }
 
@@ -104,6 +105,12 @@ struct DisputeStateProofHeaderMismatch {
 
 struct DisputeInboundHashNotInChain {
     bool __;
+}
+
+// dispute.input.lastInboundMessageBlockHeight is not ahead of
+// latestStateSnapshot.snapshotData.latestInboundMessageBlockHeight
+struct DisputeInboundAnchorBehindLatestState {
+    StateSnapshot latestStateSnapshot;
 }
 
 struct DisputeInvalidBlockStructure {

--- a/contracts/V1/types/ProofTypes.sol
+++ b/contracts/V1/types/ProofTypes.sol
@@ -60,5 +60,6 @@ enum DisputeFraudProofType {
     DisputeStateProofHeaderMismatch,
     DisputeInboundHashNotInChain,
     DisputeInvalidBlockStructure,
-    DisputeBlockAuthorNotParticipant
+    DisputeBlockAuthorNotParticipant,
+    DisputeInboundAnchorBehindLatestState
 }

--- a/src/disputeManager/DisputeManager.ts
+++ b/src/disputeManager/DisputeManager.ts
@@ -386,10 +386,18 @@ class DisputeManager {
             this.storage.timeout.getTimeout(forkId) ||
             this.getEmptyTimeoutStruct();
 
-        // AuditingData
+        // latestStateSnapshot proves its own inbound head -> naming anything
+        // below it is objective fraud against ourselves
+        const inboundHead = this.storage.inboundMessages.headNotBehind(
+            latestStateSnapshot.latestInboundMessageBlockHash,
+            latestStateSnapshot.latestInboundMessageBlockHeight
+        );
+
+        // the bound every auditor recomputes with
         const { isPartial, auditingData } = this.getAuditingData(
             forkId,
-            stateProof
+            stateProof,
+            { disputeLatestInboundMessageBlockHash: inboundHead.hash }
         );
         if (isPartial)
             throw new Error("createDispute - isPartial auditingData");
@@ -404,17 +412,6 @@ class DisputeManager {
         // selfRemoval
         const selfRemoval = this.storage.forceExit.getForceExit();
 
-        // inbound anchor - latestStateSnapshot already proves its own inbound
-        // head, so an anchor below it is self-incriminating
-        // (DisputeInboundAnchorBehindLatestState). inboundMessages lags that
-        // head whenever ingest verified a block's carried inbound blocks
-        // against the chain -> anchor on whichever head is further ahead
-        const storedInboundHeight =
-            this.storage.inboundMessages.getLatestBlockHeight() || 0;
-        const useStoredInboundHead =
-            storedInboundHeight >=
-            latestStateSnapshot.latestInboundMessageBlockHeight;
-
         const disputeInput: DisputeInputStruct = {
             channelId: this.channelId,
             forkId: forkId,
@@ -425,13 +422,8 @@ class DisputeManager {
             disputer: disputer,
             timeout: timeoutStruct,
             selfRemoval: selfRemoval,
-            latestInboundMessageBlockHash: useStoredInboundHead
-                ? this.storage.inboundMessages.getLatestBlockHash() ||
-                  ethers.ZeroHash
-                : latestStateSnapshot.latestInboundMessageBlockHash,
-            lastInboundMessageBlockHeight: useStoredInboundHead
-                ? storedInboundHeight
-                : latestStateSnapshot.latestInboundMessageBlockHeight
+            latestInboundMessageBlockHash: inboundHead.hash,
+            lastInboundMessageBlockHeight: inboundHead.height
         };
         let outputSnapshotData: SnapshotDataStruct;
         try {

--- a/src/disputeManager/DisputeManager.ts
+++ b/src/disputeManager/DisputeManager.ts
@@ -404,6 +404,17 @@ class DisputeManager {
         // selfRemoval
         const selfRemoval = this.storage.forceExit.getForceExit();
 
+        // inbound anchor - latestStateSnapshot already proves its own inbound
+        // head, so an anchor below it is self-incriminating
+        // (DisputeInboundAnchorBehindLatestState). inboundMessages lags that
+        // head whenever ingest verified a block's carried inbound blocks
+        // against the chain -> anchor on whichever head is further ahead
+        const storedInboundHeight =
+            this.storage.inboundMessages.getLatestBlockHeight() || 0;
+        const useStoredInboundHead =
+            storedInboundHeight >=
+            latestStateSnapshot.latestInboundMessageBlockHeight;
+
         const disputeInput: DisputeInputStruct = {
             channelId: this.channelId,
             forkId: forkId,
@@ -414,11 +425,13 @@ class DisputeManager {
             disputer: disputer,
             timeout: timeoutStruct,
             selfRemoval: selfRemoval,
-            latestInboundMessageBlockHash:
-                this.storage.inboundMessages.getLatestBlockHash() ||
-                ethers.ZeroHash,
-            lastInboundMessageBlockHeight:
-                this.storage.inboundMessages.getLatestBlockHeight() || 0
+            latestInboundMessageBlockHash: useStoredInboundHead
+                ? this.storage.inboundMessages.getLatestBlockHash() ||
+                  ethers.ZeroHash
+                : latestStateSnapshot.latestInboundMessageBlockHash,
+            lastInboundMessageBlockHeight: useStoredInboundHead
+                ? storedInboundHeight
+                : latestStateSnapshot.latestInboundMessageBlockHeight
         };
         let outputSnapshotData: SnapshotDataStruct;
         try {

--- a/src/stateManager/block/BlockProductionService.ts
+++ b/src/stateManager/block/BlockProductionService.ts
@@ -143,22 +143,22 @@ export default class BlockProductionService {
     private getPendingInboundMessageBlocks(
         previousStateSnapshot: StateSnapshot
     ): MessageBlockStruct[] {
-        const latestStoredHash =
-            this.stateManager.storage.inboundMessages.getLatestBlockHash();
-        if (!latestStoredHash) {
-            return [];
-        }
-
         const previousHash =
-            previousStateSnapshot.snapshotData.latestInboundMessageBlockHash;
+            previousStateSnapshot.latestInboundMessageBlockHash;
 
-        if (previousHash && latestStoredHash === previousHash) {
+        // a store still behind the snapshot has nothing pending - walking from
+        // its head would run past previousHash and return the whole chain
+        const head = this.stateManager.storage.inboundMessages.headNotBehind(
+            previousHash,
+            previousStateSnapshot.latestInboundMessageBlockHeight
+        );
+        if (head.hash === previousHash) {
             return [];
         }
 
         return this.stateManager.storage.inboundMessages.getMessageBlocksInRange(
             {
-                upperBlockHash: latestStoredHash,
+                upperBlockHash: head.hash,
                 lowerBlockHash: previousHash ?? ethers.ZeroHash
             }
         );

--- a/src/stateManager/dispute/DisputeFraudProofService.ts
+++ b/src/stateManager/dispute/DisputeFraudProofService.ts
@@ -36,7 +36,8 @@ import {
     InvalidDisputeReasonStruct,
     DisputeStateProofHeaderMismatchStruct,
     DisputeInvalidBlockStructureStruct,
-    DisputeBlockAuthorNotParticipantStruct
+    DisputeBlockAuthorNotParticipantStruct,
+    DisputeInboundAnchorBehindLatestStateStruct
 } from "@typechain-types/contracts/V1/types/DisputeFraudProofTypes";
 import { BigNumberish, BytesLike } from "ethers";
 // ────────────────────── FRAUD PROOF SERVICE ─────────────────────
@@ -252,6 +253,19 @@ export default class DisputeFraudProofService {
         const proof: { __: boolean } = { __: false };
         return this.storeFraudProof(dispute, {
             type: DisputeFraudProofType.DisputeInboundHashNotInChain,
+            struct: proof
+        });
+    }
+
+    createDisputeInboundAnchorBehindLatestState(
+        dispute: DisputeStruct,
+        latestStateSnapshot: StateSnapshotStruct
+    ): Hash {
+        const proof: DisputeInboundAnchorBehindLatestStateStruct = {
+            latestStateSnapshot
+        };
+        return this.storeFraudProof(dispute, {
+            type: DisputeFraudProofType.DisputeInboundAnchorBehindLatestState,
             struct: proof
         });
     }

--- a/src/stateManager/dispute/DisputeValidationService.ts
+++ b/src/stateManager/dispute/DisputeValidationService.ts
@@ -67,8 +67,12 @@ export default class DisputeValidationService {
                 dispute: LoggerUtils.getDisputeMetadata(dispute)
             });
             if (!dispute.postedAuditingData) {
+                // an undecodable block is never final by everyone -> the empty
+                // proof is fireable here too
+                if (await this.tryCreateLastMilestoneNotFinalProof(dispute))
+                    return false;
                 this.logger.error(
-                    "Skipping dispute audit: undecodable state proof block with no posted auditing data, no fireable fraud proof",
+                    "Skipping dispute audit: undecodable state proof block with no milestones, no fireable fraud proof",
                     { dispute: LoggerUtils.getDisputeMetadata(dispute) }
                 );
                 return true;
@@ -147,16 +151,8 @@ export default class DisputeValidationService {
                 { includeUnfinalizedBlocks: false }
             );
         } else {
-            const milestoneFinalityResult =
-                await this.stateChannelManagerContract.isLastMilestoneFinalByEveryone.staticCall(
-                    dispute
-                );
-            if (!milestoneFinalityResult) {
-                this.disputeFraudProofService.createDisputeLastMilestoneNotFinalAndNoAuditingData(
-                    dispute
-                );
+            if (await this.tryCreateLastMilestoneNotFinalProof(dispute))
                 return false;
-            }
 
             const isLastMilestoneInStorage =
                 this.isLastMilestoneStoredLocally(dispute);
@@ -190,20 +186,16 @@ export default class DisputeValidationService {
                 );
             }
 
-            const latestFinalizedSnapshot =
-                this.agreementManager.getLatestFinalizedSnapshot(
-                    dispute.input.stateProof,
-                    dispute.input.forkId
-                );
-
+            // disputeAuditingData.latestFinalizedStateStateMachineState is
+            // authored by the disputer and verifyStateProof never binds it to
+            // anything. key it by its own keccak256 -> forged bytes cannot land
+            // under the finalized snapshot's stateMachineStateHash, where every
+            // later read of that snapshot would return them as its state
             if (
                 disputeAuditingData.latestFinalizedStateStateMachineState !== ""
             ) {
                 this.storage.stateMachineStates.storeStateMachineState(
-                    disputeAuditingData.latestFinalizedStateStateMachineState,
-                    {
-                        hash: latestFinalizedSnapshot.stateMachineStateHash
-                    }
+                    disputeAuditingData.latestFinalizedStateStateMachineState
                 );
             }
 
@@ -244,6 +236,19 @@ export default class DisputeValidationService {
                 justPersist: true
             });
         }
+    }
+    private async tryCreateLastMilestoneNotFinalProof(
+        dispute: DisputeStruct
+    ): Promise<boolean> {
+        const isFinal =
+            await this.stateChannelManagerContract.isLastMilestoneFinalByEveryone.staticCall(
+                dispute
+            );
+        if (isFinal) return false;
+        this.disputeFraudProofService.createDisputeLastMilestoneNotFinalAndNoAuditingData(
+            dispute
+        );
+        return true;
     }
 
     private async tryVerifyStateProof(
@@ -649,7 +654,36 @@ export default class DisputeValidationService {
         );
 
         if (!isInputLinked) {
-            this.logger.error(
+            const isInboundAnchorBehind =
+                await this.diamondStateMachine.localDiamondContract.isDisputeInboundAnchorBehindLatestState.staticCall(
+                    dispute,
+                    disputeAuditingData.latestStateSnapshot
+                );
+
+            if (isInboundAnchorBehind) {
+                // the forward walk from snapshotData.latestInboundMessageBlockHash
+                // can't reach a dispute.input.lastInboundMessageBlockHeight below
+                // the pinned snapshot's latestInboundMessageBlockHeight ->
+                // objective fraud
+                this.logger.warn(
+                    "Dispute lastInboundMessageBlockHeight is behind its pinned snapshot's latestInboundMessageBlockHeight",
+                    {
+                        dispute: LoggerUtils.getDisputeMetadata(dispute),
+                        auditingData:
+                            LoggerUtils.getAuditingMetadata(disputeAuditingData)
+                    }
+                );
+                this.disputeFraudProofService.createDisputeInboundAnchorBehindLatestState(
+                    dispute,
+                    disputeAuditingData.latestStateSnapshot
+                );
+                return false;
+            }
+
+            // the residual: inboundMessageBlocks don't bridge the gap, or the
+            // snapshot isn't linked to the latest block. no fraud proof matches
+            // it -> skip the output check rather than submit an unprovable one
+            this.logger.warn(
                 "Skipping dispute output verification because auditing input is not linked to dispute input",
                 {
                     dispute: LoggerUtils.getDisputeMetadata(dispute),
@@ -657,9 +691,7 @@ export default class DisputeValidationService {
                         LoggerUtils.getAuditingMetadata(disputeAuditingData)
                 }
             );
-            throw new Error(
-                "Verify Dispute Output - sanity check - is data linked - failed"
-            );
+            return true;
         }
 
         // verify dispute output

--- a/src/stateManager/dispute/DisputeValidationService.ts
+++ b/src/stateManager/dispute/DisputeValidationService.ts
@@ -661,10 +661,9 @@ export default class DisputeValidationService {
                 );
 
             if (isInboundAnchorBehind) {
-                // the forward walk from snapshotData.latestInboundMessageBlockHash
-                // can't reach a dispute.input.lastInboundMessageBlockHeight below
-                // the pinned snapshot's latestInboundMessageBlockHeight ->
-                // objective fraud
+                // the forward walk can never reach a
+                // lastInboundMessageBlockHeight below the pinned snapshot's
+                // -> objective fraud
                 this.logger.warn(
                     "Dispute lastInboundMessageBlockHeight is behind its pinned snapshot's latestInboundMessageBlockHeight",
                     {
@@ -680,9 +679,9 @@ export default class DisputeValidationService {
                 return false;
             }
 
-            // the residual: inboundMessageBlocks don't bridge the gap, or the
-            // snapshot isn't linked to the latest block. no fraud proof matches
-            // it -> skip the output check rather than submit an unprovable one
+            // inboundMessageBlocks don't bridge the gap, or the snapshot isn't
+            // linked to the latest block. no fraud proof matches -> skip the
+            // output check rather than submit an unprovable one
             this.logger.warn(
                 "Skipping dispute output verification because auditing input is not linked to dispute input",
                 {

--- a/src/stateManager/ingest/BlockIngestService.ts
+++ b/src/stateManager/ingest/BlockIngestService.ts
@@ -203,14 +203,6 @@ export default class BlockIngestService {
                 return keepConnection;
             }
 
-            // both inbound checks passed -> the carried blocks are chain
-            // authentic and linked to previousStateSnapshot. record them, the
-            // chain event that would otherwise be their only writer can lag
-            sm.storage.inboundMessages.storeVerifiedRun(
-                inboundMessageBlocks,
-                previousStateSnapshot.latestInboundMessageBlockHash
-            );
-
             stateBeforeTransitionValidation =
                 await sm.diamondStateMachine.getState();
 
@@ -329,6 +321,13 @@ export default class BlockIngestService {
                     }
                 }
             );
+            // committed -> the carried inbound blocks are canonical. runs
+            // after success because reject rewinds the VM, never storage
+            sm.storage.inboundMessages.storeVerifiedRun(
+                inboundMessageBlocks,
+                previousStateSnapshot.latestInboundMessageBlockHash
+            );
+
             const blockMeta = LoggerUtils.getBlockMetadata(block, sm.storage);
             this.logger.info(
                 `onBlockConfirmation - success - ${blockMeta.blockHeight}`,

--- a/src/stateManager/ingest/BlockIngestService.ts
+++ b/src/stateManager/ingest/BlockIngestService.ts
@@ -203,6 +203,14 @@ export default class BlockIngestService {
                 return keepConnection;
             }
 
+            // both inbound checks passed -> the carried blocks are chain
+            // authentic and linked to previousStateSnapshot. record them, the
+            // chain event that would otherwise be their only writer can lag
+            sm.storage.inboundMessages.storeVerifiedRun(
+                inboundMessageBlocks,
+                previousStateSnapshot.latestInboundMessageBlockHash
+            );
+
             stateBeforeTransitionValidation =
                 await sm.diamondStateMachine.getState();
 

--- a/src/storage/MessageBlockStorage.ts
+++ b/src/storage/MessageBlockStorage.ts
@@ -49,6 +49,22 @@ export class MessageBlockStorage {
         return blockHash;
     }
 
+    // a chain-verified run, ordered ascending, linked to previousBlockHash.
+    // the latest pointers only move when that link is a block we hold ->
+    // getIterator can always walk back from the head without hitting a gap
+    storeVerifiedRun(
+        messageBlocks: MessageBlockStruct[],
+        previousBlockHash: Hash
+    ): void {
+        const isLinkedToHeldBlock =
+            previousBlockHash === ZeroHash ||
+            this.blockMap.has(previousBlockHash);
+
+        for (const messageBlock of messageBlocks) {
+            this.store(messageBlock, { justPersist: !isLinkedToHeldBlock });
+        }
+    }
+
     // ====================================
     // READ
     // ====================================

--- a/src/storage/MessageBlockStorage.ts
+++ b/src/storage/MessageBlockStorage.ts
@@ -49,25 +49,39 @@ export class MessageBlockStorage {
         return blockHash;
     }
 
-    // a chain-verified run, ordered ascending, linked to previousBlockHash.
-    // the latest pointers only move when that link is a block we hold ->
-    // getIterator can always walk back from the head without hitting a gap
+    // a chain-verified run, ordered ascending. the pointers only move when the
+    // run extends the current head exactly - a merely-held previousBlockHash
+    // can itself sit above a gap, and getIterator throws walking into one
     storeVerifiedRun(
         messageBlocks: MessageBlockStruct[],
         previousBlockHash: Hash
     ): void {
-        const isLinkedToHeldBlock =
-            previousBlockHash === ZeroHash ||
-            this.blockMap.has(previousBlockHash);
+        const extendsHead =
+            this.latestBlockHash === undefined
+                ? previousBlockHash === ZeroHash
+                : previousBlockHash === this.latestBlockHash;
 
         for (const messageBlock of messageBlocks) {
-            this.store(messageBlock, { justPersist: !isLinkedToHeldBlock });
+            this.store(messageBlock, { justPersist: !extendsHead });
         }
     }
 
     // ====================================
     // READ
     // ====================================
+
+    // the local head, or the snapshot's own head while the store still lags it
+    // -> callers never walk from a point below the snapshot they work against
+    headNotBehind(
+        snapshotHash: Hash,
+        snapshotHeight: BlockHeight
+    ): { hash: Hash; height: BlockHeight } {
+        const height = this.latestBlockHeight ?? 0;
+        if (this.latestBlockHash === undefined || height < snapshotHeight) {
+            return { hash: snapshotHash, height: snapshotHeight };
+        }
+        return { hash: this.latestBlockHash, height };
+    }
 
     getMessageBlock(blockHash: Hash): MessageBlockStruct | undefined {
         return this.blockMap.get(blockHash);

--- a/src/types/disputes.ts
+++ b/src/types/disputes.ts
@@ -192,6 +192,10 @@ export const DisputeInboundHashNotInChainProofEthersType = `tuple(
     bool __
 )`;
 
+export const DisputeInboundAnchorBehindLatestStateProofEthersType = `tuple(
+    ${StateSnapshotEthersType} latestStateSnapshot
+)`;
+
 export const InvalidDisputeReasonProofEthersType = `tuple(
     ${StateSnapshotEthersType} latestStateSnapshot
 )`;

--- a/src/types/sol-enums.ts
+++ b/src/types/sol-enums.ts
@@ -25,7 +25,8 @@ export enum DisputeFraudProofType {
     DisputeStateProofHeaderMismatch,
     DisputeInboundHashNotInChain,
     DisputeInvalidBlockStructure,
-    DisputeBlockAuthorNotParticipant
+    DisputeBlockAuthorNotParticipant,
+    DisputeInboundAnchorBehindLatestState
 }
 
 export const toSolidityFraudProofType = (value: FraudProofType) => value % 100;

--- a/src/utils/Codec.ts
+++ b/src/utils/Codec.ts
@@ -53,6 +53,7 @@ import {
     DisputeLastMilestoneNotFinalAndNoAuditingDataProofEthersType,
     DisputeStateProofHeaderMismatchProofEthersType,
     DisputeInboundHashNotInChainProofEthersType,
+    DisputeInboundAnchorBehindLatestStateProofEthersType,
     InvalidDisputeReasonProofEthersType,
     TimeoutThresholdProofEthersType,
     TimeoutCalldataPostedProofEthersType,
@@ -94,7 +95,8 @@ import {
     InvalidDisputeReasonStruct,
     DisputeStateProofHeaderMismatchStruct,
     DisputeInvalidBlockStructureStruct,
-    DisputeBlockAuthorNotParticipantStruct
+    DisputeBlockAuthorNotParticipantStruct,
+    DisputeInboundAnchorBehindLatestStateStruct
 } from "@typechain-types/contracts/V1/types/DisputeFraudProofTypes";
 
 export type FraudStruct =
@@ -120,7 +122,8 @@ export type DisputeFraudStruct =
     | InvalidDisputeReasonStruct
     | DisputeStateProofHeaderMismatchStruct
     | DisputeInvalidBlockStructureStruct
-    | DisputeBlockAuthorNotParticipantStruct;
+    | DisputeBlockAuthorNotParticipantStruct
+    | DisputeInboundAnchorBehindLatestStateStruct;
 
 type StructType =
     | FraudStruct
@@ -277,6 +280,10 @@ export class Codec {
         [
             DisputeFraudProofType.DisputeBlockAuthorNotParticipant,
             DisputeBlockAuthorNotParticipantProofEthersType
+        ],
+        [
+            DisputeFraudProofType.DisputeInboundAnchorBehindLatestState,
+            DisputeInboundAnchorBehindLatestStateProofEthersType
         ]
     ]);
 

--- a/src/utils/Codec.ts
+++ b/src/utils/Codec.ts
@@ -415,6 +415,10 @@ export class Codec {
     ): StateProofStruct;
     public static decode(
         encoded: Bytes,
+        type: DisputeFraudProofType.DisputeNotLatestState
+    ): DisputeNotLatestStateStruct;
+    public static decode(
+        encoded: Bytes,
         type: DisputeFraudProofType.DisputeInvalidBlockStructure
     ): DisputeInvalidBlockStructureStruct;
     public static decode(

--- a/test/e2e/disputeValidation/inboundHash.test.ts
+++ b/test/e2e/disputeValidation/inboundHash.test.ts
@@ -1,6 +1,12 @@
+import { expect } from "chai";
+
 import { DisputeFraudProofType } from "@/types/sol-enums";
-import { MathTestSession as TestSession } from "@test/harness";
-import { Hash } from "@/types/types";
+import {
+    DisputeTampering,
+    MathTestSession as TestSession
+} from "@test/harness";
+import { Bytes, Hash } from "@/types/types";
+import { Codec, Type } from "@/utils";
 
 // dispute.input.latestInboundMessageBlockHash is validated by walking the on-chain
 // inbound chain backwards. Junk values that don't exist anywhere in the chain are
@@ -63,5 +69,159 @@ describe("E2E: dispute validation / inboundHash", function () {
             timeoutMs: 10000
         });
         await h.dispute.resolveDisputeWait({ forkId });
+    });
+
+    // _uploadDispute never validates the inbound hash, and naming a real
+    // earlier block is not DisputeInboundHashNotInChain either -> the auditor
+    // walks forward from snapshotData.latestInboundMessageBlockHash and can
+    // never reach it
+    it("dispute.input.lastInboundMessageBlockHeight below the pinned snapshotData.latestInboundMessageBlockHeight → DisputeInboundAnchorBehindLatestState", async function () {
+        const h = TestSession.getHarness();
+        const attackerIndex = 1;
+        // larger agreementTime avoids writer-timeout disputes racing the upload
+        await h.scenario.preDisputeSetupConsumedInboundTopUp({
+            timeConfig: { agreementTime: 8, evidenceTime: 4 }
+        });
+        const forkId = h.activeForkId!;
+
+        const attacker = h.control(h.getPeer(attackerIndex));
+        const headHash = (await attacker.query
+            .getLatestInboundMessageHash()
+            .request()) as Hash;
+        const headHeight = (await attacker.query
+            .getInboundLatestHeight()
+            .request())!;
+        const head = Codec.decode(
+            (await attacker.query.getInboundMessageBlock(headHash).request())!
+                .encodedMessageBlock,
+            Type.MessageBlock
+        );
+        const previousHash = head.previousBlockHash as Hash;
+        const previousHeight = headHeight - 1;
+        // premise - an earlier inbound block really exists to name
+        expect(previousHeight).to.be.greaterThan(0);
+
+        // selfRemoval gives the dispute a stated reason, so the audit gets past
+        // hasDisputeReason and reaches the output verification
+        const { disputeConfirmation } = await h.tamper.postTamperedDispute(
+            attackerIndex,
+            (dispute) => {
+                DisputeTampering.flipSelfRemovalWithoutOutputRecompute(dispute);
+                dispute.input.latestInboundMessageBlockHash = previousHash;
+                dispute.input.lastInboundMessageBlockHeight = previousHeight;
+            }
+        );
+
+        const encodedDispute = disputeConfirmation.signedDispute
+            .encodedDispute as Bytes;
+
+        // premise - the snapshot the dispute pins via latestStateSnapshotHash
+        // is already past the height the dispute names
+        const committed = Codec.decode(encodedDispute, Type.Dispute);
+        const latestSnapshot = await h
+            .control(h.getPeer(0))
+            .query.getStateSnapshotStructByHash(
+                committed.input.latestStateSnapshotHash as Hash
+            )
+            .request();
+        expect(
+            Number(
+                Codec.decode(
+                    latestSnapshot!.encodedSnapshot,
+                    Type.StateSnapshot
+                ).snapshotData.latestInboundMessageBlockHeight
+            )
+        ).to.equal(headHeight);
+
+        // premise - the chain accepted and committed the tampered dispute (the
+        // only one in this scenario), so honest auditors meet this shape live.
+        // edge-triggered: the kill clears the window commitment and the stored
+        // confirmation as soon as an auditor wins the race
+        await h.assert.dispute.committedWait({ expectedCount: 1 });
+
+        await h.event.waitForAllPeers("onDisputeKilled", 1, {
+            mode: "atLeast"
+        });
+        await h.assert.storage.honestPeersStoredDisputeFraudProofDetached({
+            disputeFraudProofType:
+                DisputeFraudProofType.DisputeInboundAnchorBehindLatestState,
+            timeoutMs: 10000
+        });
+        await h.dispute.resolveDisputeWait({
+            forkId,
+            forkSettleTimeoutMs: 15000
+        });
+    });
+
+    // the false-slash tripwire for the proof above: an honest peer whose
+    // InboundMessagesProcessed event lags anchors on the snapshot it pins, so
+    // its own dispute is never provable fraud
+    it("honest disputer whose inbound chain event lags → dispute survives, disputer not killed or slashed", async function () {
+        const h = TestSession.getHarness();
+        const laggingIndex = 2;
+        const attackerIndex = 1;
+
+        // larger agreementTime avoids writer-timeout disputes racing the upload
+        await h.setup(3, {
+            timeConfig: {
+                p2pTime: 2,
+                agreementTime: 8,
+                chainFallbackTime: 4,
+                evidenceTime: 4
+            }
+        });
+        // held from before the channel opens -> the lagging peer never stores
+        // inbound block 1, so its inbound store head can never move
+        await h.rpcStub.holdInboundMessageEvents(laggingIndex);
+        await h.lifecycle.openChannel();
+        const forkId = h.activeForkId!;
+        await h.transition.advanceState({
+            count: 2,
+            waitForFinalization: true
+        });
+        // topping up an existing participant keeps block turns intact
+        await h.join.forceInboundJoinWait({
+            participant: h.getPeer(0).address,
+            observePeerIndices: [0, 1]
+        });
+        await h.transition.advanceState({
+            count: 2,
+            waitForFinalization: true
+        });
+        await h.assert.sync.peersInSyncWait();
+        h.event.resetEventSpies();
+        h.contextApi.captureOriginalFork();
+
+        // peer 0 never initiates -> the committed dispute is the lagging
+        // peer's, while peer 0 still audits and kills for real
+        await h
+            .control(h.getPeer(0))
+            .stub.stubSuppressDisputeInitiation()
+            .request();
+
+        await h.byzantine.submitDoubleSignBlock(attackerIndex);
+
+        await h.assert.dispute.initiatedAndCommitedWait({
+            peersIndices: [laggingIndex],
+            expectedCount: 1
+        });
+        await h.dispute.resolveDisputeWait({
+            forkId,
+            forkSettleTimeoutMs: 20000
+        });
+
+        // no auditor found fraud in the honest disputer's anchor
+        for (const peer of h.peers) {
+            expect(
+                h.event.getEventCallCount(peer.index, "onDisputeKilled"),
+                `peer ${peer.index} onDisputeKilled`
+            ).to.equal(0);
+        }
+        // resolveDisputeWait already pins the new fork to the honest peers ->
+        // the double-signer is out and the disputer is still in
+        const slashed = await h.channelManager.getOnChainSlashedParticipants(
+            h.channelId
+        );
+        expect(slashed).to.not.include(h.getPeer(laggingIndex).address);
     });
 });

--- a/test/e2e/disputeValidation/uploadRevert/disputeAuditingDataHash.test.ts
+++ b/test/e2e/disputeValidation/uploadRevert/disputeAuditingDataHash.test.ts
@@ -33,4 +33,56 @@ describe("E2E: dispute validation / uploadRevert / disputeAuditingDataHash", fun
             );
         }
     });
+
+    // both upload entry points below are what stop a committed dispute from
+    // reaching an auditor with postedAuditingData set but no data alongside it
+    // -> validateDispute never hits its "auditing data missing" throw
+    it("postedAuditingData true uploaded without calldata → dispute upload fails → ErrorDisputePostedAuditingDataMismatch", async function () {
+        const h = TestSession.getHarness();
+        await h.scenario.preDisputeSetupCalldataPath();
+        const peer = h.getPeer(3);
+
+        const { dispute, disputeConfirmation } =
+            await h.dispute.fetchConstructedDispute(peer.index);
+        expect(dispute.postedAuditingData).to.equal(true);
+        await h.tamper.resignDispute(peer.signer, dispute, disputeConfirmation);
+
+        try {
+            await peer.p2pInstance.stateChannelManagerContract.uploadDispute(
+                disputeConfirmation
+            );
+            expect.fail("expected revert");
+        } catch (error: unknown) {
+            expectDecodedError(
+                error,
+                "ErrorDisputePostedAuditingDataMismatch",
+                "expected ErrorDisputePostedAuditingDataMismatch"
+            );
+        }
+    });
+
+    it("postedAuditingData false uploaded with calldata → dispute upload fails → ErrorDisputePostedAuditingDataMismatch", async function () {
+        const h = TestSession.getHarness();
+        await h.scenario.preDisputeSetup();
+        const peer = h.getPeer(0);
+
+        const { dispute, disputeConfirmation, auditingData } =
+            await h.dispute.fetchConstructedDispute(peer.index);
+        expect(dispute.postedAuditingData).to.equal(false);
+        await h.tamper.resignDispute(peer.signer, dispute, disputeConfirmation);
+
+        try {
+            await peer.p2pInstance.stateChannelManagerContract.uploadDisputeWithCalldata(
+                disputeConfirmation,
+                auditingData
+            );
+            expect.fail("expected revert");
+        } catch (error: unknown) {
+            expectDecodedError(
+                error,
+                "ErrorDisputePostedAuditingDataMismatch",
+                "expected ErrorDisputePostedAuditingDataMismatch"
+            );
+        }
+    });
 });

--- a/test/fixtures/customRpc/harnessControl/services/dispute/DisputeRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/dispute/DisputeRpcMethods.ts
@@ -99,6 +99,13 @@ export class DisputeRpcMethods extends ARpcMethods {
         };
     }
 
+    /** Inbound-hash verdicts from this peer's local diamond and its RPC node. */
+    public probeDisputeInboundHashSources(
+        encodedDispute: string
+    ): Promise<{ local: boolean; rpc: boolean }> {
+        return this.service.probeDisputeInboundHashSources(encodedDispute);
+    }
+
     /** Run the real dispute audit on this peer; verdict + stored-proof projection. */
     public runDisputeValidation(
         encodedDispute: string,
@@ -113,6 +120,8 @@ export class DisputeRpcMethods extends ARpcMethods {
         options: {
             encodedAuditingData?: string;
             includeUnfinalizedBlocks: boolean;
+            /** Post-decode override; "" is not ABI-encodable (see service). */
+            latestFinalizedStateStateMachineStateOverride?: string;
         }
     ): PersistDisputeDataProjection {
         return this.service.persistDisputeDataWithoutAudit(

--- a/test/fixtures/customRpc/harnessControl/services/dispute/DisputeRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/dispute/DisputeRpcMethods.ts
@@ -14,7 +14,11 @@ import {
     DISPUTE_TAMPER_STRATEGIES,
     type DisputeTamperStrategy
 } from "./tamperStrategies";
-import type { DisputeService } from "./DisputeService";
+import type {
+    DisputeService,
+    DisputeValidationRun,
+    PersistDisputeDataProjection
+} from "./DisputeService";
 
 /** Spec for installing a `constructDispute` tamper (named strategy or shipped body). */
 export interface ConstructDisputeStubSpec {
@@ -93,6 +97,28 @@ export class DisputeRpcMethods extends ARpcMethods {
                 Type.DisputeAuditingData
             ) as string
         };
+    }
+
+    /** Run the real dispute audit on this peer; verdict + stored-proof projection. */
+    public runDisputeValidation(
+        encodedDispute: string,
+        options?: { encodedAuditingData?: string }
+    ): Promise<DisputeValidationRun> {
+        return this.service.runDisputeValidation(encodedDispute, options);
+    }
+
+    /** Run the real persistDisputeDataWithoutAudit; storage presence projection. */
+    public persistDisputeDataWithoutAudit(
+        encodedDispute: string,
+        options: {
+            encodedAuditingData?: string;
+            includeUnfinalizedBlocks: boolean;
+        }
+    ): PersistDisputeDataProjection {
+        return this.service.persistDisputeDataWithoutAudit(
+            encodedDispute,
+            options
+        );
     }
 
     /** Recompute auditing data for a (tampered) state proof; ABI-encoded. */

--- a/test/fixtures/customRpc/harnessControl/services/dispute/DisputeRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/dispute/DisputeRpcMethods.ts
@@ -4,7 +4,7 @@ import ARpcMethods from "@/rpc/ARpcMethods";
 import type ATransport from "@/transport/ATransport";
 import Clock from "@/Clock";
 import { Codec, Type } from "@/utils";
-import type { ForkId } from "@/types/types";
+import type { ForkId, Hash } from "@/types/types";
 import type {
     DisputeStruct,
     DisputeConfirmationStruct,
@@ -130,15 +130,21 @@ export class DisputeRpcMethods extends ARpcMethods {
         );
     }
 
-    /** Recompute auditing data for a (tampered) state proof; ABI-encoded. */
+    /**
+     * Recompute auditing data for a (tampered) state proof; ABI-encoded.
+     * `disputeLatestInboundMessageBlockHash` is the anchor an auditor bounds
+     * the inbound range with (`DisputeValidationService.continueOtherChecks`).
+     */
     public getAuditingData(
         forkId: ForkId,
-        encodedStateProof: string
+        encodedStateProof: string,
+        options?: { disputeLatestInboundMessageBlockHash?: Hash }
     ): { isPartial: boolean; encodedAuditingData: string } {
         const { isPartial, auditingData } =
             this.service.disputeManager.getAuditingData(
                 forkId,
-                Codec.decode(encodedStateProof, Type.StateProof)
+                Codec.decode(encodedStateProof, Type.StateProof),
+                options
             );
         return {
             isPartial,

--- a/test/fixtures/customRpc/harnessControl/services/dispute/DisputeService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/dispute/DisputeService.ts
@@ -87,7 +87,10 @@ export type PersistDisputeDataProjection = {
     undecodableSignedBlockCount: number;
     /** Auditing-data snapshots: latest first, then milestone snapshots. */
     snapshots: PersistedItemProjection[];
-    /** Keyed by the latest finalized snapshot's stateMachineStateHash; absent without auditing data. */
+    /**
+     * Keyed by keccak256 of the finalized state; absent without auditing data
+     * and for the "" sentinel.
+     */
     stateMachineState?: PersistedItemProjection;
     inboundMessages: PersistedItemProjection[];
     outboundMessages: PersistedItemProjection[];
@@ -569,6 +572,21 @@ export class DisputeService extends ARpcService<DisputeRpcMethods> {
         return true;
     }
 
+    /** Both sources the audit's inbound-hash check consults, read separately. */
+    async probeDisputeInboundHashSources(
+        encodedDispute: string
+    ): Promise<{ local: boolean; rpc: boolean }> {
+        const dispute = Codec.decode(encodedDispute, Type.Dispute);
+        return {
+            local: await this.sm.diamondStateMachine.localDiamondContract.isDisputeInboundHashValid.staticCall(
+                dispute
+            ),
+            rpc: await this.sm.stateChannelManagerContract.isDisputeInboundHashValid.staticCall(
+                dispute
+            )
+        };
+    }
+
     /** Run the real dispute audit; project verdict + the stored fraud proof. */
     async runDisputeValidation(
         encodedDispute: string,
@@ -626,6 +644,12 @@ export class DisputeService extends ARpcService<DisputeRpcMethods> {
         options: {
             encodedAuditingData?: string;
             includeUnfinalizedBlocks: boolean;
+            /**
+             * Applied after decode: DisputeManager emits "" in-memory for a
+             * missing finalized state, but "" is not ABI-encodable, so it
+             * cannot cross the port inside encodedAuditingData.
+             */
+            latestFinalizedStateStateMachineStateOverride?: string;
         }
     ): PersistDisputeDataProjection {
         const dispute = Codec.decode(encodedDispute, Type.Dispute);
@@ -635,6 +659,13 @@ export class DisputeService extends ARpcService<DisputeRpcMethods> {
                   Type.DisputeAuditingData
               )
             : undefined;
+        if (
+            auditingData &&
+            options.latestFinalizedStateStateMachineStateOverride !== undefined
+        ) {
+            auditingData.latestFinalizedStateStateMachineState =
+                options.latestFinalizedStateStateMachineStateOverride;
+        }
 
         const milestoneBlocks: Block[] = [];
         let undecodableMilestoneBlockCount = 0;
@@ -664,19 +695,15 @@ export class DisputeService extends ARpcService<DisputeRpcMethods> {
         const outboundHashes = (auditingData?.outboundMessageBlocks ?? []).map(
             (mb) => keccakHash(Codec.encode(mb, Type.MessageBlock)) as Hash
         );
-        // same lookup the real persist uses for the state-machine-state key;
-        // it can throw on partial storage, so retry after the persist ran
-        const resolveStateKey = (): Hash | undefined => {
-            try {
-                return this.agreementManager.getLatestFinalizedSnapshot(
-                    dispute.input.stateProof,
-                    dispute.input.forkId as ForkId
-                ).stateMachineStateHash as Hash;
-            } catch {
-                return undefined;
-            }
-        };
-        let stateKey = auditingData ? resolveStateKey() : undefined;
+        // oracle computed here, not read back from storage: the persist key is
+        // the state's own hash, and the "" sentinel has no key
+        const stateKey =
+            auditingData &&
+            auditingData.latestFinalizedStateStateMachineState !== ""
+                ? (keccakHash(
+                      auditingData.latestFinalizedStateStateMachineState
+                  ) as Hash)
+                : undefined;
 
         const blockStored = (block: Block) =>
             !!this.storage.blocks.getBlock(block.hash);
@@ -711,8 +738,6 @@ export class DisputeService extends ARpcService<DisputeRpcMethods> {
             threwMessage =
                 error instanceof Error ? error.message : String(error);
         }
-        if (auditingData && stateKey === undefined)
-            stateKey = resolveStateKey();
 
         const blockKey = (block: Block) =>
             `${block.forkId}:${block.height}:${block.hash}`;

--- a/test/fixtures/customRpc/harnessControl/services/dispute/DisputeService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/dispute/DisputeService.ts
@@ -7,7 +7,7 @@ import Clock from "@/Clock";
 import { SignatureUtils, Codec, Type, hash as keccakHash } from "@/utils";
 import Block from "@/models/Block";
 import StateSnapshot from "@/models/StateSnapshot";
-import type { ForkId, Hash } from "@/types/types";
+import type { Address, Bytes, ForkId, Hash } from "@/types/types";
 import type {
     DisputeStruct,
     DisputeConfirmationStruct,
@@ -21,6 +21,7 @@ import type {
     TransactionHeaderStruct
 } from "@typechain-types/contracts/V1/types/DataTypes";
 import type { ConstructDisputeResult } from "@/disputeManager/DisputeManager";
+import { DisputeFraudProofType } from "@/types/sol-enums";
 import {
     hash as randomHashFactory,
     blockStructWithTransactionHeader as factoryBlockStructWithHeader
@@ -33,6 +34,64 @@ import type { SignerService } from "../signer/SignerService";
 import DisputeRpcMethods from "./DisputeRpcMethods";
 
 type BlockTransform = (bs: BlockStruct) => BlockStruct;
+
+// inverse of src's toSolidityDisputeFraudProofType (value % 200)
+const fromSolidityDisputeFraudProofType = (
+    value: number
+): DisputeFraudProofType => {
+    const tsValue = value + 200;
+    if (DisputeFraudProofType[tsValue] === undefined) {
+        throw new Error(
+            `Unknown solidity DisputeFraudProofType value: ${value}`
+        );
+    }
+    return tsValue;
+};
+
+/** Projection of the dispute fraud proof stored for the audited dispute. */
+export type StoredDisputeFraudProof = {
+    disputeFraudProofType: DisputeFraudProofType;
+    /** Participant the proof accuses. */
+    proofParticipant: Address;
+    /** Evidence struct, encoded per its proof type. */
+    encodedProof: Bytes;
+};
+
+/** Outcome of one real `validateDispute` run plus the stored-proof projection. */
+export type DisputeValidationRun = {
+    /** Proof stored for this dispute; absent when none was stored. */
+    storedProof?: StoredDisputeFraudProof;
+    /** All dispute fraud proofs in storage (backs replay/idempotency counts). */
+    disputeFraudProofCount: number;
+} & (
+    | { outcome: "returned"; isValid: boolean }
+    | { outcome: "threw"; threwMessage: string }
+);
+
+/** Presence of one persisted item in storage before/after the persist call. */
+export type PersistedItemProjection = {
+    /** Blocks: `forkId:height:hash`; snapshots/messages/state: the hash. */
+    key: string;
+    storedBefore: boolean;
+    storedAfter: boolean;
+};
+
+export type PersistDisputeDataProjection = {
+    /** Message of a thrown persist error; absent when it returned. */
+    threwMessage?: string;
+    /** Per decodable milestone confirmation block, state-proof order. */
+    milestoneBlocks: PersistedItemProjection[];
+    undecodableMilestoneBlockCount: number;
+    /** Per decodable `stateProof.signedBlocks` entry, proof order. */
+    signedBlocks: PersistedItemProjection[];
+    undecodableSignedBlockCount: number;
+    /** Auditing-data snapshots: latest first, then milestone snapshots. */
+    snapshots: PersistedItemProjection[];
+    /** Keyed by the latest finalized snapshot's stateMachineStateHash; absent without auditing data. */
+    stateMachineState?: PersistedItemProjection;
+    inboundMessages: PersistedItemProjection[];
+    outboundMessages: PersistedItemProjection[];
+};
 
 /**
  * Dispute construction / auditing / tampering for the test harness. Accessors,
@@ -69,6 +128,9 @@ export class DisputeService extends ARpcService<DisputeRpcMethods> {
     }
     get disputeManager() {
         return this.sm.disputeManager;
+    }
+    get agreementManager() {
+        return this.sm.agreementManager;
     }
 
     // ===== Callback utilities (reached via the injected stateManager) =====
@@ -505,6 +567,208 @@ export class DisputeService extends ARpcService<DisputeRpcMethods> {
         this.disputeManager.constructDispute = this.originalConstructDispute;
         this.originalConstructDispute = undefined;
         return true;
+    }
+
+    /** Run the real dispute audit; project verdict + the stored fraud proof. */
+    async runDisputeValidation(
+        encodedDispute: string,
+        options?: { encodedAuditingData?: string }
+    ): Promise<DisputeValidationRun> {
+        const dispute = Codec.decode(encodedDispute, Type.Dispute);
+        const auditingData = options?.encodedAuditingData
+            ? Codec.decode(
+                  options.encodedAuditingData,
+                  Type.DisputeAuditingData
+              )
+            : undefined;
+        let outcome:
+            | { outcome: "returned"; isValid: boolean }
+            | { outcome: "threw"; threwMessage: string };
+        try {
+            outcome = {
+                outcome: "returned",
+                isValid: await this.sm.disputeValidationService.validateDispute(
+                    dispute,
+                    auditingData
+                )
+            };
+        } catch (error) {
+            outcome = {
+                outcome: "threw",
+                threwMessage:
+                    error instanceof Error ? error.message : String(error)
+            };
+        }
+        const proof =
+            this.storage.disputeFraudProofs.getDisputeFraudProofForDispute(
+                dispute
+            );
+        return {
+            ...outcome,
+            storedProof: proof
+                ? {
+                      // stored proofType is the solidity value
+                      disputeFraudProofType: fromSolidityDisputeFraudProofType(
+                          Number(proof.proofType)
+                      ),
+                      proofParticipant: String(proof.participant),
+                      encodedProof: String(proof.encodedProof)
+                  }
+                : undefined,
+            disputeFraudProofCount:
+                this.storage.disputeFraudProofs.getDisputeFraudProofs().length
+        };
+    }
+
+    /** Run the real persist; project each item's storage presence before/after. */
+    persistDisputeDataWithoutAudit(
+        encodedDispute: string,
+        options: {
+            encodedAuditingData?: string;
+            includeUnfinalizedBlocks: boolean;
+        }
+    ): PersistDisputeDataProjection {
+        const dispute = Codec.decode(encodedDispute, Type.Dispute);
+        const auditingData = options.encodedAuditingData
+            ? Codec.decode(
+                  options.encodedAuditingData,
+                  Type.DisputeAuditingData
+              )
+            : undefined;
+
+        const milestoneBlocks: Block[] = [];
+        let undecodableMilestoneBlockCount = 0;
+        for (const milestone of dispute.input.stateProof.milestones) {
+            for (const bc of milestone.blockConfirmations) {
+                const block = Block.tryFromBlockConfirmation(bc);
+                if (block) milestoneBlocks.push(block);
+                else undecodableMilestoneBlockCount++;
+            }
+        }
+        const signedBlocks: Block[] = [];
+        let undecodableSignedBlockCount = 0;
+        for (const sb of dispute.input.stateProof.signedBlocks) {
+            const block = Block.tryFromSignedBlock(sb);
+            if (block) signedBlocks.push(block);
+            else undecodableSignedBlockCount++;
+        }
+        const snapshots = auditingData
+            ? [
+                  auditingData.latestStateSnapshot,
+                  ...auditingData.milestoneSnapshots
+              ].map((struct) => StateSnapshot.from(struct))
+            : [];
+        const inboundHashes = (auditingData?.inboundMessageBlocks ?? []).map(
+            (mb) => keccakHash(Codec.encode(mb, Type.MessageBlock)) as Hash
+        );
+        const outboundHashes = (auditingData?.outboundMessageBlocks ?? []).map(
+            (mb) => keccakHash(Codec.encode(mb, Type.MessageBlock)) as Hash
+        );
+        // same lookup the real persist uses for the state-machine-state key;
+        // it can throw on partial storage, so retry after the persist ran
+        const resolveStateKey = (): Hash | undefined => {
+            try {
+                return this.agreementManager.getLatestFinalizedSnapshot(
+                    dispute.input.stateProof,
+                    dispute.input.forkId as ForkId
+                ).stateMachineStateHash as Hash;
+            } catch {
+                return undefined;
+            }
+        };
+        let stateKey = auditingData ? resolveStateKey() : undefined;
+
+        const blockStored = (block: Block) =>
+            !!this.storage.blocks.getBlock(block.hash);
+        const snapshotStored = (snapshot: StateSnapshot) =>
+            !!this.storage.stateSnapshots.getStateSnapshotByHash(snapshot.hash);
+        const stateStored = (key: Hash | undefined) =>
+            key !== undefined &&
+            this.storage.stateMachineStates.getStateMachineState(key) !==
+                undefined;
+
+        const before = {
+            milestoneBlocks: milestoneBlocks.map(blockStored),
+            signedBlocks: signedBlocks.map(blockStored),
+            snapshots: snapshots.map(snapshotStored),
+            inbound: inboundHashes.map(
+                (h) => !!this.storage.inboundMessages.getMessageBlock(h)
+            ),
+            outbound: outboundHashes.map(
+                (h) => !!this.storage.outboundMessages.getMessageBlock(h)
+            ),
+            state: stateStored(stateKey)
+        };
+
+        let threwMessage: string | undefined;
+        try {
+            this.sm.disputeValidationService.persistDisputeDataWithoutAudit(
+                dispute,
+                auditingData,
+                { includeUnfinalizedBlocks: options.includeUnfinalizedBlocks }
+            );
+        } catch (error) {
+            threwMessage =
+                error instanceof Error ? error.message : String(error);
+        }
+        if (auditingData && stateKey === undefined)
+            stateKey = resolveStateKey();
+
+        const blockKey = (block: Block) =>
+            `${block.forkId}:${block.height}:${block.hash}`;
+        const project = (
+            keys: string[],
+            storedBefore: boolean[],
+            storedAfter: boolean[]
+        ): PersistedItemProjection[] =>
+            keys.map((key, i) => ({
+                key,
+                storedBefore: storedBefore[i],
+                storedAfter: storedAfter[i]
+            }));
+
+        return {
+            threwMessage,
+            milestoneBlocks: project(
+                milestoneBlocks.map(blockKey),
+                before.milestoneBlocks,
+                milestoneBlocks.map(blockStored)
+            ),
+            undecodableMilestoneBlockCount,
+            signedBlocks: project(
+                signedBlocks.map(blockKey),
+                before.signedBlocks,
+                signedBlocks.map(blockStored)
+            ),
+            undecodableSignedBlockCount,
+            snapshots: project(
+                snapshots.map((s) => String(s.hash)),
+                before.snapshots,
+                snapshots.map(snapshotStored)
+            ),
+            stateMachineState:
+                auditingData && stateKey !== undefined
+                    ? {
+                          key: String(stateKey),
+                          storedBefore: before.state,
+                          storedAfter: stateStored(stateKey)
+                      }
+                    : undefined,
+            inboundMessages: project(
+                inboundHashes.map(String),
+                before.inbound,
+                inboundHashes.map(
+                    (h) => !!this.storage.inboundMessages.getMessageBlock(h)
+                )
+            ),
+            outboundMessages: project(
+                outboundHashes.map(String),
+                before.outbound,
+                outboundHashes.map(
+                    (h) => !!this.storage.outboundMessages.getMessageBlock(h)
+                )
+            )
+        };
     }
 
     async recoverCommittedDisputes(forkId: ForkId): Promise<number> {

--- a/test/fixtures/customRpc/harnessControl/services/query/QueryRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/query/QueryRpcMethods.ts
@@ -344,6 +344,24 @@ export class QueryRpcMethods extends ARpcMethods {
             : null;
     }
 
+    /** Encoded (`Type.MessageBlock`) inbound message block, or null. */
+    public getInboundMessageBlock(
+        messageBlockHash: Hash
+    ): { encodedMessageBlock: string } | null {
+        const block =
+            this.service.storage.inboundMessages.getMessageBlock(
+                messageBlockHash
+            );
+        return block
+            ? {
+                  encodedMessageBlock: Codec.encode(
+                      block,
+                      Type.MessageBlock
+                  ) as string
+              }
+            : null;
+    }
+
     /** Encoded (`Type.MessageBlock`) outbound message block, or null. */
     public getOutboundMessageBlock(
         messageBlockHash: Hash

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -728,6 +728,22 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
         return true;
     }
 
+    /** Park the dispute audit at its on-chain-slashes query until released. */
+    public stubHoldOnChainSlashesQuery(): boolean {
+        this.service.installOnChainSlashesQueryHold();
+        return true;
+    }
+
+    /** Release parked audits and restore the real query. */
+    public restoreOnChainSlashesQuery(): boolean {
+        return this.service.releaseOnChainSlashesQueryHold();
+    }
+
+    /** Resolves once a caller is parked at the hold; parked count. */
+    public waitForHeldOnChainSlashesQuery(): Promise<number> {
+        return this.service.waitForHeldOnChainSlashesQuery();
+    }
+
     public getHeldReductionTaskCount(): number {
         return this.service.heldReductionTasks.length;
     }

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -728,6 +728,37 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
         return true;
     }
 
+    /**
+     * Stop applying processed inbound messages to the local diamond -> its
+     * in-memory EVM falls behind the RPC node while storage stays whole.
+     */
+    public stubLocalDiamondInboundMessages(): boolean {
+        const localDiamond =
+            this.service.sm.diamondStateMachine.localDiamondContract;
+        if (!this.service.stubOriginals.has("localDiamondInboundMessages")) {
+            this.service.stubOriginals.set(
+                "localDiamondInboundMessages",
+                localDiamond.onInboundMessagesProcessed
+            );
+        }
+        localDiamond.onInboundMessagesProcessed = (async () =>
+            undefined) as unknown as typeof localDiamond.onInboundMessagesProcessed;
+        return true;
+    }
+
+    public restoreLocalDiamondInboundMessages(): boolean {
+        const original = this.service.stubOriginals.get(
+            "localDiamondInboundMessages"
+        );
+        if (original === undefined) return false;
+        const localDiamond =
+            this.service.sm.diamondStateMachine.localDiamondContract;
+        localDiamond.onInboundMessagesProcessed =
+            original as typeof localDiamond.onInboundMessagesProcessed;
+        this.service.stubOriginals.delete("localDiamondInboundMessages");
+        return true;
+    }
+
     /** Park the dispute audit at its on-chain-slashes query until released. */
     public stubHoldOnChainSlashesQuery(): boolean {
         this.service.installOnChainSlashesQueryHold();
@@ -1210,6 +1241,45 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
 
     public getHeldSnapshotUpdatedCount(): number {
         return this.service.heldSnapshotUpdatedArgs.length;
+    }
+
+    /** Hold InboundMessagesProcessed events instead of handling them. */
+    public stubHoldInboundMessageEvents(): boolean {
+        const eventHandler = this.service.sm.eventHandler;
+        if (!this.service.stubOriginals.has("inboundMessageEvents")) {
+            this.service.stubOriginals.set(
+                "inboundMessageEvents",
+                eventHandler.onInboundMessagesProcessed.bind(eventHandler)
+            );
+        }
+        eventHandler.onInboundMessagesProcessed = (async (
+            ...args: unknown[]
+        ) => {
+            this.service.heldInboundMessageArgs.push(args);
+        }) as typeof eventHandler.onInboundMessagesProcessed;
+        return true;
+    }
+
+    /** Restore the handler; optionally replay the held events through it. */
+    public restoreInboundMessageEvents(replay: boolean): boolean {
+        const eventHandler = this.service.sm.eventHandler;
+        const original = this.service.stubOriginals.get("inboundMessageEvents");
+        if (original === undefined) return false;
+        const restored =
+            original as typeof eventHandler.onInboundMessagesProcessed;
+        eventHandler.onInboundMessagesProcessed = restored;
+        this.service.stubOriginals.delete("inboundMessageEvents");
+        const held = this.service.heldInboundMessageArgs.splice(0);
+        if (replay) {
+            for (const args of held) {
+                void (restored as (...a: unknown[]) => Promise<void>)(...args);
+            }
+        }
+        return true;
+    }
+
+    public getHeldInboundMessageCount(): number {
+        return this.service.heldInboundMessageArgs.length;
     }
 
     /** Drop subscribed dispute logs before the scheduler records their key. */

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -52,6 +52,7 @@ export type StubKey =
     | "spectateAbort"
     | "reductionTasks"
     | "snapshotUpdatedEvents"
+    | "inboundMessageEvents"
     | "disputeCommittedEvents"
     | "calldataPostedEvents"
     | "disputeInitiation"
@@ -70,7 +71,8 @@ export type StubKey =
     | "timeoutCheck"
     | "scheduledTasks"
     | "ingestConfirmations"
-    | "onChainSlashesQuery";
+    | "onChainSlashesQuery"
+    | "localDiamondInboundMessages";
 
 export type ReductionSimulationErrorName =
     | "RaceConditionDisputeAlreadyReduced"
@@ -310,6 +312,7 @@ export class StubService extends ARpcService<
     /** Event arg-tuples captured by the hold-event stubs. */
     readonly heldSnapshotUpdatedArgs: unknown[][] = [];
     readonly heldDisputeCommittedArgs: unknown[][] = [];
+    readonly heldInboundMessageArgs: unknown[][] = [];
     readonly passedDisputeCommittedEventKeys =
         new Set<DisputeCommittedEventKey>();
     /** Subscribed calldata logs the hold stub has already lost once. */

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -69,7 +69,8 @@ export type StubKey =
     | "disputeKill"
     | "timeoutCheck"
     | "scheduledTasks"
-    | "ingestConfirmations";
+    | "ingestConfirmations"
+    | "onChainSlashesQuery";
 
 export type ReductionSimulationErrorName =
     | "RaceConditionDisputeAlreadyReduced"
@@ -127,6 +128,14 @@ export type DisputeSubmissionHold = {
     release: () => void;
     /** Sends parked at the hold so far. */
     held: number;
+};
+
+export type HeldOnChainSlashesQueryState = {
+    /** Callers parked at the hold so far. */
+    entered: number;
+    released: boolean;
+    gate: Promise<void>;
+    release: () => void;
 };
 
 export type RecordedFraudProofApply = {
@@ -339,6 +348,10 @@ export class StubService extends ARpcService<
     fraudProofApplyFailure?: DisputeSubmissionFailureSpec;
     /** Incremented per `killDispute` skipped by the suppress-kill stub. */
     suppressedDisputeKillCount = 0;
+    /** State for the dispute-audit hold at the on-chain-slashes query. */
+    heldOnChainSlashesQuery?: HeldOnChainSlashesQueryState;
+    /** Resolvers waiting for the first parked slashes query. */
+    private readonly heldOnChainSlashesQueryWaiters: (() => void)[] = [];
     /**
      * Serializes runBlockValidation/runBlockIngest's record-only
      * patch/restore region. The
@@ -448,6 +461,79 @@ export class StubService extends ARpcService<
         } finally {
             localDiamond.isForkDisputed = original;
         }
+    }
+
+    /**
+     * Park `localDiamondContract.getOnChainSlashedParticipants` callers until
+     * released - the dispute audit's first await after it captured auditing
+     * data, so a test can mutate real state mid-audit deterministically. Both
+     * live call sites invoke the method plainly, so a plain async replacement
+     * is faithful.
+     */
+    public installOnChainSlashesQueryHold(): void {
+        const localDiamond = this.sm.diamondStateMachine.localDiamondContract;
+        if (!this.stubOriginals.has("onChainSlashesQuery")) {
+            this.stubOriginals.set(
+                "onChainSlashesQuery",
+                localDiamond.getOnChainSlashedParticipants
+            );
+        }
+        const original = this.stubOriginals.get(
+            "onChainSlashesQuery"
+        ) as typeof localDiamond.getOnChainSlashedParticipants;
+        let releaseGate!: () => void;
+        const gate = new Promise<void>((resolve) => {
+            releaseGate = resolve;
+        });
+        const held: HeldOnChainSlashesQueryState = {
+            entered: 0,
+            released: false,
+            gate,
+            release: () => {
+                held.released = true;
+                releaseGate();
+            }
+        };
+        this.heldOnChainSlashesQuery = held;
+        localDiamond.getOnChainSlashedParticipants = (async (
+            ...args: Parameters<typeof original>
+        ) => {
+            held.entered += 1;
+            this.heldOnChainSlashesQueryWaiters
+                .splice(0)
+                .forEach((resolve) => resolve());
+            await gate;
+            return original(...args);
+        }) as typeof localDiamond.getOnChainSlashedParticipants;
+    }
+
+    /** Release parked callers and reinstall the real query. */
+    public releaseOnChainSlashesQueryHold(): boolean {
+        this.heldOnChainSlashesQuery?.release();
+        this.heldOnChainSlashesQuery = undefined;
+        const original = this.stubOriginals.get("onChainSlashesQuery");
+        if (original === undefined) return false;
+        const localDiamond = this.sm.diamondStateMachine.localDiamondContract;
+        localDiamond.getOnChainSlashedParticipants =
+            original as typeof localDiamond.getOnChainSlashedParticipants;
+        this.stubOriginals.delete("onChainSlashesQuery");
+        return true;
+    }
+
+    /** Resolve with the parked-caller count once at least one is held. */
+    public waitForHeldOnChainSlashesQuery(): Promise<number> {
+        const held = this.heldOnChainSlashesQuery;
+        if (!held) {
+            return Promise.reject(
+                new Error("onChainSlashesQuery hold not installed")
+            );
+        }
+        if (held.entered > 0) return Promise.resolve(held.entered);
+        return new Promise((resolve) =>
+            this.heldOnChainSlashesQueryWaiters.push(() =>
+                resolve(held.entered)
+            )
+        );
     }
 
     /**

--- a/test/harness/actions/DisputeOrchestrator.ts
+++ b/test/harness/actions/DisputeOrchestrator.ts
@@ -1,15 +1,20 @@
 import { PeerTestHarness } from "@test/fixtures/PeerTestHarness";
 import type { HarnessControlRpc } from "@test/fixtures/customRpc/harnessControl/HarnessControlRpc";
 import { CreateAndResolveDisputeResult } from "../core/types";
-import { Logger } from "@/utils";
+import { Codec, Logger, Type } from "@/utils";
 import { ForkId } from "@/types/types";
 import { ZeroHash } from "ethers";
 import { Status } from "@/types";
 import { FraudProofType } from "@/types/sol-enums";
 import type {
+    DisputeAuditingDataStruct,
     DisputeConfirmationStruct,
     DisputeStruct
 } from "@typechain-types/contracts/V1/types/DisputeTypes";
+import type {
+    DisputeValidationRun,
+    PersistDisputeDataProjection
+} from "@test/fixtures/customRpc/harnessControl/services/dispute/DisputeService";
 import type { FinalDisputeResolution } from "./DisputeTamperingActions";
 
 export type SubmittedFinalDispute = {
@@ -38,6 +43,96 @@ export class DisputeOrchestrator<
         protected harness: PeerTestHarness<TCustomRpc>,
         protected logger: Logger
     ) {}
+
+    /**
+     * Construct a dispute host-side on `peerIndex` and return its structs.
+     * They come back ABI-encoded (raw ethers structs don't survive JSON across
+     * the port), decoded here to plain mutable structs.
+     */
+    async fetchConstructedDispute(
+        peerIndex: number,
+        forkId?: ForkId
+    ): Promise<{
+        dispute: DisputeStruct;
+        disputeConfirmation: DisputeConfirmationStruct;
+        auditingData: DisputeAuditingDataStruct;
+    }> {
+        const targetForkId = forkId ?? this.harness.activeForkId;
+        if (!targetForkId) {
+            throw new Error("fetchConstructedDispute: no active fork ID");
+        }
+        const {
+            encodedDispute,
+            encodedDisputeConfirmation,
+            encodedAuditingData
+        } = await this.harness
+            .control(this.harness.getPeer(peerIndex))
+            .dispute.constructDispute(targetForkId)
+            .request();
+        return {
+            dispute: Codec.decode(encodedDispute, Type.Dispute),
+            disputeConfirmation: Codec.decode(
+                encodedDisputeConfirmation,
+                Type.DisputeConfirmation
+            ),
+            auditingData: Codec.decode(
+                encodedAuditingData,
+                Type.DisputeAuditingData
+            )
+        };
+    }
+
+    /** Run the real dispute audit on `auditorIndex`; decoded seam projection. */
+    async auditDispute(
+        auditorIndex: number,
+        dispute: DisputeStruct,
+        auditingData?: DisputeAuditingDataStruct
+    ): Promise<DisputeValidationRun> {
+        return (
+            this.harness
+                .control(this.harness.getPeer(auditorIndex))
+                .dispute.runDisputeValidation(
+                    Codec.encode(dispute, Type.Dispute) as string,
+                    auditingData
+                        ? {
+                              encodedAuditingData: Codec.encode(
+                                  auditingData,
+                                  Type.DisputeAuditingData
+                              ) as string
+                          }
+                        : undefined
+                )
+                // audits replay blocks + several staticCalls; the default RPC
+                // budget is sized for quick reads
+                .request({ timeoutMs: 60_000 })
+        );
+    }
+
+    /** Run the real persistDisputeDataWithoutAudit on `peerIndex`. */
+    async persistDisputeData(
+        peerIndex: number,
+        dispute: DisputeStruct,
+        options: {
+            auditingData?: DisputeAuditingDataStruct;
+            includeUnfinalizedBlocks: boolean;
+        }
+    ): Promise<PersistDisputeDataProjection> {
+        return this.harness
+            .control(this.harness.getPeer(peerIndex))
+            .dispute.persistDisputeDataWithoutAudit(
+                Codec.encode(dispute, Type.Dispute) as string,
+                {
+                    encodedAuditingData: options.auditingData
+                        ? (Codec.encode(
+                              options.auditingData,
+                              Type.DisputeAuditingData
+                          ) as string)
+                        : undefined,
+                    includeUnfinalizedBlocks: options.includeUnfinalizedBlocks
+                }
+            )
+            .request();
+    }
 
     async submitFinalDispute(options: {
         maliciousPeerIndex: number;

--- a/test/harness/actions/DisputeOrchestrator.ts
+++ b/test/harness/actions/DisputeOrchestrator.ts
@@ -115,6 +115,8 @@ export class DisputeOrchestrator<
         options: {
             auditingData?: DisputeAuditingDataStruct;
             includeUnfinalizedBlocks: boolean;
+            /** Applied host-side after decode; "" is not ABI-encodable. */
+            latestFinalizedStateStateMachineStateOverride?: string;
         }
     ): Promise<PersistDisputeDataProjection> {
         return this.harness
@@ -128,7 +130,9 @@ export class DisputeOrchestrator<
                               Type.DisputeAuditingData
                           ) as string)
                         : undefined,
-                    includeUnfinalizedBlocks: options.includeUnfinalizedBlocks
+                    includeUnfinalizedBlocks: options.includeUnfinalizedBlocks,
+                    latestFinalizedStateStateMachineStateOverride:
+                        options.latestFinalizedStateStateMachineStateOverride
                 }
             )
             .request();

--- a/test/harness/actions/DisputeTamperingActions.ts
+++ b/test/harness/actions/DisputeTamperingActions.ts
@@ -519,7 +519,8 @@ export class DisputeTamperingActions<
         return peer;
     }
 
-    private async resignDispute(
+    /** Re-sign `dispute` into `disputeConfirmation`, dropping co-signatures. */
+    async resignDispute(
         signer: Signer,
         dispute: DisputeStruct,
         disputeConfirmation: DisputeConfirmationStruct

--- a/test/harness/actions/DisputeTamperingActions.ts
+++ b/test/harness/actions/DisputeTamperingActions.ts
@@ -30,6 +30,10 @@ import type {
     MessageBlockStruct
 } from "@typechain-types/contracts/V1/types/DataTypes";
 import type { DisputeTamperStrategy } from "@test/fixtures/customRpc/harnessControl/services/dispute/tamperStrategies";
+import type {
+    DisputeValidationRun,
+    PersistDisputeDataProjection
+} from "@test/fixtures/customRpc/harnessControl/services/dispute/DisputeService";
 
 export type DisputeTamper = (
     dispute: DisputeStruct,
@@ -190,26 +194,8 @@ export class DisputeTamperingActions<
         }
         const targetForkId = forkId || this.harness.activeForkId!;
 
-        // Construct host-side; the structs come back ABI-encoded (raw ethers
-        // structs don't survive JSON across the port), so decode to plain
-        // mutable structs, then tamper, re-sign and submit on the main thread.
-        const {
-            encodedDispute,
-            encodedDisputeConfirmation,
-            encodedAuditingData
-        } = await this.harness
-            .control(peer)
-            .dispute.constructDispute(targetForkId)
-            .request();
-        const dispute = Codec.decode(encodedDispute, Type.Dispute);
-        const disputeConfirmation = Codec.decode(
-            encodedDisputeConfirmation,
-            Type.DisputeConfirmation
-        );
-        const auditingData = Codec.decode(
-            encodedAuditingData,
-            Type.DisputeAuditingData
-        );
+        const { dispute, disputeConfirmation, auditingData } =
+            await this.fetchConstructedDispute(authorPeerIndex, targetForkId);
 
         await tamper(dispute, disputeConfirmation, auditingData);
         await this.resignDispute(peer.signer, dispute, disputeConfirmation);
@@ -301,6 +287,97 @@ export class DisputeTamperingActions<
                 )
             }
         };
+    }
+
+    /**
+     * Construct a dispute host-side on `peerIndex` and return its structs.
+     * Construct host-side; the structs come back ABI-encoded (raw ethers
+     * structs don't survive JSON across the port), so decode to plain
+     * mutable structs, then tamper, re-sign and submit on the main thread.
+     */
+    async fetchConstructedDispute(
+        peerIndex: number,
+        forkId?: ForkId
+    ): Promise<{
+        dispute: DisputeStruct;
+        disputeConfirmation: DisputeConfirmationStruct;
+        auditingData: DisputeAuditingDataStruct;
+    }> {
+        const targetForkId = forkId ?? this.harness.activeForkId;
+        if (!targetForkId) {
+            throw new Error("fetchConstructedDispute: no active fork ID");
+        }
+        const {
+            encodedDispute,
+            encodedDisputeConfirmation,
+            encodedAuditingData
+        } = await this.harness
+            .control(this.harness.getPeer(peerIndex))
+            .dispute.constructDispute(targetForkId)
+            .request();
+        return {
+            dispute: Codec.decode(encodedDispute, Type.Dispute),
+            disputeConfirmation: Codec.decode(
+                encodedDisputeConfirmation,
+                Type.DisputeConfirmation
+            ),
+            auditingData: Codec.decode(
+                encodedAuditingData,
+                Type.DisputeAuditingData
+            )
+        };
+    }
+
+    /** Run the real dispute audit on `auditorIndex`; decoded seam projection. */
+    async auditDispute(
+        auditorIndex: number,
+        dispute: DisputeStruct,
+        auditingData?: DisputeAuditingDataStruct
+    ): Promise<DisputeValidationRun> {
+        return (
+            this.harness
+                .control(this.harness.getPeer(auditorIndex))
+                .dispute.runDisputeValidation(
+                    Codec.encode(dispute, Type.Dispute) as string,
+                    auditingData
+                        ? {
+                              encodedAuditingData: Codec.encode(
+                                  auditingData,
+                                  Type.DisputeAuditingData
+                              ) as string
+                          }
+                        : undefined
+                )
+                // audits replay blocks + several staticCalls; the default RPC
+                // budget is sized for quick reads
+                .request({ timeoutMs: 60_000 })
+        );
+    }
+
+    /** Run the real persistDisputeDataWithoutAudit on `peerIndex`. */
+    async persistDisputeData(
+        peerIndex: number,
+        dispute: DisputeStruct,
+        options: {
+            auditingData?: DisputeAuditingDataStruct;
+            includeUnfinalizedBlocks: boolean;
+        }
+    ): Promise<PersistDisputeDataProjection> {
+        return this.harness
+            .control(this.harness.getPeer(peerIndex))
+            .dispute.persistDisputeDataWithoutAudit(
+                Codec.encode(dispute, Type.Dispute) as string,
+                {
+                    encodedAuditingData: options.auditingData
+                        ? (Codec.encode(
+                              options.auditingData,
+                              Type.DisputeAuditingData
+                          ) as string)
+                        : undefined,
+                    includeUnfinalizedBlocks: options.includeUnfinalizedBlocks
+                }
+            )
+            .request();
     }
 
     async submitForgedFraudProof(

--- a/test/harness/actions/DisputeTamperingActions.ts
+++ b/test/harness/actions/DisputeTamperingActions.ts
@@ -30,10 +30,6 @@ import type {
     MessageBlockStruct
 } from "@typechain-types/contracts/V1/types/DataTypes";
 import type { DisputeTamperStrategy } from "@test/fixtures/customRpc/harnessControl/services/dispute/tamperStrategies";
-import type {
-    DisputeValidationRun,
-    PersistDisputeDataProjection
-} from "@test/fixtures/customRpc/harnessControl/services/dispute/DisputeService";
 
 export type DisputeTamper = (
     dispute: DisputeStruct,
@@ -195,7 +191,10 @@ export class DisputeTamperingActions<
         const targetForkId = forkId || this.harness.activeForkId!;
 
         const { dispute, disputeConfirmation, auditingData } =
-            await this.fetchConstructedDispute(authorPeerIndex, targetForkId);
+            await this.harness.dispute.fetchConstructedDispute(
+                authorPeerIndex,
+                targetForkId
+            );
 
         await tamper(dispute, disputeConfirmation, auditingData);
         await this.resignDispute(peer.signer, dispute, disputeConfirmation);
@@ -287,97 +286,6 @@ export class DisputeTamperingActions<
                 )
             }
         };
-    }
-
-    /**
-     * Construct a dispute host-side on `peerIndex` and return its structs.
-     * Construct host-side; the structs come back ABI-encoded (raw ethers
-     * structs don't survive JSON across the port), so decode to plain
-     * mutable structs, then tamper, re-sign and submit on the main thread.
-     */
-    async fetchConstructedDispute(
-        peerIndex: number,
-        forkId?: ForkId
-    ): Promise<{
-        dispute: DisputeStruct;
-        disputeConfirmation: DisputeConfirmationStruct;
-        auditingData: DisputeAuditingDataStruct;
-    }> {
-        const targetForkId = forkId ?? this.harness.activeForkId;
-        if (!targetForkId) {
-            throw new Error("fetchConstructedDispute: no active fork ID");
-        }
-        const {
-            encodedDispute,
-            encodedDisputeConfirmation,
-            encodedAuditingData
-        } = await this.harness
-            .control(this.harness.getPeer(peerIndex))
-            .dispute.constructDispute(targetForkId)
-            .request();
-        return {
-            dispute: Codec.decode(encodedDispute, Type.Dispute),
-            disputeConfirmation: Codec.decode(
-                encodedDisputeConfirmation,
-                Type.DisputeConfirmation
-            ),
-            auditingData: Codec.decode(
-                encodedAuditingData,
-                Type.DisputeAuditingData
-            )
-        };
-    }
-
-    /** Run the real dispute audit on `auditorIndex`; decoded seam projection. */
-    async auditDispute(
-        auditorIndex: number,
-        dispute: DisputeStruct,
-        auditingData?: DisputeAuditingDataStruct
-    ): Promise<DisputeValidationRun> {
-        return (
-            this.harness
-                .control(this.harness.getPeer(auditorIndex))
-                .dispute.runDisputeValidation(
-                    Codec.encode(dispute, Type.Dispute) as string,
-                    auditingData
-                        ? {
-                              encodedAuditingData: Codec.encode(
-                                  auditingData,
-                                  Type.DisputeAuditingData
-                              ) as string
-                          }
-                        : undefined
-                )
-                // audits replay blocks + several staticCalls; the default RPC
-                // budget is sized for quick reads
-                .request({ timeoutMs: 60_000 })
-        );
-    }
-
-    /** Run the real persistDisputeDataWithoutAudit on `peerIndex`. */
-    async persistDisputeData(
-        peerIndex: number,
-        dispute: DisputeStruct,
-        options: {
-            auditingData?: DisputeAuditingDataStruct;
-            includeUnfinalizedBlocks: boolean;
-        }
-    ): Promise<PersistDisputeDataProjection> {
-        return this.harness
-            .control(this.harness.getPeer(peerIndex))
-            .dispute.persistDisputeDataWithoutAudit(
-                Codec.encode(dispute, Type.Dispute) as string,
-                {
-                    encodedAuditingData: options.auditingData
-                        ? (Codec.encode(
-                              options.auditingData,
-                              Type.DisputeAuditingData
-                          ) as string)
-                        : undefined,
-                    includeUnfinalizedBlocks: options.includeUnfinalizedBlocks
-                }
-            )
-            .request();
     }
 
     async submitForgedFraudProof(

--- a/test/harness/actions/math/MathJoinActions.ts
+++ b/test/harness/actions/math/MathJoinActions.ts
@@ -12,6 +12,8 @@ export type ForceInboundJoinOptions = {
     timeoutMs?: number;
     waitForHonestPeersObserve?: boolean;
     participant?: string;
+    /** Peers that must observe the new inbound block; defaults to all honest. */
+    observePeerIndices?: number[];
 };
 
 export type PreparedForceInboundJoin = {
@@ -199,7 +201,7 @@ export class MathJoinActions extends JoinActions {
         forceJoin: PreparedForceInboundJoin,
         options?: Pick<
             ForceInboundJoinOptions,
-            "timeoutMs" | "waitForHonestPeersObserve"
+            "timeoutMs" | "waitForHonestPeersObserve" | "observePeerIndices"
         >
     ): Promise<{ participant: string }> {
         const timeoutMs =
@@ -213,7 +215,8 @@ export class MathJoinActions extends JoinActions {
         if (waitForHonestPeersObserve) {
             await this.harness.assert.storage.honestPeersObserveInboundMessageWait(
                 {
-                    previousLatestHash,
+                    previousLatestHash: previousLatestHash ?? undefined,
+                    peerIndices: options?.observePeerIndices,
                     timeoutMs
                 }
             );

--- a/test/harness/actions/math/MathScenarioActions.ts
+++ b/test/harness/actions/math/MathScenarioActions.ts
@@ -152,6 +152,34 @@ export class MathScenarioActions extends ScenarioActions {
     }
 
     /**
+     * preDisputeSetup + a top-up of an existing participant, consumed by later
+     * blocks -> snapshotData.latestInboundMessageBlockHeight sits on inbound
+     * block 2 with the channel-open block still a real ancestor. Topping up an
+     * existing participant keeps the participant set (and block turns) intact.
+     */
+    async preDisputeSetupConsumedInboundTopUp(options?: {
+        peerCount?: number;
+        timeConfig?: {
+            p2pTime?: number;
+            agreementTime?: number;
+            chainFallbackTime?: number;
+            evidenceTime?: number;
+        };
+    }) {
+        await this.preDisputeSetup(options);
+        await this.harness.join.forceInboundJoinWait({
+            participant: this.harness.getPeer(0).address
+        });
+        await this.harness.transition.advanceState({
+            count: 2,
+            waitForFinalization: true
+        });
+        await this.harness.assert.sync.peersInSyncWait();
+        this.harness.event.resetEventSpies();
+        this.harness.contextApi.captureOriginalFork();
+    }
+
+    /**
      * A committed spam dispute (internally valid, no enforcement basis) that
      * every peer audit-failed, with every peer's `killDispute` suppressed while
      * it happened. `killerIndex` therefore holds a real dispute fraud proof

--- a/test/harness/actions/rpcStubActions.ts
+++ b/test/harness/actions/rpcStubActions.ts
@@ -297,6 +297,33 @@ export class RpcStubActions<
     }
 
     /**
+     * Hold a peer's InboundMessagesProcessed handler -> its chain view of the
+     * inbound chain stops advancing while block ingest keeps running. Models a
+     * lagging chain event: everything downstream of the handler is unapplied.
+     */
+    async holdInboundMessageEvents(peerIndex: number): Promise<{
+        /** Chain events held so far. */
+        heldCount: () => Promise<number>;
+        /** Restore the handler; held events replay unless `replay: false`. */
+        release: (options?: { replay?: boolean }) => Promise<void>;
+    }> {
+        const ctl = () =>
+            this.harness.control(this.harness.getPeer(peerIndex)).stub;
+        await ctl().stubHoldInboundMessageEvents().request();
+        this.logger.debug(
+            `Holding InboundMessagesProcessed on peer ${peerIndex}`
+        );
+        return {
+            heldCount: async () =>
+                await ctl().getHeldInboundMessageCount().request(),
+            release: async (options = {}) => {
+                const { replay = true } = options;
+                await ctl().restoreInboundMessageEvents(replay).request();
+            }
+        };
+    }
+
+    /**
      * Record what `dispute()` uploads on a peer without sending it. With
      * `hold: true` every recorded send parks until `release`, so a second
      * `dispute()` can be observed queueing behind the dispute mutex.

--- a/test/unit/BlockIngestService.test.ts
+++ b/test/unit/BlockIngestService.test.ts
@@ -278,6 +278,125 @@ describe("Unit: BlockIngestService", function () {
         });
     });
 
+    describe("onBlockConfirmation → carried inbound message blocks", function () {
+        it("a run linked to a held inbound block → the store head advances with the snapshot", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 0);
+            const forkId = h.activeForkId!;
+
+            // held after the channel-open inbound block landed -> peer 2 holds
+            // inbound block 1, only the top-up chain event is withheld
+            const lagging = 2;
+            const held = await h.rpcStub.holdInboundMessageEvents(lagging);
+            await h.join.forceInboundJoinWait({
+                participant: h.getPeer(0).address,
+                observePeerIndices: [0, 1]
+            });
+            // two writers -> at least one non-lagging author carries the top-up
+            await h.transition.advanceState({
+                count: 2,
+                waitForFinalization: true
+            });
+            await h.assert.sync.peersInSyncWait();
+
+            const r = await h.execOnHost(
+                h.getPeer(lagging),
+                async (sm, args) => {
+                    const next = sm.storage.blocks.getNextBlockHeight(
+                        args.forkId
+                    );
+                    const snapshot =
+                        sm.snapshotAssemblyService.getPreviousStateSnapshotOrThrow(
+                            { forkId: args.forkId, height: next }
+                        );
+                    return {
+                        storedHash:
+                            sm.storage.inboundMessages.getLatestBlockHash() ??
+                            null,
+                        storedHeight: Number(
+                            sm.storage.inboundMessages.getLatestBlockHeight() ??
+                                0
+                        ),
+                        snapshotHash: snapshot.latestInboundMessageBlockHash,
+                        snapshotHeight: Number(
+                            snapshot.latestInboundMessageBlockHeight
+                        )
+                    };
+                },
+                { forkId }
+            );
+
+            // premise - the chain event really never landed on this peer
+            expect(await held.heldCount()).to.be.greaterThan(0);
+            // premise - the blocks it ingested carried the top-up
+            expect(r.snapshotHeight).to.equal(2);
+            expect(r.storedHash).to.equal(r.snapshotHash);
+            expect(r.storedHeight).to.equal(r.snapshotHeight);
+        });
+
+        it("a run with no held ancestor → persisted, store head stays put", async function () {
+            const h = TestSession.getHarness();
+            await h.setup(3);
+            // held from before the channel opens -> peer 2 never stores inbound
+            // block 1, so a run starting at block 2 links to nothing it holds
+            const lagging = 2;
+            const held = await h.rpcStub.holdInboundMessageEvents(lagging);
+            await h.lifecycle.openChannel();
+            const forkId = h.activeForkId!;
+
+            await h.join.forceInboundJoinWait({
+                participant: h.getPeer(0).address,
+                observePeerIndices: [0, 1]
+            });
+            await h.transition.advanceState({
+                count: 2,
+                waitForFinalization: true
+            });
+            await h.assert.sync.peersInSyncWait();
+
+            const r = await h.execOnHost(
+                h.getPeer(lagging),
+                async (sm, args) => {
+                    const next = sm.storage.blocks.getNextBlockHeight(
+                        args.forkId
+                    );
+                    const snapshot =
+                        sm.snapshotAssemblyService.getPreviousStateSnapshotOrThrow(
+                            { forkId: args.forkId, height: next }
+                        );
+                    return {
+                        storedHash:
+                            sm.storage.inboundMessages.getLatestBlockHash() ??
+                            null,
+                        snapshotHash: snapshot.latestInboundMessageBlockHash,
+                        snapshotHeight: Number(
+                            snapshot.latestInboundMessageBlockHeight
+                        ),
+                        // the carried run is looked up by hash even though the
+                        // head did not move to it
+                        carriedRunPersisted:
+                            sm.storage.inboundMessages.getMessageBlock(
+                                snapshot.latestInboundMessageBlockHash
+                            ) !== undefined,
+                        // walking back from the head must not hit the gap
+                        rangeLength:
+                            sm.storage.inboundMessages.getMessageBlocksInRange()
+                                .length
+                    };
+                },
+                { forkId }
+            );
+
+            expect(await held.heldCount()).to.be.greaterThan(0);
+            expect(r.snapshotHeight).to.equal(2);
+            expect(r.carriedRunPersisted).to.equal(true);
+            // moving the head over the missing block 1 would make every later
+            // getMessageBlocksInRange throw
+            expect(r.storedHash).to.equal(null);
+            expect(r.rangeLength).to.equal(0);
+        });
+    });
+
     describe("onBlockConfirmation → reject paths (full pipeline probe)", function () {
         it("a linked writer block with a wrong snapshot hash → invalid transition, VM turn restored", async function () {
             const h = TestSession.getHarness();

--- a/test/unit/BlockIngestService.test.ts
+++ b/test/unit/BlockIngestService.test.ts
@@ -1,12 +1,59 @@
 import { expect } from "chai";
 import { Codec, Type } from "@/utils";
-import { MathTestSession as TestSession } from "@test/harness";
+import {
+    MathPeerTestHarness,
+    MathTestSession as TestSession
+} from "@test/harness";
 import * as factory from "../factory";
-import type { Address } from "@/types/types";
+import type { Address, ForkId, Hash } from "@/types/types";
+import type { MessageBlockStruct } from "@typechain-types/contracts/V1/types/DataTypes";
 
 // the pipeline is entered the way production does: through the queue
 // (transition.ingestBlockConfirmation) or, for callers with no transport, by
 // handing a confirmation straight to onBlockConfirmationStruct.
+
+// a genuinely authored, linked next block - only its stateSnapshotHash (the
+// factory's random default) is wrong, so it dies at the state-transition gate
+async function encodeLinkedNextBlock(
+    h: MathPeerTestHarness,
+    writerIndex: number,
+    observerIndex: number,
+    forkId: ForkId,
+    messageBlocks?: MessageBlockStruct[]
+) {
+    const writer = h.getPeer(writerIndex);
+    const observer = h.getPeer(observerIndex);
+    const bundle = await h
+        .control(observer)
+        .query.getLatestBlockBundle(forkId)
+        .request();
+    const height = await h
+        .control(observer)
+        .query.getNextBlockHeight(forkId)
+        .request();
+    const call =
+        await writer.p2pInstance.p2pContractInstance.add.populateTransaction(1);
+
+    return factory.buildAndEncodeBlock(writer.signer, {
+        header: {
+            channelId: h.channelId,
+            forkId,
+            transactionCnt: height,
+            participant: writer.address as Address,
+            // inside the previous block's p2pTime window regardless of how
+            // long the test staging took
+            timestamp: bundle!.timestamp + 1
+        },
+        transaction: factory.transaction({
+            body: {
+                encodedData: call.data,
+                data: call.data
+            }
+        }),
+        previousBlockHash: bundle!.hash,
+        ...(messageBlocks ? { messageBlocks } : {})
+    });
+}
 
 describe("Unit: BlockIngestService", function () {
     describe("isKnownStaleFork", function () {
@@ -334,7 +381,7 @@ describe("Unit: BlockIngestService", function () {
             expect(r.storedHeight).to.equal(r.snapshotHeight);
         });
 
-        it("a run with no held ancestor → persisted, store head stays put", async function () {
+        it("runs with no reachable ancestor → persisted, the head never moves above the gap", async function () {
             const h = TestSession.getHarness();
             await h.setup(3);
             // held from before the channel opens -> peer 2 never stores inbound
@@ -343,11 +390,32 @@ describe("Unit: BlockIngestService", function () {
             const held = await h.rpcStub.holdInboundMessageEvents(lagging);
             await h.lifecycle.openChannel();
             const forkId = h.activeForkId!;
+            const synced = h.control(h.getPeer(0));
 
+            // round 1 - a run linked to inbound block 1, which the gapped peer
+            // does not hold at all
             await h.join.forceInboundJoinWait({
                 participant: h.getPeer(0).address,
                 observePeerIndices: [0, 1]
             });
+            const firstTopUpHash = (await synced.query
+                .getLatestInboundMessageHash()
+                .request()) as Hash;
+            await h.transition.advanceState({
+                count: 2,
+                waitForFinalization: true
+            });
+            await h.assert.sync.peersInSyncWait();
+
+            // round 2 - a run linked to the block round 1 just persisted: held
+            // in the map, but itself sitting above the missing block 1
+            await h.join.forceInboundJoinWait({
+                participant: h.getPeer(0).address,
+                observePeerIndices: [0, 1]
+            });
+            const secondTopUpHash = (await synced.query
+                .getLatestInboundMessageHash()
+                .request()) as Hash;
             await h.transition.advanceState({
                 count: 2,
                 waitForFinalization: true
@@ -372,11 +440,15 @@ describe("Unit: BlockIngestService", function () {
                         snapshotHeight: Number(
                             snapshot.latestInboundMessageBlockHeight
                         ),
-                        // the carried run is looked up by hash even though the
-                        // head did not move to it
-                        carriedRunPersisted:
+                        // both carried runs are looked up by hash even though
+                        // the head did not move to either
+                        firstRunPersisted:
                             sm.storage.inboundMessages.getMessageBlock(
-                                snapshot.latestInboundMessageBlockHash
+                                args.firstTopUpHash
+                            ) !== undefined,
+                        secondRunPersisted:
+                            sm.storage.inboundMessages.getMessageBlock(
+                                args.secondTopUpHash
                             ) !== undefined,
                         // walking back from the head must not hit the gap
                         rangeLength:
@@ -384,14 +456,19 @@ describe("Unit: BlockIngestService", function () {
                                 .length
                     };
                 },
-                { forkId }
+                { forkId, firstTopUpHash, secondTopUpHash }
             );
 
             expect(await held.heldCount()).to.be.greaterThan(0);
-            expect(r.snapshotHeight).to.equal(2);
-            expect(r.carriedRunPersisted).to.equal(true);
-            // moving the head over the missing block 1 would make every later
-            // getMessageBlocksInRange throw
+            // premise - two distinct top-ups, and the pinned snapshot sits on
+            // the second one
+            expect(firstTopUpHash).to.not.equal(secondTopUpHash);
+            expect(r.snapshotHash).to.equal(secondTopUpHash);
+            expect(r.snapshotHeight).to.equal(3);
+            expect(r.firstRunPersisted).to.equal(true);
+            expect(r.secondRunPersisted).to.equal(true);
+            // holding the link block is not reaching it -> moving the head
+            // onto either run puts it above the missing block 1
             expect(r.storedHash).to.equal(null);
             expect(r.rangeLength).to.equal(0);
         });
@@ -405,40 +482,11 @@ describe("Unit: BlockIngestService", function () {
             const writer = await h.query.getNextPeerToWrite();
             const observer = h.peers.find((p) => p.index !== writer.index)!;
 
-            const bundle = await h
-                .control(observer)
-                .query.getLatestBlockBundle(forkId)
-                .request();
-            const height = await h
-                .control(observer)
-                .query.getNextBlockHeight(forkId)
-                .request();
-            // inside the previous block's p2pTime window regardless of how
-            // long the test staging took
-            const timestamp = bundle!.timestamp + 1;
-            const call = await h
-                .getPeer(writer.index)
-                .p2pInstance.p2pContractInstance.add.populateTransaction(1);
-            // a genuinely authored, linked next block - only its
-            // stateSnapshotHash (the factory's random default) is wrong
-            const encoded = await factory.buildAndEncodeBlock(
-                h.getPeer(writer.index).signer,
-                {
-                    header: {
-                        channelId: h.channelId,
-                        forkId,
-                        transactionCnt: height,
-                        participant: writer.address as Address,
-                        timestamp
-                    },
-                    transaction: factory.transaction({
-                        body: {
-                            encodedData: call.data,
-                            data: call.data
-                        }
-                    }),
-                    previousBlockHash: bundle!.hash
-                }
+            const encoded = await encodeLinkedNextBlock(
+                h,
+                writer.index,
+                observer.index,
+                forkId
             );
 
             const turnBefore = await h
@@ -538,6 +586,86 @@ describe("Unit: BlockIngestService", function () {
             expect(probe.firedHooks).to.include(
                 "forgedInboundMessageBlockDetected"
             );
+        });
+
+        it("a rejected block carrying a real inbound run → the run is not stored, the head stays put", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 1);
+            const forkId = h.activeForkId!;
+            const writer = await h.query.getNextPeerToWrite();
+            const observer = h.peers.find((p) => p.index !== writer.index)!;
+            const synced = h.peers.find(
+                (p) => p.index !== observer.index && p.index !== writer.index
+            )!;
+
+            // the observer stops learning inbound blocks from the chain -> the
+            // top-up reaches it only via the block it is about to reject
+            const held = await h.rpcStub.holdInboundMessageEvents(
+                observer.index
+            );
+            await h.join.forceInboundJoinWait({
+                participant: h.getPeer(0).address,
+                observePeerIndices: [writer.index, synced.index]
+            });
+            const topUpHash = (await h
+                .control(synced)
+                .query.getLatestInboundMessageHash()
+                .request()) as Hash;
+            const topUp = Codec.decode(
+                (await h
+                    .control(synced)
+                    .query.getInboundMessageBlock(topUpHash)
+                    .request())!.encodedMessageBlock,
+                Type.MessageBlock
+            );
+
+            const headBefore = await h
+                .control(observer)
+                .query.getLatestInboundMessageHash()
+                .request();
+            // premise - the observer's head is the channel-open block, and the
+            // top-up is a real on-chain block it does not hold
+            expect(headBefore).to.not.equal(null);
+            expect(headBefore).to.not.equal(topUpHash);
+            expect(
+                await h
+                    .control(observer)
+                    .query.getInboundMessageBlock(topUpHash)
+                    .request()
+            ).to.equal(null);
+
+            // carries the chain's real top-up
+            const encoded = await encodeLinkedNextBlock(
+                h,
+                writer.index,
+                observer.index,
+                forkId,
+                [topUp]
+            );
+
+            const probe = await h
+                .control(observer)
+                .stub.runBlockIngest(encoded)
+                .request();
+            const headAfter = await h
+                .control(observer)
+                .query.getLatestInboundMessageHash()
+                .request();
+            const runStored = await h
+                .control(observer)
+                .query.getInboundMessageBlock(topUpHash)
+                .request();
+
+            expect(await held.heldCount()).to.be.greaterThan(0);
+            expect(probe.keepConnection).to.equal(false);
+            expect(probe.firedHooks).to.include(
+                "invalidStateTransitionDetected"
+            );
+            // a rejected block leaves no trace: nothing to move the head onto,
+            // and nothing for detectForgedInboundMessageBlock to accept later
+            // as "already in our store"
+            expect(headAfter).to.equal(headBefore);
+            expect(runStored).to.equal(null);
         });
     });
 });

--- a/test/unit/DisputeManager.test.ts
+++ b/test/unit/DisputeManager.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { ZeroAddress } from "ethers";
 import { Codec, hash, Type } from "@/utils";
+import type { Hash } from "@/types/types";
 import { MathTestSession as TestSession } from "@test/harness";
 
 describe("Unit: DisputeManager", function () {
@@ -192,9 +193,101 @@ describe("Unit: DisputeManager", function () {
             expect(r.storedInboundHash).to.equal(null);
             expect(r.snapshotInboundHeight).to.equal(2);
             expect(r.slashable).to.equal(false);
-            // getAuditingData walked the gapped store without throwing
+            // the anchor is copied from the pinned snapshot, not defaulted to
+            // zero by the empty store
             expect(r.inboundHash).to.equal(r.snapshotInboundHash);
             expect(r.inboundHeight).to.equal(r.snapshotInboundHeight);
+        });
+
+        it("a fork reduced past a lagging inbound store head → the auditing data still matches what an auditor recomputes", async function () {
+            const h = TestSession.getHarness();
+            const lagging = 3;
+            const attacker = 1;
+            await h.scenario.preDisputeSetup({
+                peerCount: 4,
+                timeConfig: { evidenceTime: 12 }
+            });
+            const forkId = h.activeForkId!;
+
+            // held after the channel-open inbound block landed -> the lagging
+            // peer keeps that block as its store head and learns nothing after it
+            const held = await h.rpcStub.holdInboundMessageEvents(lagging);
+            // no block consumes the join -> only the reduce moves the inbound
+            // head, into a genesis snapshot the lagging peer never ingested.
+            // a pending joiner also keeps the head not-final-by-everyone, so
+            // disputes post auditing data and the lagging peer can still audit
+            await h.join.forceInboundJoinWait({
+                observePeerIndices: [0, 1, 2]
+            });
+
+            // the invalid block carries no inbound run of its own, so the only
+            // inbound movement in this scenario is the reduce's
+            await h.byzantine.submitInvalidStateTransitionBlock(attacker);
+            const { newForkId } = await h.dispute.resolveDisputeWait({
+                forkId,
+                forkSettleTimeoutMs: 20000,
+                // the pending joiner the reduce admits is not one of the peers
+                syntheticOnChainParticipants: 1
+            });
+
+            const disputer = h.control(h.getPeer(lagging));
+            const genesis = Codec.decode(
+                (await disputer.dispute
+                    .getGenesisSnapshotStruct(newForkId)
+                    .request())!.encodedSnapshot,
+                Type.StateSnapshot
+            );
+            const storedHead = await disputer.query
+                .getLatestInboundMessageHash()
+                .request();
+            const storedHeight = await disputer.query
+                .getInboundLatestHeight()
+                .request();
+
+            // premise - a non-empty store head, strictly below the inbound head
+            // the new fork's genesis snapshot sits on. an empty store hides the
+            // divergence: both bounds yield []
+            expect(await held.heldCount()).to.be.greaterThan(0);
+            expect(storedHead).to.not.equal(null);
+            expect(storedHeight).to.equal(1);
+            expect(
+                Number(genesis.snapshotData.latestInboundMessageBlockHeight)
+            ).to.equal(2);
+
+            const { encodedDispute } = await disputer.dispute
+                .constructDispute(newForkId)
+                .request();
+            const dispute = Codec.decode(encodedDispute, Type.Dispute);
+            const encodedStateProof = Codec.encode(
+                dispute.input.stateProof,
+                Type.StateProof
+            ) as string;
+            const statedInboundHash = dispute.input
+                .latestInboundMessageBlockHash as Hash;
+            expect(statedInboundHash).to.equal(
+                genesis.snapshotData.latestInboundMessageBlockHash
+            );
+
+            // a synced auditor recomputes from the hash the dispute states
+            const audited = await h
+                .control(h.getPeer(0))
+                .dispute.getAuditingData(newForkId, encodedStateProof, {
+                    disputeLatestInboundMessageBlockHash: statedInboundHash
+                })
+                .request();
+            expect(audited.isPartial).to.equal(false);
+            expect(hash(audited.encodedAuditingData)).to.equal(
+                dispute.input.disputeAuditingDataHash
+            );
+
+            // unbounded falls back to the raw store head -> different bytes.
+            // the stated hash is what keeps disputer and auditors agreeing
+            const unbounded = await disputer.dispute
+                .getAuditingData(newForkId, encodedStateProof)
+                .request();
+            expect(hash(unbounded.encodedAuditingData)).to.not.equal(
+                dispute.input.disputeAuditingDataHash
+            );
         });
 
         // no test: `createDispute - isPartial auditingData` is unreachable from

--- a/test/unit/DisputeManager.test.ts
+++ b/test/unit/DisputeManager.test.ts
@@ -130,6 +130,73 @@ describe("Unit: DisputeManager", function () {
             expect(r.inboundHeight).to.equal(r.storedInboundHeight);
         });
 
+        it("inbound chain event lagging the pinned snapshot → the anchor comes from the snapshot, not the stale store head", async function () {
+            const h = TestSession.getHarness();
+            await h.setup(3);
+            // held from before the channel opens -> peer 2's inbound store head
+            // never moves while ingest advances its snapshot to inbound block 2
+            const lagging = 2;
+            const held = await h.rpcStub.holdInboundMessageEvents(lagging);
+            await h.lifecycle.openChannel();
+            const forkId = h.activeForkId!;
+
+            await h.join.forceInboundJoinWait({
+                participant: h.getPeer(0).address,
+                observePeerIndices: [0, 1]
+            });
+            // writers are peers 0 and 1 -> the lagging peer only ingests
+            await h.transition.advanceState({
+                count: 2,
+                waitForFinalization: true
+            });
+            await h.assert.sync.peersInSyncWait();
+
+            const r = await h.execOnHost(
+                h.getPeer(lagging),
+                async (sm, args) => {
+                    const { dispute, auditingData } =
+                        await sm.disputeManager.constructDispute(args.forkId);
+                    // real oracle: the honest peer's own dispute must not be
+                    // provably slashable by the proof the auditors run
+                    const slashable =
+                        await sm.diamondStateMachine.localDiamondContract.isDisputeInboundAnchorBehindLatestState.staticCall(
+                            dispute,
+                            auditingData.latestStateSnapshot
+                        );
+                    const snapshotData =
+                        auditingData.latestStateSnapshot.snapshotData;
+                    return {
+                        slashable,
+                        inboundHash:
+                            dispute.input.latestInboundMessageBlockHash,
+                        inboundHeight: Number(
+                            dispute.input.lastInboundMessageBlockHeight
+                        ),
+                        snapshotInboundHash:
+                            snapshotData.latestInboundMessageBlockHash,
+                        snapshotInboundHeight: Number(
+                            snapshotData.latestInboundMessageBlockHeight
+                        ),
+                        storedInboundHash:
+                            sm.storage.inboundMessages.getLatestBlockHash() ??
+                            null
+                    };
+                },
+                { forkId },
+                { timeoutMs: 30000 }
+            );
+
+            // premise - the chain event never landed, so the store head is
+            // behind the snapshot the dispute pins
+            expect(await held.heldCount()).to.be.greaterThan(0);
+            expect(r.storedInboundHash).to.equal(null);
+            expect(r.snapshotInboundHeight).to.equal(2);
+            expect(r.slashable).to.equal(false);
+            // getAuditingData walked the gapped store without throwing
+            expect(r.inboundHash).to.equal(r.snapshotInboundHash);
+            expect(r.inboundHeight).to.equal(r.snapshotInboundHeight);
+        });
+
         // no test: `createDispute - isPartial auditingData` is unreachable from
         // constructDispute. a peer's own proof only spans data it stored - a
         // missing milestone snapshot already throws inside getStateProof

--- a/test/unit/DisputeValidationService.test.ts
+++ b/test/unit/DisputeValidationService.test.ts
@@ -1,0 +1,297 @@
+import { expect } from "chai";
+import { Codec, Type } from "@/utils";
+import { DisputeFraudProofType } from "@/types/sol-enums";
+import Block from "@/models/Block";
+import {
+    hash as randomHash,
+    randomAddress,
+    blockStructWithTransactionHeader
+} from "@test/factory";
+import { MathTestSession as TestSession } from "@test/harness";
+
+// the auditor's contract: verdict + the exact stored fraud proof. the
+// kill/counter-dispute/slash cascades stay owned by test/e2e/disputeValidation.
+describe("Unit: DisputeValidationService", function () {
+    describe("inbound hash", function () {
+        it("tampered latestInboundMessageBlockHash not in chain -> false + DisputeInboundHashNotInChain", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 3);
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+
+            dispute.input.latestInboundMessageBlockHash = randomHash();
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeInboundHashNotInChain
+            );
+            expect(run.storedProof?.proofParticipant).to.equal(
+                h.getPeer(0).address
+            );
+            expect(run.disputeFraudProofCount).to.equal(1);
+        });
+    });
+
+    describe("state proof decode", function () {
+        it("undecodable state-proof block, no posted auditing data -> audit skipped, true, zero proofs", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 3);
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+            expect(dispute.postedAuditingData).to.equal(false);
+
+            const bc =
+                dispute.input.stateProof.milestones[0].blockConfirmations[0];
+            bc.signedBlock.encodedBlock = randomHash(); // 32 junk bytes -> Block decode throws
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            // pinned skip path: no fireable fraud proof without posted data
+            expect(run).to.include({ outcome: "returned", isValid: true });
+            expect(run.storedProof).to.equal(undefined);
+            expect(run.disputeFraudProofCount).to.equal(0);
+        });
+    });
+
+    describe("header + structure", function () {
+        it("milestone block header channelId mismatched -> false + DisputeStateProofHeaderMismatch", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 3);
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+
+            const bc = dispute.input.stateProof.milestones
+                .at(-1)!
+                .blockConfirmations.at(-1)!;
+            const block = Codec.decode(bc.signedBlock.encodedBlock, Type.Block);
+            // sanity: the honest header matches dispute.input before the tamper
+            expect(block.transaction.header.channelId).to.equal(
+                dispute.input.channelId
+            );
+            const author = h.peers.find(
+                (p) => p.address === block.transaction.header.participant
+            )!;
+            bc.signedBlock = (
+                await Block.fromBlockStruct(
+                    blockStructWithTransactionHeader(block, {
+                        channelId: randomHash()
+                    }),
+                    author.signer
+                )
+            ).signedBlock;
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeStateProofHeaderMismatch
+            );
+        });
+
+        it("milestone block header forkId mismatched -> false + DisputeStateProofHeaderMismatch", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 3);
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+
+            const bc = dispute.input.stateProof.milestones
+                .at(-1)!
+                .blockConfirmations.at(-1)!;
+            const block = Codec.decode(bc.signedBlock.encodedBlock, Type.Block);
+            expect(block.transaction.header.forkId).to.equal(
+                dispute.input.forkId
+            );
+            const author = h.peers.find(
+                (p) => p.address === block.transaction.header.participant
+            )!;
+            bc.signedBlock = (
+                await Block.fromBlockStruct(
+                    blockStructWithTransactionHeader(block, {
+                        forkId: randomHash()
+                    }),
+                    author.signer
+                )
+            ).signedBlock;
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeStateProofHeaderMismatch
+            );
+        });
+
+        it("unfinalized milestone block with an invalid author signature -> false + DisputeInvalidBlockStructure naming the block", async function () {
+            const h = TestSession.getHarness();
+            // unfinalized head (pending inbound join) -> the tampered tail sits
+            // in the unfinalized part the structure check walks
+            await h.scenario.preDisputeSetupCalldataPath();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(0);
+            expect(dispute.postedAuditingData).to.equal(true);
+
+            const confirmations =
+                dispute.input.stateProof.milestones.at(-1)!.blockConfirmations;
+            expect(confirmations.length).to.equal(1);
+            const source = confirmations.at(-1)!;
+            // author signature swapped for a confirmation signature -> invalid
+            expect(source.signatures[0]).to.not.equal(
+                source.signedBlock.signature
+            );
+            confirmations.push({
+                signedBlock: {
+                    encodedBlock: source.signedBlock.encodedBlock,
+                    signature: source.signatures[0]
+                },
+                signatures: []
+            });
+
+            const run = await h.dispute.auditDispute(1, dispute, auditingData);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeInvalidBlockStructure
+            );
+            const evidence = Codec.decode(
+                run.storedProof!.encodedProof,
+                DisputeFraudProofType.DisputeInvalidBlockStructure
+            );
+            // the unfinalized part is the milestone's confirmations after its
+            // head -> the appended copy is its sole entry, index 0
+            expect(
+                Number(evidence.blockIndexInUnfinalizedPartOfStateProof)
+            ).to.equal(0);
+        });
+    });
+
+    describe("other checks", function () {
+        it("tampered latestStateSnapshotHash -> false + DisputeInvalidStateProof after replay", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 3);
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+
+            dispute.input.latestStateSnapshotHash = randomHash();
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeInvalidStateProof
+            );
+        });
+
+        it("onChainSlashes padded with an unslashed address -> false + DisputeOnChainSlashesNotSubset", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 3);
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+
+            const outsider = randomAddress();
+            dispute.input.onChainSlashes = [
+                ...dispute.input.onChainSlashes,
+                outsider
+            ];
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeOnChainSlashesNotSubset
+            );
+        });
+
+        it("state proof truncated below disputer's latest signed block -> false + DisputeNotLatestState embedding the newer block", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 5);
+            const forkId = h.activeForkId!;
+
+            // truncate host-side so input hashes stay consistent with the
+            // shorter proof (same recipe as the notLatestState e2e)
+            await h.tamper.stubConstructDispute(
+                0,
+                async (dispute, sm) => {
+                    await sm.p2pManager.localRpc.dispute.truncateStateProofToHeight(
+                        dispute,
+                        2
+                    );
+                },
+                { autoRestore: true }
+            );
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+
+            // sanity: the auditor knows a newer block signed by the disputer
+            const disputer = h.getPeer(0).address;
+            const seen = await h.execOnHost(
+                h.getPeer(1),
+                async (sm, args) => {
+                    const result =
+                        sm.agreementManager.getLatestSignedBlockByParticipant(
+                            args.forkId,
+                            args.disputer
+                        );
+                    return { height: result ? result.block.height : -1 };
+                },
+                { forkId, disputer }
+            );
+            expect(seen.height).to.be.greaterThan(2);
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeNotLatestState
+            );
+            // the evidence embeds the newer block + the disputer's signature
+            const evidence = Codec.decode(
+                run.storedProof!.encodedProof,
+                DisputeFraudProofType.DisputeNotLatestState
+            );
+            const newerBlock = Codec.decode(evidence.encodedBlock, Type.Block);
+            expect(
+                Number(newerBlock.transaction.header.transactionCnt)
+            ).to.equal(seen.height);
+            const recovered = await Block.fromSignedBlock({
+                encodedBlock: evidence.encodedBlock,
+                signature: evidence.signature
+            }).signatureToAddress(evidence.signature as string);
+            expect(recovered).to.equal(disputer);
+        });
+
+        it("honest dispute at head: latest signed height equals snapshot height -> equality not flagged, true", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 3);
+            const forkId = h.activeForkId!;
+            // self-removal gives the dispute a genuine reason (hasDisputeReason)
+            // without needing an on-chain timeout window
+            await h.control(h.getPeer(0)).dispute.setForceExit(true).request();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(0);
+            expect(dispute.input.selfRemoval).to.equal(true);
+
+            // sanity: exactly at the boundary the strict `>` must not flag
+            const disputer = h.getPeer(0).address;
+            const seen = await h.execOnHost(
+                h.getPeer(1),
+                async (sm, args) => {
+                    const result =
+                        sm.agreementManager.getLatestSignedBlockByParticipant(
+                            args.forkId,
+                            args.disputer
+                        );
+                    return { height: result ? result.block.height : -1 };
+                },
+                { forkId, disputer }
+            );
+            expect(seen.height).to.equal(
+                Number(auditingData.latestStateSnapshot.blockHeight)
+            );
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: true });
+            expect(run.disputeFraudProofCount).to.equal(0);
+        });
+
+        it("fully valid untampered dispute over real history -> true, zero proofs stored", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 5);
+            // self-removal is the dispute's stated reason (see boundary test)
+            await h.control(h.getPeer(0)).dispute.setForceExit(true).request();
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+            expect(dispute.input.selfRemoval).to.equal(true);
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: true });
+            expect(run.storedProof).to.equal(undefined);
+            expect(run.disputeFraudProofCount).to.equal(0);
+        });
+    });
+});

--- a/test/unit/DisputeValidationService.test.ts
+++ b/test/unit/DisputeValidationService.test.ts
@@ -1,19 +1,26 @@
 import { expect } from "chai";
-import { Codec, Type } from "@/utils";
+import { ZeroHash } from "ethers";
+import { Codec, hash, Type } from "@/utils";
 import { DisputeFraudProofType } from "@/types/sol-enums";
+import { Hash } from "@/types/types";
 import Block from "@/models/Block";
+import StateSnapshot from "@/models/StateSnapshot";
 import {
     hash as randomHash,
     randomAddress,
     blockStructWithTransactionHeader
 } from "@test/factory";
-import { MathTestSession as TestSession } from "@test/harness";
+import { timeoutWaitTime } from "@/types";
+import {
+    MathTestSession as TestSession,
+    resolveTestTimeConfig
+} from "@test/harness";
 
 // the auditor's contract: verdict + the exact stored fraud proof. the
 // kill/counter-dispute/slash cascades stay owned by test/e2e/disputeValidation.
 describe("Unit: DisputeValidationService", function () {
     describe("inbound hash", function () {
-        it("tampered latestInboundMessageBlockHash not in chain -> false + DisputeInboundHashNotInChain", async function () {
+        it("dispute.input.latestInboundMessageBlockHash = random -> false + DisputeInboundHashNotInChain", async function () {
             const h = TestSession.getHarness();
             await h.lifecycle.start(3, 3);
             const { dispute } = await h.dispute.fetchConstructedDispute(0);
@@ -33,7 +40,7 @@ describe("Unit: DisputeValidationService", function () {
     });
 
     describe("state proof decode", function () {
-        it("undecodable state-proof block, no posted auditing data -> audit skipped, true, zero proofs", async function () {
+        it("milestones[0].blockConfirmations[0].signedBlock.encodedBlock = junk AND postedAuditingData false -> false + DisputeLastMilestoneNotFinalAndNoAuditingData", async function () {
             const h = TestSession.getHarness();
             await h.lifecycle.start(3, 3);
             const { dispute } = await h.dispute.fetchConstructedDispute(0);
@@ -44,7 +51,33 @@ describe("Unit: DisputeValidationService", function () {
             bc.signedBlock.encodedBlock = randomHash(); // 32 junk bytes -> Block decode throws
 
             const run = await h.dispute.auditDispute(1, dispute);
-            // pinned skip path: no fireable fraud proof without posted data
+            // the proof carries no data from us: the chain recomputes finality
+            // from the committed dispute, and an undecodable block can never be
+            // final by everyone
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeLastMilestoneNotFinalAndNoAuditingData
+            );
+            expect(run.disputeFraudProofCount).to.equal(1);
+        });
+
+        it("signedBlocks[-1].encodedBlock = junk with no milestones AND postedAuditingData false -> audit skipped, true, no proof", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupDisconnectedPeer();
+            const { dispute } = await h.dispute.fetchConstructedDispute(3);
+            expect(dispute.postedAuditingData).to.equal(false);
+            expect(dispute.input.stateProof.milestones.length).to.equal(0);
+            expect(
+                dispute.input.stateProof.signedBlocks.length
+            ).to.be.greaterThan(0);
+
+            dispute.input.stateProof.signedBlocks.at(-1)!.encodedBlock =
+                randomHash();
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            // project_dispute_gaps.md Gap 1, left open on purpose: with no
+            // milestones the chain's _isLastMilestoneFinalByEveryone returns
+            // true, so firing the proof slashes us instead of the disputer
             expect(run).to.include({ outcome: "returned", isValid: true });
             expect(run.storedProof).to.equal(undefined);
             expect(run.disputeFraudProofCount).to.equal(0);
@@ -52,7 +85,7 @@ describe("Unit: DisputeValidationService", function () {
     });
 
     describe("header + structure", function () {
-        it("milestone block header channelId mismatched -> false + DisputeStateProofHeaderMismatch", async function () {
+        it("milestones[-1].blockConfirmations[-1] header.channelId = random -> false + DisputeStateProofHeaderMismatch", async function () {
             const h = TestSession.getHarness();
             await h.lifecycle.start(3, 3);
             const { dispute } = await h.dispute.fetchConstructedDispute(0);
@@ -84,7 +117,7 @@ describe("Unit: DisputeValidationService", function () {
             );
         });
 
-        it("milestone block header forkId mismatched -> false + DisputeStateProofHeaderMismatch", async function () {
+        it("milestones[-1].blockConfirmations[-1] header.forkId = random -> false + DisputeStateProofHeaderMismatch", async function () {
             const h = TestSession.getHarness();
             await h.lifecycle.start(3, 3);
             const { dispute } = await h.dispute.fetchConstructedDispute(0);
@@ -115,7 +148,7 @@ describe("Unit: DisputeValidationService", function () {
             );
         });
 
-        it("unfinalized milestone block with an invalid author signature -> false + DisputeInvalidBlockStructure naming the block", async function () {
+        it("milestones[-1].blockConfirmations += copy signed by a confirmer -> false + DisputeInvalidBlockStructure at blockIndex 0", async function () {
             const h = TestSession.getHarness();
             // unfinalized head (pending inbound join) -> the tampered tail sits
             // in the unfinalized part the structure check walks
@@ -158,7 +191,7 @@ describe("Unit: DisputeValidationService", function () {
     });
 
     describe("other checks", function () {
-        it("tampered latestStateSnapshotHash -> false + DisputeInvalidStateProof after replay", async function () {
+        it("dispute.input.latestStateSnapshotHash = random -> false + DisputeInvalidStateProof", async function () {
             const h = TestSession.getHarness();
             await h.lifecycle.start(3, 3);
             const { dispute } = await h.dispute.fetchConstructedDispute(0);
@@ -172,7 +205,7 @@ describe("Unit: DisputeValidationService", function () {
             );
         });
 
-        it("onChainSlashes padded with an unslashed address -> false + DisputeOnChainSlashesNotSubset", async function () {
+        it("dispute.input.onChainSlashes += unslashed address -> false + DisputeOnChainSlashesNotSubset", async function () {
             const h = TestSession.getHarness();
             await h.lifecycle.start(3, 3);
             const { dispute } = await h.dispute.fetchConstructedDispute(0);
@@ -190,7 +223,7 @@ describe("Unit: DisputeValidationService", function () {
             );
         });
 
-        it("state proof truncated below disputer's latest signed block -> false + DisputeNotLatestState embedding the newer block", async function () {
+        it("stateProof truncated below the disputer's latest signed block -> false + DisputeNotLatestState carrying that block", async function () {
             const h = TestSession.getHarness();
             await h.lifecycle.start(3, 5);
             const forkId = h.activeForkId!;
@@ -246,7 +279,7 @@ describe("Unit: DisputeValidationService", function () {
             expect(recovered).to.equal(disputer);
         });
 
-        it("honest dispute at head: latest signed height equals snapshot height -> equality not flagged, true", async function () {
+        it("disputer's latest signed height == latestStateSnapshot.blockHeight -> not flagged, true", async function () {
             const h = TestSession.getHarness();
             await h.lifecycle.start(3, 3);
             const forkId = h.activeForkId!;
@@ -280,7 +313,7 @@ describe("Unit: DisputeValidationService", function () {
             expect(run.disputeFraudProofCount).to.equal(0);
         });
 
-        it("fully valid untampered dispute over real history -> true, zero proofs stored", async function () {
+        it("untampered dispute over real history -> true, no proof", async function () {
             const h = TestSession.getHarness();
             await h.lifecycle.start(3, 5);
             // self-removal is the dispute's stated reason (see boundary test)
@@ -292,6 +325,1263 @@ describe("Unit: DisputeValidationService", function () {
             expect(run).to.include({ outcome: "returned", isValid: true });
             expect(run.storedProof).to.equal(undefined);
             expect(run.disputeFraudProofCount).to.equal(0);
+        });
+    });
+
+    describe("posted auditing data", function () {
+        it("milestones[0].blockConfirmations[0].signedBlock.encodedBlock = junk AND postedAuditingData true -> false + DisputeInvalidStateProof", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupCalldataPath();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(0);
+            expect(dispute.postedAuditingData).to.equal(true);
+
+            const bc =
+                dispute.input.stateProof.milestones[0].blockConfirmations[0];
+            bc.signedBlock.encodedBlock = randomHash(); // junk -> Block decode throws
+
+            const run = await h.dispute.auditDispute(1, dispute, auditingData);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeInvalidStateProof
+            );
+            expect(run.disputeFraudProofCount).to.equal(1);
+        });
+
+        it("postedAuditingData true + matching auditingData -> verifyStateProof accepts, true", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupCalldataPath();
+            // self-removal is the dispute's stated reason (hasDisputeReason)
+            await h.control(h.getPeer(0)).dispute.setForceExit(true).request();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(0);
+            expect(dispute.postedAuditingData).to.equal(true);
+
+            const run = await h.dispute.auditDispute(1, dispute, auditingData);
+            expect(run).to.include({ outcome: "returned", isValid: true });
+            expect(run.disputeFraudProofCount).to.equal(0);
+        });
+
+        it("auditingData.latestStateSnapshot.timestamp += 1 (breaks disputeAuditingDataHash) -> false + DisputeInvalidStateProof", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupCalldataPath();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(0);
+            expect(dispute.postedAuditingData).to.equal(true);
+
+            auditingData.latestStateSnapshot.timestamp =
+                Number(auditingData.latestStateSnapshot.timestamp) + 1;
+            // premise: the tamper broke the on-chain hash commitment
+            expect(
+                hash(Codec.encode(auditingData, Type.DisputeAuditingData))
+            ).to.not.equal(dispute.input.disputeAuditingDataHash);
+
+            const run = await h.dispute.auditDispute(1, dispute, auditingData);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeInvalidStateProof
+            );
+        });
+
+        it("dispute.postedAuditingData = false on an unfinalized head -> false + DisputeLastMilestoneNotFinalAndNoAuditingData", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupCalldataPath();
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+            expect(dispute.postedAuditingData).to.equal(true);
+
+            dispute.postedAuditingData = false;
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeLastMilestoneNotFinalAndNoAuditingData
+            );
+        });
+
+        it("auditingData.latestStateSnapshot.snapshotData.totalDeposits.amount += 1 -> false + DisputeInvalidBalanceInvariant", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetup();
+            const forged = await h.tamper.buildForgedSnapshot(2, (ctx) => ({
+                snapshotData: {
+                    ...ctx.originalSnapshotData,
+                    totalDeposits: {
+                        ...ctx.originalSnapshotData.totalDeposits,
+                        amount:
+                            BigInt(
+                                ctx.originalSnapshotData.totalDeposits.amount
+                            ) + 1n
+                    }
+                }
+            }));
+
+            // same re-stitch as the balanceInvariant e2e: forged head block +
+            // forged snapshot committed by the dispute's hashes
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(2);
+            const proof = dispute.input.stateProof;
+            if (proof.signedBlocks.length > 0) {
+                proof.signedBlocks[proof.signedBlocks.length - 1] =
+                    forged.forgedBlock.signedBlock;
+            } else {
+                const milestone = proof.milestones.at(-1)!;
+                milestone.blockConfirmations[0] =
+                    forged.forgedBlock.blockConfirmationStruct;
+                auditingData.milestoneSnapshots[
+                    auditingData.milestoneSnapshots.length - 1
+                ] = forged.forgedSnapshot.toStruct();
+            }
+            auditingData.latestStateSnapshot = forged.forgedSnapshot.toStruct();
+            dispute.input.latestStateSnapshotHash = forged.forgedSnapshot.hash;
+            dispute.input.disputeAuditingDataHash = hash(
+                Codec.encode(auditingData, Type.DisputeAuditingData)
+            );
+            dispute.postedAuditingData = true;
+
+            const run = await h.dispute.auditDispute(0, dispute, auditingData);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeInvalidBalanceInvariant
+            );
+        });
+
+        it("auditingData.inboundMessageBlocks nonempty (real join) -> chain verified, true", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupCalldataPath();
+            await h.control(h.getPeer(0)).dispute.setForceExit(true).request();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(0);
+            // premise: the join really put messages on the inbound chain
+            expect(auditingData.inboundMessageBlocks.length).to.be.greaterThan(
+                0
+            );
+
+            const run = await h.dispute.auditDispute(1, dispute, auditingData);
+            expect(run).to.include({ outcome: "returned", isValid: true });
+            expect(run.disputeFraudProofCount).to.equal(0);
+        });
+
+        // the general shape: a real earlier inbound block, so
+        // _isDisputeInboundHashValid still accepts it as an ancestor, while
+        // snapshotData.latestInboundMessageBlockHeight already moved past it
+        it("dispute.input.lastInboundMessageBlockHeight = an earlier real inbound block below snapshotData.latestInboundMessageBlockHeight -> false + DisputeInboundAnchorBehindLatestState", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupConsumedInboundTopUp();
+            await h.control(h.getPeer(0)).dispute.setForceExit(true).request();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(0);
+
+            const control = h.control(h.getPeer(0));
+            const headHash = (await control.query
+                .getLatestInboundMessageHash()
+                .request()) as Hash;
+            const headHeight = (await control.query
+                .getInboundLatestHeight()
+                .request())!;
+            const head = Codec.decode(
+                (await control.query
+                    .getInboundMessageBlock(headHash)
+                    .request())!.encodedMessageBlock,
+                Type.MessageBlock
+            );
+            const previousHash = head.previousBlockHash as Hash;
+            const previousHeight = headHeight - 1;
+            // premise: an earlier inbound block really exists, and the pinned
+            // snapshot already sits on the head above it
+            expect(previousHeight).to.be.greaterThan(0);
+            expect(
+                Number(
+                    auditingData.latestStateSnapshot.snapshotData
+                        .latestInboundMessageBlockHeight
+                )
+            ).to.equal(headHeight);
+
+            dispute.input.latestInboundMessageBlockHash = previousHash;
+            dispute.input.lastInboundMessageBlockHeight = previousHeight;
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeInboundAnchorBehindLatestState
+            );
+            expect(run.storedProof?.proofParticipant).to.equal(
+                h.getPeer(0).address
+            );
+            expect(run.disputeFraudProofCount).to.equal(1);
+        });
+
+        // boundary of the same rule: height 0 is the pre-genesis value, below
+        // every snapshot (channel open already appends inbound block 1)
+        it("dispute.input.latestInboundMessageBlockHash = ZeroHash AND lastInboundMessageBlockHeight = 0 -> false + DisputeInboundAnchorBehindLatestState", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 3);
+            await h.control(h.getPeer(0)).dispute.setForceExit(true).request();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(0);
+            // premise: the channel-open join left a nonzero inbound head
+            expect(dispute.input.latestInboundMessageBlockHash).to.not.equal(
+                ZeroHash
+            );
+            // premise: the pinned snapshot is already past the claimed height
+            expect(
+                Number(
+                    auditingData.latestStateSnapshot.snapshotData
+                        .latestInboundMessageBlockHeight
+                )
+            ).to.be.greaterThan(0);
+
+            dispute.input.latestInboundMessageBlockHash = ZeroHash;
+            dispute.input.lastInboundMessageBlockHeight = 0;
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeInboundAnchorBehindLatestState
+            );
+            // pinned: the type is appended last, so its value must not move
+            expect(
+                DisputeFraudProofType.DisputeInboundAnchorBehindLatestState
+            ).to.equal(217);
+            expect(run.storedProof?.proofParticipant).to.equal(
+                h.getPeer(0).address
+            );
+            expect(run.disputeFraudProofCount).to.equal(1);
+        });
+
+        // the other route into verifyDisputeOutput: validateDispute's
+        // postedAuditingData branch instead of its else branch
+        it("the same ZeroHash + height 0 pair on the posted-auditing-data path -> false + DisputeInboundAnchorBehindLatestState", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupCalldataPath();
+            await h.control(h.getPeer(0)).dispute.setForceExit(true).request();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(0);
+            expect(dispute.postedAuditingData).to.equal(true);
+            expect(dispute.input.latestInboundMessageBlockHash).to.not.equal(
+                ZeroHash
+            );
+
+            dispute.input.latestInboundMessageBlockHash = ZeroHash;
+            dispute.input.lastInboundMessageBlockHeight = 0;
+
+            const run = await h.dispute.auditDispute(1, dispute, auditingData);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeInboundAnchorBehindLatestState
+            );
+            expect(run.disputeFraudProofCount).to.equal(1);
+        });
+    });
+
+    describe("milestone finality + state proof anchor", function () {
+        // tripwire for the skip below: a peer that joined mid-history still
+        // syncs the pre-join blocks, so it holds the last milestone's first
+        // block even though it never signed that milestone, and audits for real
+        it("dispute.input.latestInboundMessageBlockHash = pre-join head -> joiner still holds milestones[-1].blockConfirmations[0], audits it", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupCalldataPath(); // peer 3 joins late
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+
+            // claim the pre-join inbound head: still a real chain entry
+            // (StateChannelCommon.sol:583-592), so the expected participant set
+            // is the pre-join one and peer 3 is not part of it
+            const inboundHead = await h
+                .control(h.getPeer(0))
+                .query.getInboundMessageBlock(
+                    dispute.input.latestInboundMessageBlockHash
+                )
+                .request();
+            expect(inboundHead, "expected the inbound head in storage").to.not
+                .be.null;
+            const headBlock = Codec.decode(
+                inboundHead!.encodedMessageBlock,
+                Type.MessageBlock
+            );
+            dispute.input.latestInboundMessageBlockHash =
+                headBlock.previousBlockHash;
+            dispute.input.lastInboundMessageBlockHeight =
+                Number(headBlock.blockHeight) - 1;
+            dispute.postedAuditingData = false;
+
+            const lastMilestoneFirstBlock = Codec.decode(
+                dispute.input.stateProof.milestones.at(-1)!
+                    .blockConfirmations[0].signedBlock.encodedBlock,
+                Type.Block
+            );
+            const joinerHas = await h
+                .control(h.getPeer(3))
+                .query.getBlockByHeight(
+                    h.activeForkId!,
+                    Number(
+                        lastMilestoneFirstBlock.transaction.header
+                            .transactionCnt
+                    )
+                )
+                .request();
+            expect(joinerHas, "joiner synced the pre-join block").to.not.be
+                .null;
+
+            // holding that block, the joiner runs the same audit as a peer that
+            // signed the milestone - no skip
+            const joiner = await h.dispute.auditDispute(3, dispute);
+            const inSync = await h.dispute.auditDispute(1, dispute);
+            expect(joiner.outcome).to.equal("returned");
+            expect(joiner).to.deep.include({
+                outcome: inSync.outcome,
+                isValid: inSync.outcome === "returned" ? inSync.isValid : null
+            });
+        });
+
+        // no test: the false branch of isLastMilestoneStoredLocally needs an
+        // auditor that never stored the last milestone's first block.
+        // _isLastMilestoneFinalByEveryone (DisputeFraudProofFacet.sol:764-775)
+        // only reports final when every expected participant signed it, so a
+        // participant auditor necessarily has it; while any participant is
+        // disconnected no milestone forms at all (see "E2E: ... stateProof /
+        // case3_signedBlocksOnly"); and a peer that joined after the milestone
+        // still syncs it, pinned by the test above. only a peer that left the
+        // channel is outside the expected set, and it no longer audits.
+        it.skip("milestones[-1].blockConfirmations[0] missing from the auditor's block storage -> audit skipped", function () {});
+
+        it("stateProof.milestones = [] AND signedBlocks = [] -> stored genesis snapshot + forkId == snapshotDataHash, true", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 0); // no blocks -> empty proof
+            const forkId = h.activeForkId!;
+            await h.control(h.getPeer(0)).dispute.setForceExit(true).request();
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+            expect(dispute.input.stateProof.milestones.length).to.equal(0);
+            expect(dispute.input.stateProof.signedBlocks.length).to.equal(0);
+
+            // premises for the genesis branches: the dispute pins the genesis
+            // snapshot and the forkId is its snapshot-data hash
+            const genesisResult = await h
+                .control(h.getPeer(1))
+                .dispute.getGenesisSnapshotStruct(forkId)
+                .request();
+            const genesis = StateSnapshot.from(
+                Codec.decode(genesisResult!.encodedSnapshot, Type.StateSnapshot)
+            );
+            expect(dispute.input.latestStateSnapshotHash).to.equal(
+                genesis.hash
+            );
+            expect(dispute.input.forkId).to.equal(genesis.snapshotDataHash);
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: true });
+            expect(run.disputeFraudProofCount).to.equal(0);
+        });
+
+        it("stateProof.signedBlocks only (partial-signature fork) -> anchored via previous block, true", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupDisconnectedPeer();
+            await h.control(h.getPeer(3)).dispute.setForceExit(true).request();
+            const { dispute } = await h.dispute.fetchConstructedDispute(3);
+            expect(dispute.input.stateProof.milestones.length).to.equal(0);
+            expect(
+                dispute.input.stateProof.signedBlocks.length
+            ).to.be.greaterThan(0);
+            expect(dispute.postedAuditingData).to.equal(false);
+
+            const run = await h.dispute.auditDispute(0, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: true });
+            expect(run.disputeFraudProofCount).to.equal(0);
+        });
+
+        it("dispute.input.forkId = random on an empty stateProof -> no stored genesis, audit skipped, true", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 0); // empty proof -> genesis snapshot branch
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+            // no reason stated -> the audited path ends in InvalidDisputeReason
+            const audited = await h.dispute.auditDispute(1, dispute);
+            expect(audited).to.include({ outcome: "returned", isValid: false });
+            expect(audited.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.InvalidDisputeReason
+            );
+
+            // an unknown fork keeps passing the channel-scoped inbound check
+            // (StateChannelCommon.sol:578-594) but has no stored genesis, so
+            // the state proof anchor lookup skips the audit instead
+            dispute.input.forkId = randomHash();
+            const skipped = await h.dispute.auditDispute(1, dispute);
+            expect(skipped).to.include({ outcome: "returned", isValid: true });
+            expect(skipped.disputeFraudProofCount).to.equal(1); // from the audit above
+        });
+
+        it("localDiamond.isDisputeInboundHashValid false + RPC true -> no DisputeInboundHashNotInChain", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(4, 2);
+            // the auditor stops applying inbound messages to its in-memory EVM
+            // before the join, so only its local diamond falls behind
+            await h
+                .control(h.getPeer(1))
+                .stub.stubLocalDiamondInboundMessages()
+                .request();
+            await h.join.forceInboundJoinWait();
+            await h.control(h.getPeer(0)).dispute.setForceExit(true).request();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(0);
+
+            // premise: the two sources genuinely disagree on this dispute
+            const sources = await h
+                .control(h.getPeer(1))
+                .dispute.probeDisputeInboundHashSources(
+                    Codec.encode(dispute, Type.Dispute) as string
+                )
+                .request({ timeoutMs: 30000 });
+            expect(sources).to.deep.equal({ local: false, rpc: true });
+
+            const run = await h.dispute.auditDispute(1, dispute, auditingData);
+            expect(run.outcome).to.equal("returned");
+            expect(run.storedProof?.disputeFraudProofType).to.not.equal(
+                DisputeFraudProofType.DisputeInboundHashNotInChain
+            );
+        });
+    });
+
+    describe("pipeline", function () {
+        it("signedBlocks[-1].encodedBlock.stateSnapshotHash = ZeroHash -> false + DisputeInvalidBlockInStateProofApplyFraudProof", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupDisconnectedPeer();
+            // rewrite host-side: the block is re-signed by its author, so
+            // structure stays valid and only the replay catches it
+            await h.tamper.stubConstructDispute(
+                3,
+                async (dispute, sm) => {
+                    const svc = sm.p2pManager.localRpc.dispute;
+                    await svc.rewriteLastSignedBlockInDispute(
+                        dispute,
+                        (bs) => ({
+                            ...bs,
+                            stateSnapshotHash: svc.zeroHash
+                        })
+                    );
+                },
+                { autoRestore: true }
+            );
+            const { dispute } = await h.dispute.fetchConstructedDispute(3);
+            expect(dispute.input.stateProof.milestones.length).to.equal(0);
+
+            const run = await h.dispute.auditDispute(0, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeInvalidBlockInStateProofApplyFraudProof
+            );
+        });
+
+        // no test: the pipeline only sees false from
+        // interpretFinalValidationResult(DISPUTE) (DisputeValidationStrategy.ts:110);
+        // SUCCESS and DUPLICATE return true (:90, :97) and every other result
+        // throws inside the strategy. each DISPUTE return stores its proof
+        // immediately above it (:78-82, :153-160, :201-208, :224-225, :244-245,
+        // :256-257, :328-329), so false-with-empty-proof-store has no producer
+        it.skip("onBlockConfirmationStruct false with an empty disputeFraudProofs store -> throw", function () {});
+    });
+
+    describe("dispute output", function () {
+        it("dispute.outputSnapshotDataHash = random -> false + DisputeInvalidOutputState", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 3);
+            await h.control(h.getPeer(0)).dispute.setForceExit(true).request();
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+
+            dispute.outputSnapshotDataHash = randomHash();
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeInvalidOutputState
+            );
+        });
+
+        it("timeout.participant = 0 AND onChainSlashes = [] AND selfRemoval false -> false + InvalidDisputeReason", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 3);
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+            // premise: nothing states a reason
+            expect(dispute.input.timeout.participant).to.equal(
+                "0x0000000000000000000000000000000000000000"
+            );
+            expect(dispute.input.onChainSlashes.length).to.equal(0);
+            expect(dispute.input.selfRemoval).to.equal(false);
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.InvalidDisputeReason
+            );
+        });
+
+        // verifyDisputeOutput's unlinked-auditing-data kill is covered under
+        // "posted auditing data" by the two ZeroHash + height 0 cases
+    });
+
+    describe("replay", function () {
+        it("same invalid dispute audited twice -> false both times, disputeFraudProofs stays at 1", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 5);
+            await h.tamper.stubConstructDispute(
+                0,
+                async (dispute, sm) => {
+                    await sm.p2pManager.localRpc.dispute.truncateStateProofToHeight(
+                        dispute,
+                        2
+                    );
+                },
+                { autoRestore: true }
+            );
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+
+            const first = await h.dispute.auditDispute(1, dispute);
+            expect(first).to.include({ outcome: "returned", isValid: false });
+            expect(first.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeNotLatestState
+            );
+            expect(first.disputeFraudProofCount).to.equal(1);
+
+            // replay: the store is keyed by dispute hash -> idempotent
+            const second = await h.dispute.auditDispute(1, dispute);
+            expect(second).to.include({ outcome: "returned", isValid: false });
+            expect(second.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeNotLatestState
+            );
+            expect(second.disputeFraudProofCount).to.equal(1);
+        });
+    });
+
+    describe("persistDisputeDataWithoutAudit", function () {
+        it("includeUnfinalizedBlocks true -> stateProof.signedBlocks + latestStateSnapshot stored on a peer that missed them", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupDisconnectedPeer();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(3);
+            expect(
+                dispute.input.stateProof.signedBlocks.length
+            ).to.be.greaterThan(1);
+
+            const p = await h.dispute.persistDisputeData(2, dispute, {
+                auditingData,
+                includeUnfinalizedBlocks: true
+            });
+            expect(p.threwMessage).to.equal(undefined);
+            // the disconnected peer never saw these blocks - the persist is
+            // what puts them (and the head snapshot) into its storage
+            for (const item of p.signedBlocks) {
+                expect(item.storedBefore, item.key).to.equal(false);
+                expect(item.storedAfter, item.key).to.equal(true);
+            }
+            expect(p.snapshots[0].storedBefore).to.equal(false);
+            expect(p.snapshots[0].storedAfter).to.equal(true);
+        });
+
+        it("includeUnfinalizedBlocks false -> stateProof.signedBlocks and latestStateSnapshot not stored", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupDisconnectedPeer();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(3);
+            expect(
+                dispute.input.stateProof.signedBlocks.length
+            ).to.be.greaterThan(1);
+
+            const p = await h.dispute.persistDisputeData(2, dispute, {
+                auditingData,
+                includeUnfinalizedBlocks: false
+            });
+            expect(p.threwMessage).to.equal(undefined);
+            for (const item of p.signedBlocks) {
+                expect(item.storedAfter, item.key).to.equal(false);
+            }
+            expect(p.snapshots[0].storedAfter).to.equal(false);
+        });
+
+        it("disputeAuditingData undefined -> stateProof blocks stored, snapshots/messages/state untouched", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupDisconnectedPeer();
+            const { dispute } = await h.dispute.fetchConstructedDispute(3);
+
+            const p = await h.dispute.persistDisputeData(2, dispute, {
+                includeUnfinalizedBlocks: true
+            });
+            expect(p.threwMessage).to.equal(undefined);
+            for (const item of p.signedBlocks) {
+                expect(item.storedAfter, item.key).to.equal(true);
+            }
+            expect(p.snapshots).to.deep.equal([]);
+            expect(p.stateMachineState).to.equal(undefined);
+            expect(p.inboundMessages).to.deep.equal([]);
+            expect(p.outboundMessages).to.deep.equal([]);
+        });
+
+        it('auditingData.latestFinalizedStateStateMachineState = "" -> state store skipped, blocks still stored', async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupDisconnectedPeer();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(3);
+            expect(
+                auditingData.latestFinalizedStateStateMachineState
+            ).to.not.equal("");
+
+            // "" is DisputeManager's in-memory missing-state sentinel and is
+            // not ABI-encodable -> applied host-side after decode
+            const p = await h.dispute.persistDisputeData(2, dispute, {
+                auditingData,
+                includeUnfinalizedBlocks: true,
+                latestFinalizedStateStateMachineStateOverride: ""
+            });
+            expect(p.threwMessage).to.equal(undefined);
+            // the sentinel has no content-addressed key -> nothing is stored
+            expect(p.stateMachineState).to.equal(undefined);
+            for (const item of p.signedBlocks) {
+                expect(item.storedAfter, item.key).to.equal(true);
+            }
+        });
+
+        it("stateProof.signedBlocks[0].encodedBlock = junk -> skipped, decodable siblings stored", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetupDisconnectedPeer();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(3);
+            expect(
+                dispute.input.stateProof.signedBlocks.length
+            ).to.be.greaterThan(1);
+            dispute.input.stateProof.signedBlocks[0].encodedBlock =
+                randomHash();
+
+            const p = await h.dispute.persistDisputeData(2, dispute, {
+                auditingData,
+                includeUnfinalizedBlocks: true
+            });
+            expect(p.threwMessage).to.equal(undefined);
+            expect(p.undecodableSignedBlockCount).to.equal(1);
+            expect(p.signedBlocks.length).to.be.greaterThan(0);
+            for (const item of p.signedBlocks) {
+                expect(item.storedAfter, item.key).to.equal(true);
+            }
+        });
+
+        it("milestones[0].blockConfirmations[0].signedBlock.encodedBlock = junk, no auditingData -> skipped, no throw", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 2);
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+            expect(
+                dispute.input.stateProof.milestones.length
+            ).to.be.greaterThan(0);
+            dispute.input.stateProof.milestones[0].blockConfirmations[0].signedBlock.encodedBlock =
+                randomHash();
+
+            const p = await h.dispute.persistDisputeData(1, dispute, {
+                includeUnfinalizedBlocks: false
+            });
+            expect(p.threwMessage).to.equal(undefined);
+            expect(p.undecodableMilestoneBlockCount).to.equal(1);
+        });
+
+        // the persist never decodes the last milestone's first block: the
+        // finalized state is keyed by its own hash, so junk there only skips
+        // that entry's block store
+        it("milestones[-1].blockConfirmations[0].signedBlock.encodedBlock = junk + auditingData -> skipped, decodable siblings stored", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 2);
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(0);
+            const lastMilestone = dispute.input.stateProof.milestones.at(-1)!;
+            lastMilestone.blockConfirmations[0].signedBlock.encodedBlock =
+                randomHash();
+
+            const p = await h.dispute.persistDisputeData(1, dispute, {
+                auditingData,
+                includeUnfinalizedBlocks: true
+            });
+            expect(p.threwMessage).to.equal(undefined);
+            expect(p.undecodableMilestoneBlockCount).to.equal(1);
+            // the finalized state is persisted even though that block is junk
+            expect(p.stateMachineState?.storedAfter).to.equal(true);
+            for (const item of p.milestoneBlocks) {
+                expect(item.storedAfter, item.key).to.equal(true);
+            }
+        });
+
+        it("auditingData + decodable milestones[-1].blockConfirmations[0] -> finalized state stored under that block's snapshot stateMachineStateHash", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 2);
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(0);
+
+            // independent oracle: the key that block's own snapshot commits to
+            const lastMilestoneFirstBlock = Codec.decode(
+                dispute.input.stateProof.milestones.at(-1)!
+                    .blockConfirmations[0].signedBlock.encodedBlock,
+                Type.Block
+            );
+            const blockSnapshot = StateSnapshot.from(
+                Codec.decode(
+                    (await h
+                        .control(h.getPeer(1))
+                        .query.getStateSnapshotStructByHash(
+                            lastMilestoneFirstBlock.stateSnapshotHash
+                        )
+                        .request())!.encodedSnapshot,
+                    Type.StateSnapshot
+                )
+            );
+            const committedStateHash = blockSnapshot.stateMachineStateHash;
+
+            const p = await h.dispute.persistDisputeData(1, dispute, {
+                auditingData,
+                includeUnfinalizedBlocks: true
+            });
+            expect(p.threwMessage).to.equal(undefined);
+            // content-addressing lands on the same word for honest data
+            expect(p.stateMachineState?.key).to.equal(committedStateHash);
+            expect(p.stateMachineState?.storedAfter).to.equal(true);
+            expect(
+                hash(auditingData.latestFinalizedStateStateMachineState)
+            ).to.equal(committedStateHash);
+        });
+
+        it("auditingData.latestFinalizedStateStateMachineState = another real state -> stored under its own hash, the honest snapshot's key untouched", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 2);
+            const forkId = h.activeForkId!;
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(0);
+            const persister = h.control(h.getPeer(1));
+
+            const lastMilestoneFirstBlock = Codec.decode(
+                dispute.input.stateProof.milestones.at(-1)!
+                    .blockConfirmations[0].signedBlock.encodedBlock,
+                Type.Block
+            );
+            const blockSnapshot = StateSnapshot.from(
+                Codec.decode(
+                    (await persister.query
+                        .getStateSnapshotStructByHash(
+                            lastMilestoneFirstBlock.stateSnapshotHash
+                        )
+                        .request())!.encodedSnapshot,
+                    Type.StateSnapshot
+                )
+            );
+            const committedStateHash = blockSnapshot.stateMachineStateHash;
+            const stateBefore = await persister.query
+                .getStateMachineState(committedStateHash)
+                .request();
+
+            // a real state of the same channel from a different height - the
+            // math machine's state changes on every transition
+            const otherSnapshot = await persister.query
+                .getStateSnapshotStructAt(
+                    forkId,
+                    blockSnapshot.blockHeight === 0 ? 1 : 0
+                )
+                .request();
+            const otherStateHash = StateSnapshot.from(
+                Codec.decode(otherSnapshot!.encodedSnapshot, Type.StateSnapshot)
+            ).stateMachineStateHash;
+            const otherState = await persister.query
+                .getStateMachineState(otherStateHash)
+                .request();
+            // premise: the substituted bytes really are a different state
+            expect(otherState).to.not.equal(stateBefore);
+
+            const p = await h.dispute.persistDisputeData(1, dispute, {
+                auditingData,
+                includeUnfinalizedBlocks: true,
+                latestFinalizedStateStateMachineStateOverride: otherState!
+            });
+            expect(p.threwMessage).to.equal(undefined);
+            expect(p.stateMachineState?.key).to.equal(otherStateHash);
+            // the honest key still holds the honest state - substituted bytes
+            // only ever land under their own hash
+            expect(
+                await persister.query
+                    .getStateMachineState(committedStateHash)
+                    .request()
+            ).to.equal(stateBefore);
+            expect(
+                await persister.query
+                    .getStateMachineState(otherStateHash)
+                    .request()
+            ).to.equal(otherState);
+        });
+    });
+
+    describe("timeout checks", function () {
+        it("dispute.input.timeout.blockHeight += 1 -> false + TimeoutNotLinkedToLatestState", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 2);
+            await h.tamper.plantFreshTimeoutForNextWriter(0);
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+            expect(dispute.input.timeout.participant).to.not.equal(
+                "0x0000000000000000000000000000000000000000"
+            );
+
+            dispute.input.timeout.blockHeight =
+                Number(dispute.input.timeout.blockHeight) + 1;
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.TimeoutNotLinkedToLatestState
+            );
+        });
+
+        it("dispute.input.timeout.participant = a peer that is not next to write -> false + TimeoutParticipantNotNext", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 2);
+            await h.tamper.plantFreshTimeoutForNextWriter(0);
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+
+            const next = dispute.input.timeout.participant;
+            const wrong = h.peers.find((p) => p.address !== next)!.address;
+            dispute.input.timeout.participant = wrong;
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.TimeoutParticipantNotNext
+            );
+        });
+
+        it("window creation timestamp >= previous block timestamp + timeoutWaitTime -> timeout checks pass, true", async function () {
+            const h = TestSession.getHarness();
+            await h.scenario.preDisputeSetup();
+            const forkId = h.activeForkId!;
+            // the committed dispute would otherwise reduce the fork mid-test,
+            // and idle peers would race in their own natural timeout disputes
+            for (const peer of h.peers) {
+                await h.rpcStub.holdReductionRace(peer.index);
+                await h.rpcStub.suppressTimeoutCheck(peer.index);
+            }
+
+            const head = await h
+                .control(h.getPeer(0))
+                .query.getLatestBlockInfo(forkId)
+                .request();
+            const headBlock = Codec.decode(head!.encodedBlock, Type.Block);
+            const headTs = Number(headBlock.transaction.header.timestamp);
+            const headHeight = Number(
+                headBlock.transaction.header.transactionCnt
+            );
+            const wait = timeoutWaitTime(
+                resolveTestTimeConfig(),
+                headHeight + 1
+            );
+            // plant first: the upload's window-created-too-early guard compares
+            // against the timeout's minTimeStamp (set at plant time)
+            await h.tamper.plantFreshTimeoutForNextWriter(0);
+            await h.event.waitUntilTimestamp(headTs + wait + 2);
+
+            const posted = await h.tamper.postTamperedDispute(0, () => {}, {
+                markMalicious: false
+            });
+            // premise: the window was created after the writer's full wait
+            const windowTs = Number(
+                await h.channelManager.getDisputeWindowCreationTimestamp(
+                    h.channelId,
+                    forkId
+                )
+            );
+            expect(windowTs).to.be.greaterThanOrEqual(headTs + wait);
+
+            const run = await h.dispute.auditDispute(1, posted.dispute);
+            expect(run).to.include({ outcome: "returned", isValid: true });
+            expect(run.disputeFraudProofCount).to.equal(0);
+        });
+
+        it("window creation timestamp < previous block timestamp + timeoutWaitTime -> false + TimeoutTooEarly", async function () {
+            const h = TestSession.getHarness();
+            // wide wait window -> the immediate post is deterministically early
+            await h.scenario.preDisputeSetup({
+                timeConfig: { chainFallbackTime: 12 }
+            });
+            const forkId = h.activeForkId!;
+            for (const peer of h.peers) {
+                await h.rpcStub.holdReductionRace(peer.index);
+                // live audits store the same proof and try to kill on-chain
+                await h.rpcStub.suppressDisputeKill(peer.index);
+                await h.rpcStub.suppressTimeoutCheck(peer.index);
+            }
+
+            const head = await h
+                .control(h.getPeer(0))
+                .query.getLatestBlockInfo(forkId)
+                .request();
+            const headBlock = Codec.decode(head!.encodedBlock, Type.Block);
+            const headTs = Number(headBlock.transaction.header.timestamp);
+            const wait = timeoutWaitTime(
+                resolveTestTimeConfig({ chainFallbackTime: 12 }),
+                Number(headBlock.transaction.header.transactionCnt) + 1
+            );
+
+            await h.tamper.plantFreshTimeoutForNextWriter(0);
+            const posted = await h.tamper.postTamperedDispute(0, () => {});
+            const windowTs = Number(
+                await h.channelManager.getDisputeWindowCreationTimestamp(
+                    h.channelId,
+                    forkId
+                )
+            );
+            expect(windowTs).to.be.lessThan(headTs + wait);
+
+            const run = await h.dispute.auditDispute(1, posted.dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.TimeoutTooEarly
+            );
+            expect(run.disputeFraudProofCount).to.equal(1);
+        });
+
+        // no test: timeoutTimestamp comes from
+        // getDisputeWindowCreationTimestamp and previousTimestamp from the
+        // stored previous block, so hitting equality means landing the upload
+        // transaction in one chosen second - only evm_setNextBlockTimestamp
+        // does that, and AGENTS.md forbids node-wide time RPCs on a shared
+        // node. both sides of the strict `<` are pinned by the too-early and
+        // pass-through tests above, and by the three-way forfeit test which
+        // moves previousTimestamp across the same comparison
+        it.skip("window creation timestamp == previous block timestamp + timeoutWaitTime -> accepted", function () {});
+
+        it("timeout.participantSignatureOnPreviousBlock: 0x / timed-out signer / other signer -> TimeoutTooEarly, none, TimeoutTooEarly", async function () {
+            const h = TestSession.getHarness();
+            // agreementTime 10 widens the authored->calldata gap so the window
+            // deterministically lands between the two forfeit clocks
+            await h.lifecycle.timeoutSetup(4, 0, {
+                timeConfig: { agreementTime: 10, evidenceTime: 8 }
+            });
+            await h.transition.advanceState({ count: 2 });
+            // height 2: peer 3 cannot confirm -> the author posts calldata
+            await h
+                .control(h.getPeer(3))
+                .stub.stubRejectIngestedConfirmations()
+                .request();
+            await Promise.all(
+                [0, 1, 2, 3].map((i) => h.rpcStub.suppressTimeoutCheck(i))
+            );
+            await h.network.disconnectPeer(3);
+            await h.transition.advanceState({
+                count: 1,
+                waitForPeers: [0, 1, 2],
+                waitForFinalization: false
+            });
+            await h.event.waitForPeers("onBlockCalldataPosted", [0, 1, 2], 1, {
+                mode: "atLeast",
+                timeoutMs: 25000
+            });
+            await h
+                .control(h.getPeer(3))
+                .stub.restoreRejectIngestedConfirmations()
+                .request();
+            const forkId = h.activeForkId!;
+            for (const i of [0, 1, 2, 3]) {
+                await h.rpcStub.holdReductionRace(i);
+            }
+
+            const block2 = await h
+                .control(h.getPeer(1))
+                .query.getBlockByHeight(forkId, 2)
+                .request();
+            expect(block2!.onChainTimestamp).to.not.equal(null);
+            const tAuth = block2!.timestamp;
+            const tCal = block2!.onChainTimestamp!;
+            const wait = timeoutWaitTime(
+                resolveTestTimeConfig({ agreementTime: 10, evidenceTime: 8 }),
+                3
+            );
+
+            // open the window inside (tAuth + wait, tCal + wait)
+            await h.event.waitUntilTimestamp(tAuth + wait + 1);
+            await h.control(h.getPeer(2)).dispute.setForceExit(true).request();
+            await h.tamper.postTamperedDispute(2, () => {}, {
+                markMalicious: false
+            });
+            const windowTs = Number(
+                await h.channelManager.getDisputeWindowCreationTimestamp(
+                    h.channelId,
+                    forkId
+                )
+            );
+            expect(windowTs).to.be.greaterThan(tAuth + wait);
+            expect(windowTs).to.be.lessThan(tCal + wait);
+
+            // disputer 0's proof heads at block 2; timeout blames height 3
+            await h.tamper.plantFreshTimeoutForNextWriter(0);
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+            expect(Number(dispute.input.timeout.blockHeight)).to.equal(3);
+            // a calldata-committed head counts as final, so constructDispute
+            // has no auditing data to post
+            expect(dispute.postedAuditingData).to.equal(false);
+
+            const prevBlock = Block.fromSignedBlock(
+                Codec.decode(block2!.encodedSignedBlock, Type.SignedBlock)
+            );
+            const timedOut = h.peers.find(
+                (p) => p.address === dispute.input.timeout.participant
+            )!;
+            const wrongSigner = h.peers.find(
+                (p) => p.address !== dispute.input.timeout.participant
+            )!;
+
+            // no signature -> previous clock is the calldata timestamp -> early
+            const noSig = await h.dispute.auditDispute(1, dispute);
+            expect(noSig.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.TimeoutTooEarly
+            );
+
+            // the timed-out participant's own signature forfeits the extra time
+            dispute.input.timeout.participantSignatureOnPreviousBlock =
+                (await prevBlock.sign(timedOut.signer)) as string;
+            const validSig = await h.dispute.auditDispute(1, dispute);
+            expect(validSig.outcome).to.equal("returned");
+            expect(validSig.storedProof?.disputeFraudProofType).to.not.equal(
+                DisputeFraudProofType.TimeoutTooEarly
+            );
+
+            // a wrong signer's signature does not forfeit -> still early
+            dispute.input.timeout.participantSignatureOnPreviousBlock =
+                (await prevBlock.sign(wrongSigner.signer)) as string;
+            const invalidSig = await h.dispute.auditDispute(1, dispute);
+            expect(invalidSig.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.TimeoutTooEarly
+            );
+        });
+
+        // no test: the [check] N/N Threshold check reads the block at
+        // timeout.blockHeight, which the [check] isLinked to stateProof check
+        // above it pins to stateProof head + 1. didEveryoneSign needs every
+        // participant of that block signed, so if the disputer is one of them
+        // it signed above the dispute's own snapshot height and the earlier
+        // DisputeNotLatestState fires instead. that leaves only a disputer
+        // outside the block's participant set, which uploadDispute rejects
+        // with ErrorCantParticipateInDispute - enforced by
+        // "E2E: dispute validation / uploadRevert / channelId" and
+        // "... / uploadRevert / disputer".
+        it.skip("block at timeout.blockHeight signed by every participant -> false + TimeoutThreshold", function () {});
+
+        it("timeout.blockHeight = a block whose calldata is on-chain, isForced true -> false + TimeoutCalldataPosted", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.timeoutSetup(4, 0, {
+                timeConfig: { evidenceTime: 8 }
+            });
+            await h.transition.advanceState({ count: 2 });
+            const calldataAuthor = await h.query.getNextPeerToWrite();
+            await h
+                .control(h.getPeer(3))
+                .stub.stubRejectIngestedConfirmations()
+                .request();
+            await Promise.all(
+                [0, 1, 2, 3].map((i) => h.rpcStub.suppressTimeoutCheck(i))
+            );
+            await h.network.disconnectPeer(3);
+            await h.transition.advanceState({
+                count: 1,
+                waitForPeers: [0, 1, 2],
+                waitForFinalization: false
+            });
+            await h.event.waitForPeers("onBlockCalldataPosted", [0, 1, 2], 1, {
+                mode: "atLeast",
+                timeoutMs: 25000
+            });
+            await h
+                .control(h.getPeer(3))
+                .stub.restoreRejectIngestedConfirmations()
+                .request();
+            const forkId = h.activeForkId!;
+            for (const i of [0, 1, 2, 3]) {
+                await h.rpcStub.holdReductionRace(i);
+            }
+
+            // too-early clock for coords height 2 is block 1
+            const block1 = await h
+                .control(h.getPeer(1))
+                .query.getBlockByHeight(forkId, 1)
+                .request();
+            const wait = timeoutWaitTime(
+                resolveTestTimeConfig({ evidenceTime: 8 }),
+                2
+            );
+            await h.event.waitUntilTimestamp(block1!.timestamp + wait + 1);
+            await h.control(h.getPeer(2)).dispute.setForceExit(true).request();
+            await h.tamper.postTamperedDispute(2, () => {}, {
+                markMalicious: false
+            });
+
+            // peer 3's proof stops at height 1, blaming the calldata author
+            await h.tamper.plantFreshTimeoutForParticipant(
+                3,
+                calldataAuthor.address
+            );
+            const { dispute } = await h.dispute.fetchConstructedDispute(3);
+            expect(Number(dispute.input.timeout.blockHeight)).to.equal(2);
+            expect(dispute.postedAuditingData).to.equal(false);
+            dispute.input.timeout.isForced = true; // same deviation the e2e posts
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.TimeoutCalldataPosted
+            );
+            expect(run.storedProof?.proofParticipant).to.equal(
+                h.getPeer(3).address
+            );
+        });
+
+        it("stale local previousBlockCalldata -> validateTimeoutCalldataPostedProof false, audit continues without TimeoutCalldataPosted", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.timeoutSetup(4, 0, {
+                timeConfig: { evidenceTime: 8 }
+            });
+            await h.transition.advanceState({ count: 2 });
+            const calldataAuthor = await h.query.getNextPeerToWrite();
+            await h
+                .control(h.getPeer(3))
+                .stub.stubRejectIngestedConfirmations()
+                .request();
+            await Promise.all(
+                [0, 1, 2, 3].map((i) => h.rpcStub.suppressTimeoutCheck(i))
+            );
+            await h.network.disconnectPeer(3);
+            await h.transition.advanceState({
+                count: 1,
+                waitForPeers: [0, 1, 2],
+                waitForFinalization: false
+            });
+            await h.event.waitForPeers("onBlockCalldataPosted", [0, 1, 2], 1, {
+                mode: "atLeast",
+                timeoutMs: 25000
+            });
+            await h
+                .control(h.getPeer(3))
+                .stub.restoreRejectIngestedConfirmations()
+                .request();
+            const forkId = h.activeForkId!;
+            for (const i of [0, 1, 2, 3]) {
+                await h.rpcStub.holdReductionRace(i);
+            }
+
+            const block1 = await h
+                .control(h.getPeer(1))
+                .query.getBlockByHeight(forkId, 1)
+                .request();
+            const wait = timeoutWaitTime(
+                resolveTestTimeConfig({ evidenceTime: 8 }),
+                2
+            );
+            await h.event.waitUntilTimestamp(block1!.timestamp + wait + 1);
+            await h.control(h.getPeer(2)).dispute.setForceExit(true).request();
+            await h.tamper.postTamperedDispute(2, () => {}, {
+                markMalicious: false
+            });
+
+            await h.tamper.plantFreshTimeoutForParticipant(
+                3,
+                calldataAuthor.address
+            );
+            const { dispute } = await h.dispute.fetchConstructedDispute(3);
+            expect(Number(dispute.input.timeout.blockHeight)).to.equal(2);
+
+            // stale previous-block calldata on the auditor: its proof claims
+            // timestamp 1 while the chain commitment carries the real one ->
+            // the preflight commitment compare rejects the proof
+            await h.control(h.getPeer(1)).stub.stubCalldataPosting().request();
+            await h
+                .control(h.getPeer(1))
+                .stub.stageBlockCalldata(block1!.encodedSignedBlock, 1)
+                .request();
+            // only the block author may post its calldata on-chain
+            const block1Author = h.peers.find(
+                (p) => p.address === block1!.author
+            )!;
+            await h
+                .control(block1Author)
+                .stub.postBlockCalldataOnChain(block1!.encodedSignedBlock)
+                .request();
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run).to.include({ outcome: "returned", isValid: true });
+            expect(run.storedProof).to.equal(undefined);
+        });
+
+        it("timeout dispute audited before the window reaches the local chain view -> throw", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 2);
+            for (const peer of h.peers) {
+                await h.rpcStub.suppressTimeoutCheck(peer.index);
+            }
+            // a planted, untampered timeout passes the linkage and next-writer
+            // checks, so the audit reaches getDisputeWindowCreationTimestamp.
+            // throwing is correct: the only caller applies the commit to the
+            // local diamond first (EventHandler.onDisputeCommitted), so a zero
+            // window means local dispute state is corrupt, not a peer race
+            await h.tamper.plantFreshTimeoutForNextWriter(0);
+            const { dispute } = await h.dispute.fetchConstructedDispute(0);
+
+            const run = await h.dispute.auditDispute(1, dispute);
+            expect(run.outcome).to.equal("threw");
+            expect(run.outcome === "threw" ? run.threwMessage : "").to.contain(
+                "Timeout timestamp not found"
+            );
+        });
+    });
+
+    describe("race", function () {
+        it("fork advances while the audit is parked at getOnChainSlashedParticipants -> false + DisputeNotLatestState", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 3);
+            const forkId = h.activeForkId!;
+            await h.control(h.getPeer(0)).dispute.setForceExit(true).request();
+            const { dispute, auditingData } =
+                await h.dispute.fetchConstructedDispute(0);
+            const snapshotHeight = Number(
+                auditingData.latestStateSnapshot.blockHeight
+            );
+
+            await h
+                .control(h.getPeer(1))
+                .stub.stubHoldOnChainSlashesQuery()
+                .request();
+            const auditPromise = h.dispute.auditDispute(1, dispute);
+            await h
+                .control(h.getPeer(1))
+                .stub.waitForHeldOnChainSlashesQuery()
+                .request({ timeoutMs: 15000 });
+
+            // real state moves while the audit is parked mid-flight
+            await h.transition.advanceState({ count: 2 });
+            const disputer = h.getPeer(0).address;
+            const seen = await h.execOnHost(
+                h.getPeer(1),
+                async (sm, args) => {
+                    const result =
+                        sm.agreementManager.getLatestSignedBlockByParticipant(
+                            args.forkId,
+                            args.disputer
+                        );
+                    return { height: result ? result.block.height : -1 };
+                },
+                { forkId, disputer }
+            );
+            expect(seen.height).to.be.greaterThan(snapshotHeight);
+
+            await h
+                .control(h.getPeer(1))
+                .stub.restoreOnChainSlashesQuery()
+                .request();
+            const run = await auditPromise;
+
+            // the disputer signed above its own dispute snapshot while the
+            // audit was parked, so the dispute is no longer the latest state
+            // and the evidence (its own newer signed block) is genuine
+            expect(run).to.include({ outcome: "returned", isValid: false });
+            expect(run.storedProof?.disputeFraudProofType).to.equal(
+                DisputeFraudProofType.DisputeNotLatestState
+            );
+            const evidence = Codec.decode(
+                run.storedProof!.encodedProof,
+                DisputeFraudProofType.DisputeNotLatestState
+            );
+            const newerBlock = Codec.decode(evidence.encodedBlock, Type.Block);
+            expect(
+                Number(newerBlock.transaction.header.transactionCnt)
+            ).to.equal(seen.height);
         });
     });
 });


### PR DESCRIPTION
unit suite for `DisputeValidationService`, plus the bugs writing it turned up. stacked on #415.

**the attack**

`uploadDispute` doesn't validate `dispute.input.latestInboundMessageBlockHash`. the auditor walks the inbound chain *forward* from the pinned snapshot's inbound head, so a value sitting *behind* that head can never be reached -> the walk runs off the end and the audit throws.

the throw escapes `onDisputeCommitted` into `EventSyncService`, which then never moves the peer past that log -> it stops processing chain events entirely. one cheap dispute, one permanently disabled honest peer. same shape on the non-calldata path via an undecodable block in the state proof.

**fixes**

- new `DisputeInboundAnchorBehindLatestState` fraud proof -> the unreachable case is provable on chain, so the auditor kills the dispute instead of throwing. `pure` predicate in `DisputeUtils.sol`, handler in `DisputeFraudProofFacet`, `LocalDiamond` forwarder
- undecodable block on the non-calldata path fires a real proof instead of abstaining
- `latestFinalizedStateStateMachineState` is disputer-authored and `verifyStateProof` never binds it, but it was stored under the *finalized snapshot's* `stateMachineStateHash` -> forged bytes came back as that snapshot's state on every later read. now keyed by its own `keccak256`
- block ingest records the inbound blocks it already proved authentic, once the block is committed -> previously only the chain event wrote `inboundMessages`, so a peer's store could lag a snapshot it had already validated
- `MessageBlockStorage.headNotBehind` is now the single owner of "local head, or the snapshot's own head while the store lags it". `constructDispute` uses it for the value it states and for the bound it hands `getAuditingData` - the bound every auditor recomputes with - and `BlockProductionService` uses it instead of walking from a head below the snapshot

**tests**

- `test/unit/DisputeValidationService.test.ts` - the suite this PR set out to write
- `test/unit/DisputeManager.test.ts`, `test/unit/BlockIngestService.test.ts` - inbound-head and ingest cases
- e2e: the proof firing on a tampered dispute, and the tripwire that an honest peer with a lagging inbound event is neither killed nor slashed
