### PR TITLE
don't let a missing inbound event evict or false-accuse an honest peer

### DIFF
--- a/src/agreementManager/AgreementManager.ts
+++ b/src/agreementManager/AgreementManager.ts
@@ -15,6 +15,7 @@ import { Codec, difference, Logger, Type } from "@/utils";
 import { ZeroHash } from "ethers";
 import { ReduceData } from "@/types";
 import { LoggerUtils } from "@/utils/LoggerUtils";
+import type EventSyncService from "@/stateManager/eventSync/EventSyncService";
 
 /**
  * AgreementManager acts as a higher logic layer over storage
@@ -23,6 +24,7 @@ import { LoggerUtils } from "@/utils/LoggerUtils";
 class AgreementManager {
     constructor(
         private storage: Storage,
+        private eventSyncService: EventSyncService,
         private logger: Logger
     ) {
         this.logger = logger.child({ component: "AgreementManager" });
@@ -364,7 +366,7 @@ class AgreementManager {
     public async getReduceData(
         forkId: ForkId,
         reducedOutput: ReduceOutputStruct
-    ): Promise<ReduceData> {
+    ): Promise<ReduceData | undefined> {
         // reducedOutput latestStateSnapshot
         this.logger.debug(
             "ReduceOutput",
@@ -405,12 +407,25 @@ class AgreementManager {
                 "Missing latestEncodedState for reducedOutput in storage for syncing"
             );
 
+        // the run the chain applied in its reduce. we cannot invent blocks whose
+        // log never reached us -> no reduce data yet, and the caller retries
         const inboundMessageBlocksAppliedInReduce =
-            this.storage.inboundMessages.getMessageBlocksInRange({
-                upperBlockHash: reducedOutput.latestInboundMessageBlockHash,
-                lowerBlockHash:
+            await this.eventSyncService.loadSynchronizedInboundRun(
+                reducedOutput.latestInboundMessageBlockHash as Hash,
+                reducedLatestStateSnapshot.latestInboundMessageBlockHash,
+                reducedLatestStateSnapshot.timestamp
+            );
+        if (!inboundMessageBlocksAppliedInReduce) {
+            this.logger.warn("No reduce data: inbound run unavailable", {
+                forkId,
+                reducedOutput:
+                    LoggerUtils.getReducedOutputMetadata(reducedOutput),
+                snapshotInboundHash: String(
                     reducedLatestStateSnapshot.latestInboundMessageBlockHash
+                )
             });
+            return undefined;
+        }
         return {
             forkId: forkId,
             reducedOutput: reducedOutput,

--- a/src/disputeManager/DisputeManager.ts
+++ b/src/disputeManager/DisputeManager.ts
@@ -33,7 +33,11 @@ import {
 } from "@typechain-types/contracts/V1/types/DisputeTypes";
 import { BytesLike } from "ethers";
 import { config } from "@/utils/config";
-import { SnapshotDataStruct } from "@typechain-types/contracts/V1/types/DataTypes";
+import {
+    MessageBlockStruct,
+    SnapshotDataStruct
+} from "@typechain-types/contracts/V1/types/DataTypes";
+import type EventSyncService from "@/stateManager/eventSync/EventSyncService";
 
 export type ConstructDisputeResult = {
     dispute: DisputeStruct;
@@ -41,6 +45,10 @@ export type ConstructDisputeResult = {
     auditingData: DisputeAuditingDataStruct;
     fraudProofsToApply: FraudProofStruct[];
 };
+
+// our own auditing data could not be rebuilt whole - our missing history, not
+// anyone's fraud. named so callers can tell it from a real construction failure
+export class PartialAuditingDataError extends Error {}
 
 // Right-sized from 5M: the dispute upload measures ~0.5M in e2e; 2.5M keeps
 // generous headroom for larger disputes while freeing block gas under concurrency.
@@ -56,6 +64,7 @@ class DisputeManager {
     storage: Storage;
     diamondStateMachine: ADiamondStateMachine;
     mutex: Mutex;
+    private eventSyncService: EventSyncService;
     private logger: Logger;
 
     constructor(
@@ -67,6 +76,7 @@ class DisputeManager {
         p2pEventHooks: P2pEventHooks,
         storage: Storage,
         diamondStateMachine: ADiamondStateMachine,
+        eventSyncService: EventSyncService,
         logger: Logger
     ) {
         this.channelId = channelId;
@@ -77,6 +87,7 @@ class DisputeManager {
         this.p2pEventHooks = p2pEventHooks;
         this.storage = storage;
         this.diamondStateMachine = diamondStateMachine;
+        this.eventSyncService = eventSyncService;
         this.logger = logger.child({ component: "DisputeManager" });
         this.mutex = new Mutex(
             this.logger.child({ component: "DisputeManager:Mutex" })
@@ -394,13 +405,15 @@ class DisputeManager {
         );
 
         // the bound every auditor recomputes with
-        const { isPartial, auditingData } = this.getAuditingData(
+        const { isPartial, auditingData } = await this.getAuditingData(
             forkId,
             stateProof,
             { disputeLatestInboundMessageBlockHash: inboundHead.hash }
         );
         if (isPartial)
-            throw new Error("createDispute - isPartial auditingData");
+            throw new PartialAuditingDataError(
+                "createDispute - isPartial auditingData"
+            );
 
         const disputeAuditingDataHash = hash(
             Codec.encode(auditingData, Type.DisputeAuditingData)
@@ -498,13 +511,16 @@ class DisputeManager {
         };
     }
 
-    public getAuditingData(
+    public async getAuditingData(
         forkId: ForkId,
         stateProof: StateProofStruct,
         options?: {
             disputeLatestInboundMessageBlockHash?: Hash;
         }
-    ): { isPartial: boolean; auditingData: DisputeAuditingDataStruct } {
+    ): Promise<{
+        isPartial: boolean;
+        auditingData: DisputeAuditingDataStruct;
+    }> {
         let isPartial = false;
         // genesisStateSnapshot
         const genesisStateSnapshot =
@@ -555,14 +571,26 @@ class DisputeManager {
             latestFinalizedStateStateMachineState = ""; // not needed for verifyStateProof and if the dispute is honest, we'll catchup and have it later
         }
 
-        // inbound message blocks
-        const inboundMessageBlocks =
-            this.storage.inboundMessages.getMessageBlocksInRange({
-                upperBlockHash: options?.disputeLatestInboundMessageBlockHash,
-                lowerBlockHash:
-                    latestStateSnapshot.snapshotData
-                        .latestInboundMessageBlockHash
-            });
+        // the run the dispute names, recovering a log that never reached us. an
+        // auditor cannot rebuild what it never received -> partial, not a throw
+        const upperBlockHash =
+            options?.disputeLatestInboundMessageBlockHash ??
+            this.storage.inboundMessages.getLatestBlockHash();
+        let inboundMessageBlocks: MessageBlockStruct[] = [];
+        // an already-partial rebuild substituted the genesis snapshot above, so
+        // the bounds below are wrong and every consumer discards the result ->
+        // don't spend the widest possible getLogs on it
+        if (upperBlockHash && !isPartial) {
+            const run = await this.eventSyncService.loadSynchronizedInboundRun(
+                upperBlockHash,
+                latestStateSnapshot.snapshotData
+                    .latestInboundMessageBlockHash as Hash,
+                latestStateSnapshot.timestamp,
+                this.channelId
+            );
+            if (run) inboundMessageBlocks = run;
+            else isPartial = true;
+        }
 
         // outbound message blocks
         const outboundMessageBlocks =
@@ -584,7 +612,7 @@ class DisputeManager {
                 milestoneSnapshots: milestoneSnapshots.map((snapshot) =>
                     snapshot.toStruct()
                 ),
-                inboundMessageBlocks: inboundMessageBlocks ?? [],
+                inboundMessageBlocks,
                 outboundMessageBlocks: outboundMessageBlocks
             }
         };

--- a/src/eventHandlers/EventHandler.ts
+++ b/src/eventHandlers/EventHandler.ts
@@ -37,6 +37,7 @@ import P2pEventHooksUtils from "@/utils/P2pEventHooksUtils";
 import { isEqual } from "lodash";
 import CalldataCommittedStrategy from "@/stateManager/validationStrategy/CalldataCommittedStrategy";
 import type { ReductionGenesis } from "@/stateManager/reduction";
+import { PartialAuditingDataError } from "@/disputeManager/DisputeManager";
 import { Status } from "@/types";
 import { Block, StateSnapshot } from "@/models";
 
@@ -382,7 +383,7 @@ export class EventHandler {
             try {
                 if (!disputeAuditingData) {
                     const { isPartial, auditingData } =
-                        this.stateManager.disputeManager.getAuditingData(
+                        await this.stateManager.disputeManager.getAuditingData(
                             forkId,
                             dispute.input.stateProof,
                             {
@@ -391,9 +392,21 @@ export class EventHandler {
                             }
                         );
                     if (isPartial) {
-                        throw new Error(
-                            "DisputeAuditingData not available on a final dispute"
+                        // cannot rebuild the final dispute's data yet. the
+                        // confirmation is already stored, so the ordinary reduce
+                        // path picks the window up with this dispute in it and
+                        // derives the same result
+                        this.logger.warn(
+                            "Final dispute genesis deferred: auditing data could not be rebuilt locally",
+                            { channelId, forkId, dispute: disputeMeta }
                         );
+                        this.stateManager.reductionManager.schedule(
+                            forkId,
+                            Number(disputeCreationTimestamp) +
+                                this.stateManager.timeConfig.chainFallbackTime,
+                            true
+                        );
+                        return;
                     }
                     disputeAuditingData = auditingData;
                 }
@@ -485,7 +498,7 @@ export class EventHandler {
             if (!persistableAuditingData) {
                 try {
                     const derived =
-                        this.stateManager.disputeManager.getAuditingData(
+                        await this.stateManager.disputeManager.getAuditingData(
                             forkId,
                             dispute.input.stateProof,
                             {
@@ -611,10 +624,27 @@ export class EventHandler {
         dispute: DisputeStruct
     ): Promise<boolean> {
         // Create our own dispute
-        const { dispute: ourDispute } =
-            await this.stateManager.disputeManager.constructDispute(
-                this.stateManager.forkId
+        let ourDispute: DisputeStruct;
+        try {
+            ourDispute = (
+                await this.stateManager.disputeManager.constructDispute(
+                    this.stateManager.forkId
+                )
+            ).dispute;
+        } catch (error) {
+            if (!(error instanceof PartialAuditingDataError)) throw error;
+            // we cannot rebuild our own auditing data -> we have no more
+            // evidence to give. the caller falls through to scheduling the
+            // reduction instead of dying on the throw
+            this.logger.warn(
+                "No more evidence: own auditing data could not be rebuilt locally",
+                {
+                    forkId: this.stateManager.forkId,
+                    dispute: LoggerUtils.getDisputeMetadata(dispute)
+                }
             );
+            return false;
+        }
 
         this.logger.verbose("Constructed our own dispute for comparison", {
             ourDispute: LoggerUtils.getDisputeMetadata(ourDispute),
@@ -895,6 +925,17 @@ export class EventHandler {
             await this.stateManager.reductionManager.getSyncedForkDisputes(
                 forkId
             );
+        if (!disputes) {
+            // the window's disputes are on-chain but not locally readable yet,
+            // so we are in no position to challenge it. `true` follows the
+            // chain instead, the same path a peer takes for a reduction it
+            // agrees with
+            this.logger.warn(
+                "Dispute reduction not challenged: dispute window unavailable",
+                { forkId, reducedForkId }
+            );
+            return true;
+        }
         if (disputes.length === 0) {
             // The commitments for this fork are no longer available locally:
             // the reduction was already consumed (finalized and applied) or
@@ -915,6 +956,16 @@ export class EventHandler {
                 forkId,
                 disputes
             );
+        if (!computation) {
+            // we cannot rebuild the run this reduction consumed -> we are in no
+            // position to challenge it. `true` follows the chain instead, the
+            // same path a peer takes for a reduction it agrees with
+            this.logger.warn(
+                "Dispute reduction not challenged: reduce data unavailable",
+                { forkId, reducedForkId }
+            );
+            return true;
+        }
         const { reduceData } = computation;
         const latestSnapshot = reduceData.latestStateSnapshot;
         const isValid = computation.reducedForkId == reducedForkId;

--- a/src/rpc/services/spectate/SpectateService.ts
+++ b/src/rpc/services/spectate/SpectateService.ts
@@ -506,6 +506,16 @@ class SpectateService extends ARpcService<SpectateServiceRpcMethods> {
                     channelId,
                     currentForkId
                 );
+            if (!currentWindowCommitments) {
+                // the window's disputes are on-chain but not locally readable
+                // yet, so we cannot prove the tip -> refuse to serve rather
+                // than serve a proof we could not build
+                this.logger.warn(
+                    "generateSyncPayload - dispute window unavailable",
+                    { channelId, forkId: currentForkId }
+                );
+                return undefined;
+            }
             const currentWindowDisputeConfirmations =
                 agreementManager.getForkDisputeConfirmations(
                     currentWindowCommitments
@@ -522,6 +532,16 @@ class SpectateService extends ARpcService<SpectateServiceRpcMethods> {
                     currentForkId,
                     currentWindowDisputes
                 );
+            if (!computation) {
+                // we cannot rebuild the run this window's reduce consumed, so we
+                // cannot prove the tip -> refuse to serve rather than serve a
+                // proof we could not build
+                this.logger.warn(
+                    "generateSyncPayload - reduce data unavailable for a disputed window",
+                    { channelId, forkId: currentForkId }
+                );
+                return undefined;
+            }
             const { reduceData, reducedForkId } = computation;
 
             // Move to the next fork using local EVM

--- a/src/stateManager/StateManager.ts
+++ b/src/stateManager/StateManager.ts
@@ -179,7 +179,11 @@ class StateManager<
             this.eventSyncService,
             logger
         );
-        this.agreementManager = new AgreementManager(this.storage, this.logger);
+        this.agreementManager = new AgreementManager(
+            this.storage,
+            this.eventSyncService,
+            this.logger
+        );
         this.disputeManager = new DisputeManager(
             this.channelId,
             signer,
@@ -189,6 +193,7 @@ class StateManager<
             this.p2pEventHooks,
             this.storage,
             this.diamondStateMachine,
+            this.eventSyncService,
             logger
         );
         this.p2pManager = new P2PManager<TCustomRpc>(

--- a/src/stateManager/block/BlockProductionService.ts
+++ b/src/stateManager/block/BlockProductionService.ts
@@ -156,12 +156,31 @@ export default class BlockProductionService {
             return [];
         }
 
-        return this.stateManager.storage.inboundMessages.getMessageBlocksInRange(
-            {
-                upperBlockHash: head.hash,
-                lowerBlockHash: previousHash ?? ethers.ZeroHash
-            }
-        );
+        const run =
+            this.stateManager.storage.inboundMessages.tryGetMessageBlocksInRange(
+                {
+                    upperBlockHash: head.hash,
+                    lowerBlockHash: previousHash ?? ethers.ZeroHash
+                }
+            );
+        if (run.missingBlockHash) {
+            // our head sits above an inbound log we never received. a truncated
+            // run is not anchored to the snapshot -> carry none, the next block
+            // picks them up once the log lands
+            this.logger.warn(
+                "Inbound run incomplete; producing without pending inbound messages",
+                {
+                    inboundRun: LoggerUtils.getInboundRunMetadata({
+                        upperBlockHash: head.hash,
+                        lowerBlockHash: previousHash ?? ethers.ZeroHash,
+                        blocks: run.blocks,
+                        missingBlockHash: run.missingBlockHash
+                    })
+                }
+            );
+            return [];
+        }
+        return run.blocks;
     }
 
     private async logPlayTransaction(tx: TransactionStruct): Promise<string> {

--- a/src/stateManager/chainFallback/ParticipantTimeoutService.ts
+++ b/src/stateManager/chainFallback/ParticipantTimeoutService.ts
@@ -234,7 +234,9 @@ export default class ParticipantTimeoutService {
                 blockHeight,
                 participantAddress
             );
-        if (recovery.validationScheduled) {
+        // calldata in hand without a query means the pipeline is already in
+        // flight -> re-check, never time out a participant who did post
+        if (recovery.validationScheduled || recovery.blockCalldata) {
             this.logger.info(
                 "tryTimeoutParticipant - waiting for current on-chain block validation",
                 {

--- a/src/stateManager/dispute/DisputeValidationService.ts
+++ b/src/stateManager/dispute/DisputeValidationService.ts
@@ -329,9 +329,8 @@ export default class DisputeValidationService {
     ): Promise<boolean> {
         const isValid = true;
 
-        //TODO - quick hack, but the stuff we need SHOULD actually be available
-        const { auditingData: disputeAuditingData } =
-            this.disputeManager.getAuditingData(
+        const { isPartial, auditingData: disputeAuditingData } =
+            await this.disputeManager.getAuditingData(
                 dispute.input.forkId,
                 dispute.input.stateProof,
                 {
@@ -339,6 +338,21 @@ export default class DisputeValidationService {
                         dispute.input.latestInboundMessageBlockHash
                 }
             );
+        if (isPartial) {
+            // we could not rebuild the data this dispute needs - our own missing
+            // history, not the disputer's fraud. abstain: other auditors still
+            // challenge, and a proof built on substituted data would slash an
+            // honest peer
+            this.logger.warn(
+                "Skipping dispute audit: auditing data could not be rebuilt locally",
+                {
+                    dispute: LoggerUtils.getDisputeMetadata(dispute),
+                    auditingData:
+                        LoggerUtils.getAuditingMetadata(disputeAuditingData)
+                }
+            );
+            return true;
+        }
         // TODO move this check above and into its own fraud proof
         if (!dispute.postedAuditingData) {
             const isCorrectLatestState =

--- a/src/stateManager/eventSync/EventSyncService.ts
+++ b/src/stateManager/eventSync/EventSyncService.ts
@@ -1,5 +1,6 @@
 import { StateChannelManagerProxy } from "@typechain-types";
-import { Filter, Log, hexlify, zeroPadValue } from "ethers";
+import { MessageBlockStruct } from "@typechain-types/contracts/V1/types/DataTypes";
+import { BytesLike, Filter, Log, Result, hexlify, zeroPadValue } from "ethers";
 
 import Clock from "@/Clock";
 import { EventHandler } from "@/eventHandlers/EventHandler";
@@ -11,16 +12,30 @@ import {
     BlockHeight,
     ChannelId,
     ForkId,
-    Hash
+    Hash,
+    Timestamp
 } from "@/types/types";
-import { convertEthersValue, DetachedPromises, hash, Logger } from "@/utils";
+import {
+    Codec,
+    convertEthersValue,
+    DetachedPromises,
+    hash,
+    Logger,
+    Type
+} from "@/utils";
+import { LoggerUtils } from "@/utils/LoggerUtils";
 
-type BlockState = { pending: number; complete: boolean; failed: boolean };
+type BlockState = {
+    pending: number;
+    complete: boolean;
+    failedEventKeys: Set<EventKey>;
+};
 type OnChainBlockValidationKey = string;
 type EventKey = string;
 type ChannelKey = string;
 type BlockNumber = number;
-type NormalizedDisputeCommitment = string;
+/** A dispute commitment lowercased, so hash comparisons are case-stable. */
+export type NormalizedDisputeCommitment = string;
 type EventPromise = Promise<void>;
 export type BlockCalldataRecoveryResult = {
     blockCalldata?: BlockCalldata;
@@ -47,6 +62,10 @@ const STATE_CHANNEL_MANAGER_EVENT_NAME_SET =
     new Set<SupportedStateChannelManagerEventName>(
         STATE_CHANNEL_MANAGER_EVENT_NAMES
     );
+// widening getLogs spans a log recovery tries before giving up
+const LOG_RECOVERY_ATTEMPTS = 3;
+// one span already covers the whole window the calldata can be in
+const CALLDATA_RECOVERY_ATTEMPTS = 1;
 
 export default class EventSyncService {
     /** Calldata recoveries currently querying or scheduling validation. */
@@ -93,15 +112,10 @@ export default class EventSyncService {
     }
 
     getSubscriptionFilter(channelId: ChannelId): Filter {
-        const topics = STATE_CHANNEL_MANAGER_EVENT_NAMES.map(
-            (name) =>
-                this.stateChannelManagerContract.interface.getEvent(name)!
-                    .topicHash
+        return this.buildLogFilter(
+            STATE_CHANNEL_MANAGER_EVENT_NAMES,
+            channelId
         );
-        return {
-            address: String(this.stateChannelManagerContract.target),
-            topics: [topics, zeroPadValue(hexlify(channelId), 32)]
-        };
     }
 
     scheduleLog(
@@ -117,18 +131,24 @@ export default class EventSyncService {
         const state = states.get(log.blockNumber) ?? {
             pending: 0,
             complete: false,
-            failed: false
+            failedEventKeys: new Set<EventKey>()
         };
         state.pending += 1;
         state.complete = false;
         states.set(log.blockNumber, state);
 
-        // A log executes atomically: it either completes or throws. A throw is
-        // fatal - the rejected promise stays cached so the log is never
-        // re-dispatched, and its block never completes so the watermark holds.
+        // A log executes atomically. A failure is retryable: the rejected
+        // promise is dropped so a later recovery can re-dispatch the same log,
+        // and the block stays incomplete - the watermark holds - until every
+        // log in it succeeded.
         const promise = this.dispatchLog(log, scheduledChannelId)
+            .then(() => {
+                state.failedEventKeys.delete(eventKey);
+            })
             .catch((error) => {
-                state.failed = true;
+                state.failedEventKeys.add(eventKey);
+                this.eventPromises.delete(eventKey);
+                this.eventBlockNumbers.delete(eventKey);
                 this.logger.error("Contract event pipeline failed", {
                     blockNumber: log.blockNumber,
                     logIndex: log.index,
@@ -139,7 +159,8 @@ export default class EventSyncService {
             })
             .finally(() => {
                 state.pending -= 1;
-                state.complete = state.pending === 0 && !state.failed;
+                state.complete =
+                    state.pending === 0 && state.failedEventKeys.size === 0;
                 this.publishCompletedBlocks(scheduledChannelId, channelKey);
             });
         this.eventPromises.set(eventKey, promise);
@@ -181,19 +202,211 @@ export default class EventSyncService {
      * The fork's dispute window as the chain has it, with any commitment whose
      * event hasn't reached us yet recovered before we return. Single owner for
      * both the reduce path and spectate requests, so neither reads a window
-     * its local storage can't back.
+     * its local storage can't back. `undefined` when a commitment's dispute
+     * survives recovery - the window is not locally readable yet.
      */
     async loadSynchronizedWindowCommitments(
         channelId: ChannelId,
         forkId: ForkId
-    ): Promise<readonly Hash[]> {
+    ): Promise<readonly Hash[] | undefined> {
         const commitments =
             await this.stateChannelManagerContract.getWindowCommitments(
                 channelId,
                 forkId
             );
-        await this.ensureDisputesProcessed(channelId, forkId, commitments);
+        const missing = await this.ensureDisputesProcessed(
+            channelId,
+            forkId,
+            commitments
+        );
+        if (missing.size > 0) {
+            // we cannot invent a dispute whose log never reached us -> the
+            // window is not locally readable yet, and the caller retries. never
+            // a throw: a throw here reaches `abort()` through
+            // `getSyncedForkDisputes`
+            this.logger.warn("Disputes unavailable after event recovery", {
+                channelId,
+                disputeWindow: LoggerUtils.getDisputeWindowMetadata({
+                    forkId,
+                    commitments,
+                    missingCommitments: [...missing]
+                })
+            });
+            return undefined;
+        }
         return commitments;
+    }
+
+    /**
+     * The inbound run (lowerBlockHash, upperBlockHash] as local storage has it,
+     * with any InboundMessagesProcessed log that never reached us recovered
+     * first. `undefined` when the gap survives recovery. Single owner for the
+     * audit and reduce paths, so neither walks into a storage gap.
+     *
+     * Never throws - a failed chain read is a failed attempt. A throw here
+     * would reach `abort()` through `getReduceData` -> `tryReduce`.
+     */
+    async loadSynchronizedInboundRun(
+        upperBlockHash: Hash,
+        lowerBlockHash: Hash,
+        notBefore: Timestamp,
+        channelId: ChannelId = this.channelId
+    ): Promise<MessageBlockStruct[] | undefined> {
+        // the honest path holds the whole run -> no chain call at all
+        let run = this.storage.inboundMessages.tryGetMessageBlocksInRange({
+            upperBlockHash,
+            lowerBlockHash
+        });
+        if (!run.missingBlockHash) return run.blocks;
+
+        const latest = await this.tryGetBlockchainTime();
+        if (latest) {
+            // notBefore is the on-chain timestamp of the snapshot that owns
+            // lowerBlockHash, so every block of the needed run was appended
+            // at or after it -> the span covers them
+            const recovery = await this.recoverLogsUntil({
+                channelId,
+                eventNames: ["InboundMessagesProcessed"],
+                toBlock: latest.blockNumber,
+                span: this.getBlockSpan(latest.timestamp - notBefore),
+                attempts: LOG_RECOVERY_ATTEMPTS,
+                dispatch: "awaited",
+                probe: () =>
+                    this.storage.inboundMessages.tryGetMessageBlocksInRange({
+                        upperBlockHash,
+                        lowerBlockHash
+                    }),
+                isRecovered: (held) => !held.missingBlockHash,
+                // only the blocks we do not hold: re-dispatching an applied log
+                // is pointless work, and that filter is what makes recovery
+                // terminate
+                isMissingLog: (args) =>
+                    !this.storage.inboundMessages.getMessageBlock(
+                        hash(Codec.encode(args.messageBlock, Type.MessageBlock))
+                    )
+            });
+            run = recovery.held;
+        }
+
+        if (!run.missingBlockHash) return run.blocks;
+        this.logger.warn("Inbound run unavailable after event recovery", {
+            channelId,
+            inboundRun: LoggerUtils.getInboundRunMetadata({
+                upperBlockHash,
+                lowerBlockHash,
+                blocks: run.blocks,
+                missingBlockHash: run.missingBlockHash
+            })
+        });
+        return undefined;
+    }
+
+    /**
+     * One widening getLogs recovery: query the channel's `eventNames` logs,
+     * dispatch the ones the caller is still missing, re-probe, widen, repeat.
+     * Every attempt is contained - a failed chain read or a rejected
+     * re-dispatch is a failed attempt, never a throw, because a throw out of a
+     * recovery reaches `abort()` through the reduce path. Exhaustion is the
+     * caller's outcome: it branches on `isRecovered`.
+     */
+    private async recoverLogsUntil<THeld>(recovery: {
+        channelId: ChannelId;
+        eventNames: readonly SupportedStateChannelManagerEventName[];
+        /** indexed topic values after channelId, e.g. a calldata commitment */
+        indexedTopics?: readonly BytesLike[];
+        /** newest chain block every attempt queries up to */
+        toBlock: BlockNumber;
+        /** blocks back from `toBlock` the first attempt queries; doubles after each */
+        span: number;
+        attempts: number;
+        /** "detached" for a caller that must not await the dispatched pipeline */
+        dispatch: "awaited" | "detached";
+        /** what local storage holds right now */
+        probe: () => THeld;
+        isRecovered: (held: THeld) => boolean;
+        /**
+         * which queried logs are still worth dispatching; all of them when
+         * omitted. `args` arrives normalized - `isLogMissing` applies
+         * `convertEthersValue` before invoking, like both scans do today.
+         */
+        isMissingLog?: (args: Result, held: THeld) => boolean;
+    }): Promise<{
+        held: THeld;
+        isRecovered: boolean;
+        scheduledLogCount: number;
+    }> {
+        const isMissingLog = recovery.isMissingLog;
+        let held = recovery.probe();
+        let span = recovery.span;
+        let scheduledLogCount = 0;
+        for (
+            let attempt = 0;
+            attempt < recovery.attempts && !recovery.isRecovered(held);
+            attempt++
+        ) {
+            const fallback = Math.max(0, recovery.toBlock - span);
+            const cursor = this.storage.eventSync.getLatestProcessedBlock(
+                recovery.channelId
+            );
+            const fromBlock = Math.min(cursor ?? fallback, fallback);
+            try {
+                const logs = await this.getProvider().getLogs({
+                    ...this.buildLogFilter(
+                        recovery.eventNames,
+                        recovery.channelId,
+                        recovery.indexedTopics
+                    ),
+                    fromBlock,
+                    toBlock: recovery.toBlock
+                });
+                const missingLogs = isMissingLog
+                    ? logs.filter((log) =>
+                          this.isLogMissing(log, isMissingLog, held)
+                      )
+                    : logs;
+                scheduledLogCount += missingLogs.length;
+                const dispatched = missingLogs.map((log) =>
+                    this.scheduleLog(log, recovery.channelId)
+                );
+                if (recovery.dispatch === "awaited") {
+                    await Promise.all(dispatched);
+                } else {
+                    dispatched.forEach((eventPromise) =>
+                        DetachedPromises.collect(eventPromise)
+                    );
+                }
+            } catch (error) {
+                this.logger.warn("Contract event recovery query failed", {
+                    channelId: recovery.channelId,
+                    events: recovery.eventNames,
+                    fromBlock,
+                    toBlock: recovery.toBlock,
+                    error
+                });
+            }
+            held = recovery.probe();
+            span *= 2;
+        }
+        return {
+            held,
+            isRecovered: recovery.isRecovered(held),
+            scheduledLogCount
+        };
+    }
+
+    private isLogMissing<THeld>(
+        log: Log,
+        isMissingLog: (args: Result, held: THeld) => boolean,
+        held: THeld
+    ): boolean {
+        const parsed = this.stateChannelManagerContract.interface.parseLog({
+            topics: log.topics,
+            data: log.data
+        });
+        if (!parsed) return false;
+        // parseLog is invoked directly, outside createEthersResultProxy, so
+        // normalize nested Result structs before they reach storage/models.
+        return isMissingLog(convertEthersValue(parsed.args), held);
     }
 
     private async recoverBlockCalldataAndScheduleValidation(
@@ -202,10 +415,11 @@ export default class EventSyncService {
         blockHeight: BlockHeight,
         blockAuthor: Address
     ): Promise<BlockCalldataRecoveryResult> {
+        const channelId = this.channelId;
         try {
             const commitmentResult =
                 await this.stateChannelManagerContract.getBlockCallDataCommitment(
-                    this.channelId,
+                    channelId,
                     forkId,
                     blockHeight,
                     blockAuthor
@@ -214,44 +428,36 @@ export default class EventSyncService {
                 return { validationScheduled: false };
             }
             const commitment = commitmentResult.blockCalldataCommitment;
-            const existing = this.storage.blockCalldata.getBlockCalldata(
-                forkId,
-                blockHeight,
-                blockAuthor
-            );
+            const probe = () =>
+                this.storage.blockCalldata.getBlockCalldata(
+                    forkId,
+                    blockHeight,
+                    blockAuthor
+                );
+            let recovered = probe();
             let validationScheduled = false;
-            if (!existing) {
-                const latest = await this.getProvider().getBlockNumber();
-                const fallback = this.getBlockFallbackFrom(latest, blockHeight);
-                const cursor = this.storage.eventSync.getLatestProcessedBlock(
-                    this.channelId
-                );
-                const fromBlock = Math.min(cursor ?? fallback, fallback);
-                const logs = await this.stateChannelManagerContract.queryFilter(
-                    this.stateChannelManagerContract.filters.BlockCalldataPosted(
-                        this.channelId,
-                        commitment
-                    ),
-                    fromBlock,
-                    latest
-                );
-                const scheduledChannelId = this.channelId;
+            if (!recovered) {
+                const toBlock = await this.getProvider().getBlockNumber();
                 // onBlockCalldataPosted stores before its first await, so the
                 // explicit read below observes calldata without waiting for validation.
-                for (const log of logs) {
-                    const eventPromise = this.scheduleLog(
-                        log,
-                        scheduledChannelId
-                    );
-                    DetachedPromises.collect(eventPromise);
-                    validationScheduled = true;
-                }
+                const recovery = await this.recoverLogsUntil({
+                    channelId,
+                    eventNames: ["BlockCalldataPosted"],
+                    indexedTopics: [commitment],
+                    toBlock,
+                    span: this.getBlockSpan(
+                        timeoutWaitTime(this.timeConfig, blockHeight)
+                    ),
+                    // one span is the whole window the calldata can be in; the
+                    // retry comes from this method's callers, not from here
+                    attempts: CALLDATA_RECOVERY_ATTEMPTS,
+                    dispatch: "detached",
+                    probe,
+                    isRecovered: (held) => held !== undefined
+                });
+                recovered = recovery.held;
+                validationScheduled = recovery.scheduledLogCount > 0;
             }
-            const recovered = this.storage.blockCalldata.getBlockCalldata(
-                forkId,
-                blockHeight,
-                blockAuthor
-            );
             if (!recovered) return { validationScheduled };
             this.processedOnChainBlockValidationKeys.add(validationKey);
             return { blockCalldata: recovered, validationScheduled };
@@ -261,91 +467,91 @@ export default class EventSyncService {
         }
     }
 
+    /** Commitments of the window whose dispute local storage still lacks. */
     private async ensureDisputesProcessed(
         channelId: ChannelId,
         forkId: ForkId,
         commitments: readonly Hash[]
-    ): Promise<void> {
-        let missing = commitments.filter(
-            (commitment) => !this.storage.disputes.getDispute(commitment)
-        );
-        if (missing.length === 0) return;
-        const [windowCreationTimestamp, latest] = await Promise.all([
-            this.stateChannelManagerContract.getDisputeWindowCreationTimestamp(
-                channelId,
-                forkId
-            ),
-            Clock.getBlockchainTime()
-        ]);
-        const average = Clock.getAverageOnChainBlockTime();
-        const elapsed = Math.max(
-            0,
-            latest.timestamp - Number(windowCreationTimestamp)
-        );
-        let span =
-            Math.ceil((average > 0 ? elapsed / average : elapsed) * 1.5) + 2;
-        for (let attempt = 0; attempt < 3 && missing.length > 0; attempt++) {
-            const fallback = Math.max(0, latest.blockNumber - span);
-            const cursor =
-                this.storage.eventSync.getLatestProcessedBlock(channelId);
-            const fromBlock = Math.min(cursor ?? fallback, fallback);
-            await this.queryAndProcessDisputeEvents(
-                channelId,
-                fromBlock,
-                latest.blockNumber,
-                new Set(
-                    missing.map((commitment) =>
-                        String(commitment).toLowerCase()
+    ): Promise<ReadonlySet<NormalizedDisputeCommitment>> {
+        const probe = () =>
+            new Set<NormalizedDisputeCommitment>(
+                commitments
+                    .filter(
+                        (commitment) =>
+                            !this.storage.disputes.getDispute(commitment)
                     )
+                    .map((commitment) => String(commitment).toLowerCase())
+            );
+        const missing = probe();
+        if (missing.size === 0) return missing;
+
+        const window = await this.tryGetDisputeWindowSpan(channelId, forkId);
+        if (!window) return missing;
+
+        const recovery = await this.recoverLogsUntil({
+            channelId,
+            eventNames: [
+                "DisputeCommitted",
+                "DisputeCommittedWithAuditingData"
+            ],
+            toBlock: window.latest.blockNumber,
+            span: window.span,
+            attempts: LOG_RECOVERY_ATTEMPTS,
+            dispatch: "awaited",
+            probe,
+            isRecovered: (held) => held.size === 0,
+            isMissingLog: (args, held) =>
+                held.has(
+                    hash(
+                        args.disputeConfirmation.signedDispute.encodedDispute
+                    ).toLowerCase()
                 )
-            );
-            missing = commitments.filter(
-                (commitment) => !this.storage.disputes.getDispute(commitment)
-            );
-            span *= 2;
-        }
-        if (missing.length > 0) {
-            throw new Error(
-                `Disputes unavailable after event recovery: ${missing.join(", ")}`
-            );
+        });
+        return recovery.held;
+    }
+
+    // a failed chain read counts as a failed recovery attempt, never a throw
+    private async tryGetBlockchainTime() {
+        try {
+            return await Clock.getBlockchainTime();
+        } catch (error) {
+            this.logger.warn("Inbound run recovery could not read chain time", {
+                error
+            });
+            return undefined;
         }
     }
 
-    private async queryAndProcessDisputeEvents(
+    // a failed chain read counts as a failed recovery attempt, never a throw
+    private async tryGetDisputeWindowSpan(
         channelId: ChannelId,
-        fromBlock: BlockNumber,
-        toBlock: BlockNumber,
-        missingCommitments: ReadonlySet<NormalizedDisputeCommitment>
-    ): Promise<void> {
-        const topics = [
-            this.stateChannelManagerContract.interface.getEvent(
-                "DisputeCommitted"
-            )!.topicHash,
-            this.stateChannelManagerContract.interface.getEvent(
-                "DisputeCommittedWithAuditingData"
-            )!.topicHash
-        ];
-        const logs = await this.getProvider().getLogs({
-            address: String(this.stateChannelManagerContract.target),
-            topics: [topics, zeroPadValue(hexlify(channelId), 32)],
-            fromBlock,
-            toBlock
-        });
-        const missingLogs = logs.filter((log) => {
-            const parsed = this.stateChannelManagerContract.interface.parseLog({
-                topics: log.topics,
-                data: log.data
-            });
-            if (!parsed) return false;
-            const args = convertEthersValue(parsed.args);
-            const commitment = hash(
-                args.disputeConfirmation.signedDispute.encodedDispute
+        forkId: ForkId
+    ) {
+        try {
+            const [windowCreationTimestamp, latest] = await Promise.all([
+                this.stateChannelManagerContract.getDisputeWindowCreationTimestamp(
+                    channelId,
+                    forkId
+                ),
+                Clock.getBlockchainTime()
+            ]);
+            return {
+                latest,
+                span: this.getBlockSpan(
+                    latest.timestamp - Number(windowCreationTimestamp)
+                )
+            };
+        } catch (error) {
+            this.logger.warn(
+                "Dispute recovery could not read the window span",
+                {
+                    channelId,
+                    forkId,
+                    error
+                }
             );
-            return missingCommitments.has(commitment.toLowerCase());
-        });
-        await Promise.all(
-            missingLogs.map((log) => this.scheduleLog(log, channelId))
-        );
+            return undefined;
+        }
     }
 
     private async dispatchLog(
@@ -512,15 +718,33 @@ export default class EventSyncService {
         return states;
     }
 
-    private getBlockFallbackFrom(
-        latestBlock: BlockNumber,
-        blockHeight: BlockHeight
-    ): BlockNumber {
+    // blocks to look back over `seconds` of chain time, with headroom
+    private getBlockSpan(seconds: number): number {
         const average = Clock.getAverageOnChainBlockTime();
-        const seconds = timeoutWaitTime(this.timeConfig, blockHeight);
-        const span =
-            Math.ceil((average > 0 ? seconds / average : seconds) * 1.5) + 2;
-        return Math.max(0, latestBlock - span);
+        const elapsed = Math.max(0, seconds);
+        return Math.ceil((average > 0 ? elapsed / average : elapsed) * 1.5) + 2;
+    }
+
+    private buildLogFilter(
+        eventNames: readonly SupportedStateChannelManagerEventName[],
+        channelId: ChannelId,
+        indexedTopics: readonly BytesLike[] = []
+    ): Filter {
+        const topics = eventNames.map(
+            (name) =>
+                this.stateChannelManagerContract.interface.getEvent(name)!
+                    .topicHash
+        );
+        return {
+            address: String(this.stateChannelManagerContract.target),
+            topics: [
+                topics,
+                zeroPadValue(hexlify(channelId), 32),
+                ...indexedTopics.map((topic) =>
+                    zeroPadValue(hexlify(topic), 32)
+                )
+            ]
+        };
     }
 
     private getProvider() {

--- a/src/stateManager/eventSync/EventSyncService.ts
+++ b/src/stateManager/eventSync/EventSyncService.ts
@@ -25,11 +25,7 @@ import {
 } from "@/utils";
 import { LoggerUtils } from "@/utils/LoggerUtils";
 
-type BlockState = {
-    pending: number;
-    complete: boolean;
-    failedEventKeys: Set<EventKey>;
-};
+type BlockState = { pending: number; complete: boolean; failed: boolean };
 type OnChainBlockValidationKey = string;
 type EventKey = string;
 type ChannelKey = string;
@@ -131,24 +127,18 @@ export default class EventSyncService {
         const state = states.get(log.blockNumber) ?? {
             pending: 0,
             complete: false,
-            failedEventKeys: new Set<EventKey>()
+            failed: false
         };
         state.pending += 1;
         state.complete = false;
         states.set(log.blockNumber, state);
 
-        // A log executes atomically. A failure is retryable: the rejected
-        // promise is dropped so a later recovery can re-dispatch the same log,
-        // and the block stays incomplete - the watermark holds - until every
-        // log in it succeeded.
+        // A log executes atomically: it either completes or throws. A throw is
+        // fatal - the rejected promise stays cached so the log is never
+        // re-dispatched, and its block never completes so the watermark holds.
         const promise = this.dispatchLog(log, scheduledChannelId)
-            .then(() => {
-                state.failedEventKeys.delete(eventKey);
-            })
             .catch((error) => {
-                state.failedEventKeys.add(eventKey);
-                this.eventPromises.delete(eventKey);
-                this.eventBlockNumbers.delete(eventKey);
+                state.failed = true;
                 this.logger.error("Contract event pipeline failed", {
                     blockNumber: log.blockNumber,
                     logIndex: log.index,
@@ -159,8 +149,7 @@ export default class EventSyncService {
             })
             .finally(() => {
                 state.pending -= 1;
-                state.complete =
-                    state.pending === 0 && state.failedEventKeys.size === 0;
+                state.complete = state.pending === 0 && !state.failed;
                 this.publishCompletedBlocks(scheduledChannelId, channelKey);
             });
         this.eventPromises.set(eventKey, promise);

--- a/src/stateManager/reduction/ReductionComputationService.ts
+++ b/src/stateManager/reduction/ReductionComputationService.ts
@@ -26,7 +26,7 @@ export default class ReductionComputationService {
     public async compute(
         forkId: ForkId,
         disputes: DisputeStruct[]
-    ): Promise<ReductionComputation> {
+    ): Promise<ReductionComputation | undefined> {
         const reducedOutput =
             await this.stateManager.stateChannelManagerContract.reduce.staticCall(
                 disputes
@@ -37,7 +37,7 @@ export default class ReductionComputationService {
     public async computeLocally(
         forkId: ForkId,
         disputes: DisputeStruct[]
-    ): Promise<ReductionComputation> {
+    ): Promise<ReductionComputation | undefined> {
         const reducedOutput =
             await this.stateManager.diamondStateMachine.localDiamondContract.reduce.staticCall(
                 disputes
@@ -67,13 +67,15 @@ export default class ReductionComputationService {
     private async computeFromOutput(
         forkId: ForkId,
         reducedOutput: ReduceData["reducedOutput"]
-    ): Promise<ReductionComputation> {
+    ): Promise<ReductionComputation | undefined> {
         // Use getReduceData to properly handle genesis case (when latestBlock is undefined)
         const reduceData =
             await this.stateManager.agreementManager.getReduceData(
                 forkId,
                 reducedOutput
             );
+        // our inbound view cannot back the chain's reduced head yet
+        if (!reduceData) return undefined;
         const [
             reducedSnapshotData,
             reducedEncodedStateMachineState,

--- a/src/stateManager/reduction/ReductionExecutor.ts
+++ b/src/stateManager/reduction/ReductionExecutor.ts
@@ -82,12 +82,13 @@ export default class ReductionExecutor {
 
     public async getSyncedForkDisputes(
         forkId: ForkId
-    ): Promise<DisputeStruct[]> {
+    ): Promise<DisputeStruct[] | undefined> {
         const commitments =
             await this.stateManager.eventSyncService.loadSynchronizedWindowCommitments(
                 this.stateManager.channelId,
                 forkId
             );
+        if (!commitments) return undefined;
         return this.stateManager.agreementManager.getForkDisputes(commitments);
     }
 
@@ -152,6 +153,20 @@ export default class ReductionExecutor {
         }
 
         const disputes = await this.getSyncedForkDisputes(forkId);
+        if (!disputes) {
+            // the window's disputes are on-chain but not locally readable yet ->
+            // retry, never abort: the peer would lose its turns and be slashed
+            this.logger.warn("Reduction deferred: dispute window unavailable", {
+                forkId
+            });
+            this.stateManager.reductionManager.schedule(
+                forkId,
+                Clock.getTimeInSeconds() +
+                    this.stateManager.timeConfig.chainFallbackTime,
+                true
+            );
+            return;
+        }
         if (forkId !== this.stateManager.forkId) return;
         const freshExpiry =
             await this.stateManager.stateChannelManagerContract.isKillPeriodExpired(
@@ -191,6 +206,20 @@ export default class ReductionExecutor {
             freshObservation.killPeriodEnd,
             disputes
         );
+        if (!candidate) {
+            // our inbound view cannot back the chain's reduced head yet -> retry,
+            // never abort: the peer would lose its turns and be slashed for it
+            this.logger.warn("Reduction deferred: reduce data unavailable", {
+                forkId
+            });
+            this.stateManager.reductionManager.schedule(
+                forkId,
+                Clock.getTimeInSeconds() +
+                    this.stateManager.timeConfig.chainFallbackTime,
+                true
+            );
+            return;
+        }
         const submission = await this.prepareSubmission(candidate);
         const submissionStatus = await this.simulateSubmission(
             forkId,
@@ -228,7 +257,7 @@ export default class ReductionExecutor {
         forkId: ForkId,
         genesisTimestamp: Timestamp,
         disputes: DisputeStruct[]
-    ): Promise<LocalReductionCandidate> {
+    ): Promise<LocalReductionCandidate | undefined> {
         this.logger.debug(
             `Performing local reduction on disputes for fork ${LoggerUtils.formatHash(forkId)}`,
             {
@@ -242,6 +271,7 @@ export default class ReductionExecutor {
                 forkId,
                 disputes
             );
+            if (!computation) return undefined;
             const {
                 reducedSnapshotData,
                 reducedOutboundMessageBlock,

--- a/src/stateManager/reduction/ReductionManager.ts
+++ b/src/stateManager/reduction/ReductionManager.ts
@@ -155,14 +155,14 @@ export default class ReductionManager {
     public computeReduction(
         forkId: ForkId,
         disputes: DisputeStruct[]
-    ): Promise<ReductionComputation> {
+    ): Promise<ReductionComputation | undefined> {
         return this.reductionComputationService.compute(forkId, disputes);
     }
 
     public computeReductionLocally(
         forkId: ForkId,
         disputes: DisputeStruct[]
-    ): Promise<ReductionComputation> {
+    ): Promise<ReductionComputation | undefined> {
         return this.reductionComputationService.computeLocally(
             forkId,
             disputes
@@ -254,7 +254,9 @@ export default class ReductionManager {
         return this.completions.has(forkId);
     }
 
-    public getSyncedForkDisputes(forkId: ForkId): Promise<DisputeStruct[]> {
+    public getSyncedForkDisputes(
+        forkId: ForkId
+    ): Promise<DisputeStruct[] | undefined> {
         return this.reductionExecutor.getSyncedForkDisputes(forkId);
     }
 

--- a/src/storage/MessageBlockStorage.ts
+++ b/src/storage/MessageBlockStorage.ts
@@ -13,6 +13,13 @@ type GetRangeOptions = {
     lowerBlockHash?: Hash; // older/lower block (stop of backwards traversal, exclusive)
 };
 
+export type MessageBlockRun = {
+    // the part of the range storage can prove, oldest first
+    blocks: MessageBlockStruct[];
+    // the first hash the walk needed and we do not hold
+    missingBlockHash?: Hash;
+};
+
 export class MessageBlockStorage {
     private blockMap: Map<Hash, MessageBlockStruct>;
     private latestBlockHash?: Hash;
@@ -51,7 +58,7 @@ export class MessageBlockStorage {
 
     // a chain-verified run, ordered ascending. the pointers only move when the
     // run extends the current head exactly - a merely-held previousBlockHash
-    // can itself sit above a gap, and getIterator throws walking into one
+    // can itself sit above a gap, and the strict range read throws walking into one
     storeVerifiedRun(
         messageBlocks: MessageBlockStruct[],
         previousBlockHash: Hash
@@ -87,32 +94,20 @@ export class MessageBlockStorage {
         return this.blockMap.get(blockHash);
     }
 
-    // [upperBlockHash, lowerBlockHash) - iterate backwards the blockchain
-    *getIterator(
-        options?: GetRangeOptions
-    ): Generator<MessageBlockStruct, void, unknown> {
-        const { upperBlockHash, lowerBlockHash } = options ?? {};
-        const startBlockHash = upperBlockHash ?? this.latestBlockHash;
-        if (!startBlockHash || startBlockHash == ZeroHash) return;
-
-        let currentHash = startBlockHash;
-        while (currentHash != ZeroHash) {
-            if (lowerBlockHash && currentHash === lowerBlockHash) break;
-            const messageBlock = this.blockMap.get(currentHash);
-            if (!messageBlock)
-                throw new Error(
-                    `Block hash ${currentHash} not found in storage`
-                );
-            yield messageBlock;
-            currentHash = messageBlock.previousBlockHash as Hash;
-        }
+    // [upperBlockHash, lowerBlockHash) - oldest first, truncated at the first
+    // hash we do not hold
+    tryGetMessageBlocksInRange(options?: GetRangeOptions): MessageBlockRun {
+        const { newestFirst, missingBlockHash } = this.walkBack(options);
+        return { blocks: newestFirst.reverse(), missingBlockHash };
     }
 
     getMessageBlocksInRange(options?: GetRangeOptions): MessageBlockStruct[] {
-        const blocks: MessageBlockStruct[] = [];
-        for (const messageBlock of this.getIterator(options)) {
-            blocks.unshift(messageBlock);
-        }
+        const { blocks, missingBlockHash } =
+            this.tryGetMessageBlocksInRange(options);
+        if (missingBlockHash)
+            throw new Error(
+                `Block hash ${missingBlockHash} not found in storage`
+            );
         return blocks;
     }
 
@@ -129,17 +124,40 @@ export class MessageBlockStorage {
         return this.latestBlockHeight;
     }
 
+    // newest first, and truncated at a gap rather than throwing - "the latest
+    // N blocks" is exactly what a truncated walk returns
     getLatestMessageBlocks(limit?: number): MessageBlockStruct[] {
         if (!this.latestBlockHash) return [];
 
-        const blocks: MessageBlockStruct[] = [];
-        for (const messageBlock of this.getIterator({
-            upperBlockHash: this.latestBlockHash
-        })) {
-            blocks.push(messageBlock);
-            if (limit !== undefined && blocks.length >= limit) break;
+        return this.walkBack({
+            upperBlockHash: this.latestBlockHash,
+            limit
+        }).newestFirst;
+    }
+
+    // newest-first walk over [upperBlockHash, lowerBlockHash), stopping at the
+    // first hash we do not hold -> no caller walks into a gap by accident
+    private walkBack(options?: GetRangeOptions & { limit?: number }): {
+        newestFirst: MessageBlockStruct[];
+        missingBlockHash?: Hash;
+    } {
+        const { upperBlockHash, lowerBlockHash, limit } = options ?? {};
+        const newestFirst: MessageBlockStruct[] = [];
+        const startBlockHash = upperBlockHash ?? this.latestBlockHash;
+        if (!startBlockHash || startBlockHash == ZeroHash)
+            return { newestFirst };
+
+        let currentHash = startBlockHash;
+        while (currentHash != ZeroHash) {
+            if (lowerBlockHash && currentHash === lowerBlockHash) break;
+            const messageBlock = this.blockMap.get(currentHash);
+            if (!messageBlock)
+                return { newestFirst, missingBlockHash: currentHash };
+            newestFirst.push(messageBlock);
+            if (limit !== undefined && newestFirst.length >= limit) break;
+            currentHash = messageBlock.previousBlockHash as Hash;
         }
-        return blocks;
+        return { newestFirst };
     }
 
     private normalizeBlockHeight(

--- a/src/utils/LoggerUtils.ts
+++ b/src/utils/LoggerUtils.ts
@@ -16,7 +16,8 @@ import { isEthersResult } from "./EthersResultProxy";
 import type { CustomEvmError } from "./evmErrorHandler";
 import { hash } from "./hash";
 import { difference } from "./set";
-import { Address, BlockOrSnapshot, Bytes, Hash } from "@/types/types";
+import { Address, BlockOrSnapshot, Bytes, ForkId, Hash } from "@/types/types";
+import type { NormalizedDisputeCommitment } from "@/stateManager/eventSync/EventSyncService";
 import {
     DisputeFraudProofType,
     FraudProofType,
@@ -521,6 +522,44 @@ export class LoggerUtils {
                 amount: Number(messageBlock.totalBalance.amount),
                 data: String(messageBlock.totalBalance.data)
             }
+        };
+    }
+
+    /**
+     * An inbound-run request and what storage could prove of it: the bounds the
+     * caller asked for, how much came back, and the first hash we do not hold.
+     */
+    static getInboundRunMetadata(run: {
+        upperBlockHash: Hash;
+        lowerBlockHash: Hash;
+        blocks: MessageBlockStruct[];
+        missingBlockHash?: Hash;
+    }) {
+        return {
+            upperBlockHash: this.formatHash(run.upperBlockHash),
+            lowerBlockHash: this.formatHash(run.lowerBlockHash),
+            blockCount: run.blocks.length,
+            missingBlockHash: run.missingBlockHash
+                ? this.formatHash(run.missingBlockHash)
+                : undefined
+        };
+    }
+
+    /**
+     * A fork's dispute window and what local storage could resolve of it: the
+     * committed set's size and the commitments whose dispute we still lack.
+     */
+    static getDisputeWindowMetadata(window: {
+        forkId: ForkId;
+        commitments: readonly Hash[];
+        missingCommitments: readonly NormalizedDisputeCommitment[];
+    }) {
+        return {
+            forkId: this.formatHash(window.forkId),
+            commitmentCount: window.commitments.length,
+            missingCommitments: window.missingCommitments.map((commitment) =>
+                this.formatHash(commitment)
+            )
         };
     }
 

--- a/test/e2e/E2E-DisputeManager.test.ts
+++ b/test/e2e/E2E-DisputeManager.test.ts
@@ -303,7 +303,7 @@ describe("E2E: Dispute Manager", function () {
                 .control(missedPeer)
                 .dispute.recoverCommittedDisputes(disputedForkId)
                 .request();
-            if (recoveredCount < 1) {
+            if (recoveredCount === null || recoveredCount < 1) {
                 throw new Error("Expected at least one recovered dispute");
             }
             await h.assert.storage.storedDisputeConfirmationsWait({

--- a/test/e2e/E2E-ReductionManager.test.ts
+++ b/test/e2e/E2E-ReductionManager.test.ts
@@ -110,6 +110,101 @@ describe("E2E: ReductionManager", function () {
         });
     });
 
+    it("dispute-window recovery defeated → the reduction defers, the peer is not evicted", async function () {
+        const h = TestSession.getHarness();
+        const laggingIndex = 0;
+        const maliciousPeerIndex = 2;
+        const healthyIndices = [1, 3];
+        const { forkId, race, restoreEvents } =
+            await h.scenario.disputeWithSuppressedCommitEvents({
+                observerIndex: laggingIndex,
+                maliciousPeerIndex
+            });
+
+        // a healthy reduction landing while the lagging peer is blinded emits
+        // StateSnapshotUpdated for a fork it cannot resolve, which is a fatal
+        // detached throw of its own - hold them until the queries come back
+        const healthyRaces = [];
+        for (const peerIndex of healthyIndices) {
+            healthyRaces.push(await h.rpcStub.holdReductionRace(peerIndex));
+        }
+
+        const blinded = await h.rpcStub.failChainLogQueries(laggingIndex);
+        // before the kill period expires the attempt exits at the gate and
+        // never reaches the window read
+        await waitFor(
+            async () =>
+                h.execOnHost(
+                    h.getPeer(laggingIndex),
+                    async (sm, a) => {
+                        const { isExpired } =
+                            await sm.reductionManager.isKillPeriodExpiredCached(
+                                a.forkId
+                            );
+                        return isExpired;
+                    },
+                    { forkId }
+                ),
+            25000
+        );
+
+        const commitmentsBefore = (
+            await h.channelManager.getWindowCommitments(h.channelId, forkId)
+        ).length;
+        // no reduction timer is armed while dispute events are held, so the
+        // attempt has to be triggered. startReduction, not awaitReduction: the
+        // shared completion promise stays pending across a deferral
+        await h
+            .control(h.getPeer(laggingIndex))
+            .dispute.startReduction(forkId)
+            .request();
+
+        expect(
+            await TestSession.consumeFirstDetachedError(
+                h.event.protocolEventTimeoutMs()
+            ),
+            "a deferred reduction must not surface an error"
+        ).to.equal(undefined);
+        expect(
+            await h
+                .control(h.getPeer(laggingIndex))
+                .query.getStatus()
+                .request(),
+            "the peer must not be evicted for a window it cannot read"
+        ).to.equal(Status.PARTICIPATING);
+        expect(
+            (await h.channelManager.getWindowCommitments(h.channelId, forkId))
+                .length,
+            "an unreadable window must not be answered with a fresh dispute"
+        ).to.equal(commitmentsBefore);
+
+        // the queries come back before the healthy holds are released, so the
+        // lagging peer recovers the window on its own attempt
+        await blinded.restore();
+        await restoreEvents(false);
+        expect(
+            await h
+                .control(h.getPeer(laggingIndex))
+                .dispute.awaitReduction(forkId)
+                .request(),
+            "the recovered attempt must complete the reduction"
+        ).to.not.equal(null);
+
+        for (const healthy of healthyRaces) {
+            await healthy.release({ replayEvents: true, runHeldTasks: true });
+        }
+        await race.release({
+            replayEvents: true,
+            runHeldTasks: false,
+            keepTasksHeld: true
+        });
+        await h.assert.sync.forkChangedWait({
+            originalForkId: forkId,
+            honestPeerIndices: [laggingIndex, ...healthyIndices],
+            timeoutMs: 30000
+        });
+    });
+
     it("an empty dispute set posts replacement evidence and resumes the same reduction", async function () {
         const h = TestSession.getHarness();
         await h.scenario.preDisputeSetup({

--- a/test/e2e/disputeValidation/settledPathInboundGap.test.ts
+++ b/test/e2e/disputeValidation/settledPathInboundGap.test.ts
@@ -1,0 +1,348 @@
+import { expect } from "chai";
+
+import { Status } from "@/types";
+import { Hash } from "@/types/types";
+import { MathTestSession as TestSession } from "@test/harness";
+import { DisputeTampering } from "@test/harness/actions/DisputeTamperingActions";
+
+// On the settled path (postedAuditingData = false) the disputer posts no
+// auditing data, so every auditor rebuilds it from its own inbound store. An
+// auditor missing the inbound block the dispute names used to walk into the gap:
+// getAuditingData -> MessageBlockStorage threw, the throw escaped
+// onDisputeCommitted, EventSyncService cached the rejected log forever, and
+// every later reduce replayed it into abort(). The audit now recovers the log
+// on demand, and a gap that survives recovery is an abstain, never a throw.
+
+describe("E2E: dispute validation / inbound run gap", function () {
+    const TIME_CONFIG = {
+        p2pTime: 2,
+        agreementTime: 8,
+        chainFallbackTime: 4,
+        evidenceTime: 4
+    };
+
+    /**
+     * 3 peers, two finalized transitions, then a top-up of an existing
+     * participant: block turns and the final-by-everyone head stay intact, so
+     * disputes take the settled path, and the chain's inbound head ends up above
+     * the snapshot every dispute pins. Returns the head the disputes will name.
+     */
+    const stageInboundGap = async (
+        h: ReturnType<typeof TestSession.getHarness>,
+        laggingIndex: number,
+        observePeerIndices: number[]
+    ): Promise<Hash> => {
+        await h.join.forceInboundJoinWait({
+            participant: h.getPeer(observePeerIndices[0]).address,
+            observePeerIndices
+        });
+
+        const inboundHeadHash = (await h
+            .control(h.getPeer(observePeerIndices[0]))
+            .query.getLatestInboundMessageHash()
+            .request()) as Hash;
+        // premise - the lagging peer holds no block at the inbound head the
+        // other peers' disputes name
+        expect(
+            await h
+                .control(h.getPeer(laggingIndex))
+                .query.getInboundMessageBlock(inboundHeadHash)
+                .request(),
+            "lagging peer must not hold the inbound head"
+        ).to.equal(null);
+        return inboundHeadHash;
+    };
+
+    /** No peer may answer a gap with a fraud proof - it is nobody's fraud. */
+    const expectNoDisputeFraudProofs = async (
+        h: ReturnType<typeof TestSession.getHarness>
+    ): Promise<void> => {
+        for (const peer of h.peers) {
+            expect(
+                await h
+                    .control(peer)
+                    .query.getDisputeFraudProofTypes()
+                    .request(),
+                `peer ${peer.index} must store no dispute fraud proof`
+            ).to.deep.equal([]);
+        }
+    };
+
+    it("recoverable inbound log → the auditor recovers it, audits for real and converges", async function () {
+        const h = TestSession.getHarness();
+        await h.setup(3, { timeConfig: TIME_CONFIG });
+        await h.lifecycle.openChannel();
+        const forkId = h.activeForkId!;
+        await h.transition.advanceState({
+            count: 2,
+            waitForFinalization: true
+        });
+        await h.assert.sync.peersInSyncWait();
+
+        const offenderIndex = (await h.query.getNextPeerToWrite()).index;
+        const [disputerIndex, laggingIndex] = h.peers
+            .map((peer) => peer.index)
+            .filter((index) => index !== offenderIndex);
+
+        // the delivery is lost, not the handler: an explicit query of the same
+        // log still applies it, so on-demand recovery can heal this gap
+        const dropped = await h.rpcStub.dropInboundMessageLogs(laggingIndex);
+        const inboundHeadHash = await stageInboundGap(h, laggingIndex, [
+            disputerIndex,
+            offenderIndex
+        ]);
+        await dropped.waitUntilDropped();
+
+        h.event.resetEventSpies();
+        h.contextApi.captureOriginalFork();
+
+        await h.byzantine.submitInvalidStateTransitionBlock(offenderIndex);
+
+        // premise - a settled-path dispute is committed, and the lagging peer
+        // audits it
+        await h.assert.dispute.initiatedAndCommitedWait({
+            peersIndices: [disputerIndex],
+            expectedCount: 1,
+            initiatedWithAuditingData: false
+        });
+
+        // the disputed fork resolves for everyone, the lagging peer included
+        await h.assert.sync.forkChangedWait({
+            originalForkId: forkId,
+            honestPeerIndices: [disputerIndex, laggingIndex],
+            timeoutMs: 20000
+        });
+
+        // the audit recovered the missing log instead of throwing on it
+        expect(
+            await h
+                .control(h.getPeer(laggingIndex))
+                .query.getInboundMessageBlock(inboundHeadHash)
+                .request(),
+            "lagging peer must hold the recovered inbound head"
+        ).to.not.equal(null);
+        expect(
+            await h
+                .control(h.getPeer(laggingIndex))
+                .query.getStatus()
+                .request(),
+            "lagging peer must still be participating"
+        ).to.equal(Status.PARTICIPATING);
+        await expectNoDisputeFraudProofs(h);
+        expect(
+            await TestSession.consumeFirstDetachedError(
+                h.event.protocolEventTimeoutMs()
+            )
+        ).to.equal(undefined);
+
+        await dropped.release();
+    });
+
+    it("unrecoverable inbound log → the auditor abstains, stays participating, converges once the event lands", async function () {
+        const h = TestSession.getHarness();
+        await h.setup(3, { timeConfig: TIME_CONFIG });
+        await h.lifecycle.openChannel();
+        const forkId = h.activeForkId!;
+        await h.transition.advanceState({
+            count: 2,
+            waitForFinalization: true
+        });
+        await h.assert.sync.peersInSyncWait();
+
+        const offenderIndex = (await h.query.getNextPeerToWrite()).index;
+        const [disputerIndex, laggingIndex] = h.peers
+            .map((peer) => peer.index)
+            .filter((index) => index !== offenderIndex);
+
+        // the handler itself is held, so recovery re-dispatches into the same
+        // hold and cannot heal the gap -> the audit must abstain
+        const held = await h.rpcStub.holdInboundMessageEvents(laggingIndex);
+        await stageInboundGap(h, laggingIndex, [disputerIndex, offenderIndex]);
+
+        h.event.resetEventSpies();
+        h.contextApi.captureOriginalFork();
+
+        await h.byzantine.submitInvalidStateTransitionBlock(offenderIndex);
+
+        await h.assert.dispute.initiatedAndCommitedWait({
+            peersIndices: [disputerIndex],
+            expectedCount: 1,
+            initiatedWithAuditingData: false
+        });
+
+        // the healthy auditor reduces the disputed fork
+        await h.assert.sync.forkChangedWait({
+            originalForkId: forkId,
+            honestPeerIndices: [disputerIndex],
+            timeoutMs: 20000
+        });
+
+        // nothing threw, and abstaining is not an accusation
+        expect(
+            await TestSession.consumeFirstDetachedError(
+                h.event.protocolEventTimeoutMs()
+            )
+        ).to.equal(undefined);
+        await expectNoDisputeFraudProofs(h);
+
+        // an inbound gap it cannot help having must not have evicted it
+        expect(
+            await h
+                .control(h.getPeer(laggingIndex))
+                .query.getStatus()
+                .request(),
+            "lagging peer must still be participating"
+        ).to.equal(Status.PARTICIPATING);
+
+        // the missing chain event lands - the peer now holds the whole inbound
+        // chain again and reduces on its own
+        await held.release();
+
+        await h.assert.sync.forkChangedWait({
+            originalForkId: forkId,
+            honestPeerIndices: [laggingIndex],
+            timeoutMs: 20000
+        });
+    });
+
+    it("final dispute over an unrecoverable gap → reduction deferred, then settles on the final dispute's fork", async function () {
+        const h = TestSession.getHarness();
+        await h.setup(3, { timeConfig: TIME_CONFIG });
+        await h.lifecycle.openChannel();
+        const forkId = h.activeForkId!;
+        await h.transition.advanceState({
+            count: 2,
+            waitForFinalization: true
+        });
+        await h.assert.sync.peersInSyncWait();
+
+        // the double-signer has to be the author of the head block - the
+        // conflicting copy carries that author's coordinates
+        const latestBlock = await h
+            .control(h.getPeer(0))
+            .query.getLatestBlockInfo(forkId)
+            .request();
+        const maliciousPeerIndex = h.peers.find(
+            (peer) => peer.address === latestBlock!.author
+        )!.index;
+        const [finalAuthorIndex, laggingIndex] = h.peers
+            .map((peer) => peer.index)
+            .filter((index) => index !== maliciousPeerIndex);
+
+        const held = await h.rpcStub.holdInboundMessageEvents(laggingIndex);
+        await stageInboundGap(h, laggingIndex, [
+            finalAuthorIndex,
+            maliciousPeerIndex
+        ]);
+
+        h.event.resetEventSpies();
+        h.contextApi.captureOriginalFork();
+
+        // a threshold-final dispute drives the final-genesis branch on the
+        // lagging peer, which used to rethrow on a partial rebuild
+        const submitted = await h.dispute.submitFinalDispute({
+            maliciousPeerIndex,
+            finalAuthorPeerIndex: finalAuthorIndex
+        });
+
+        await h.assert.sync.forkChangedWait({
+            originalForkId: forkId,
+            honestPeerIndices: [finalAuthorIndex],
+            timeoutMs: 20000
+        });
+
+        expect(
+            await TestSession.consumeFirstDetachedError(
+                h.event.protocolEventTimeoutMs()
+            )
+        ).to.equal(undefined);
+        expect(
+            await h
+                .control(h.getPeer(laggingIndex))
+                .query.getStatus()
+                .request(),
+            "lagging peer must still be participating"
+        ).to.equal(Status.PARTICIPATING);
+
+        await held.release();
+
+        await h.assert.sync.forkChangedWait({
+            originalForkId: forkId,
+            honestPeerIndices: [laggingIndex],
+            timeoutMs: 20000
+        });
+
+        // the deferred reduce must derive the final dispute's own output, not
+        // some other fork - otherwise the attempt stands down as superseded and
+        // never installs anything
+        expect(
+            await h
+                .control(h.getPeer(laggingIndex))
+                .query.getForkId()
+                .request(),
+            "the deferred reduction must settle on the final dispute's fork"
+        ).to.equal(submitted.finalResolution.forkId);
+    });
+
+    it("posted auditing data with an emptied inbound run → the auditor still rebuilds locally, nobody is slashed", async function () {
+        const h = TestSession.getHarness();
+        const attackerIndex = 0;
+        const laggingIndex = 1;
+
+        // a pending inbound join leaves the head not-final-by-everyone, so a
+        // dispute has to post its auditing data - and the held peer never
+        // stores the inbound head that dispute names
+        const { releaseLaggingInbound } =
+            await h.scenario.preDisputeSetupCalldataPath({
+                laggingInboundPeerIndex: laggingIndex
+            });
+        const forkId = h.activeForkId!;
+
+        const inboundHeadHash = (await h
+            .control(h.getPeer(attackerIndex))
+            .query.getLatestInboundMessageHash()
+            .request()) as Hash;
+        // premise - the auditor holds no block at the head the dispute names
+        expect(
+            await h
+                .control(h.getPeer(laggingIndex))
+                .query.getInboundMessageBlock(inboundHeadHash)
+                .request(),
+            "lagging peer must not hold the inbound head"
+        ).to.equal(null);
+
+        const { dispute } = await h.tamper.postTamperedDispute(
+            attackerIndex,
+            DisputeTampering.emptyPostedInboundRun
+        );
+        expect(dispute.postedAuditingData).to.equal(true);
+
+        await h.assert.dispute.committedWait({ expectedCount: 1 });
+
+        // the truncated posted run is harmless: the auditor verifies the output
+        // against its own rebuild, so the honest verdict is unaffected and the
+        // gap accuses nobody
+        expect(
+            await TestSession.consumeFirstDetachedError(
+                h.event.protocolEventTimeoutMs()
+            )
+        ).to.equal(undefined);
+        await expectNoDisputeFraudProofs(h);
+        expect(
+            await h
+                .control(h.getPeer(laggingIndex))
+                .query.getStatus()
+                .request(),
+            "lagging peer must still be participating"
+        ).to.equal(Status.PARTICIPATING);
+
+        await releaseLaggingInbound?.();
+
+        // every peer that is not the attacker converges on the reduced fork
+        await h.assert.sync.forkChangedWait({
+            originalForkId: forkId,
+            honestPeerIndices: [laggingIndex, 2, 3],
+            timeoutMs: 25000
+        });
+    });
+});

--- a/test/fixtures/customRpc/harnessControl/services/dispute/DisputeRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/dispute/DisputeRpcMethods.ts
@@ -56,7 +56,7 @@ export class DisputeRpcMethods extends ARpcMethods {
     }
 
     /** Recover missed committed-dispute logs through the production query path. */
-    public recoverCommittedDisputes(forkId: ForkId): Promise<number> {
+    public recoverCommittedDisputes(forkId: ForkId): Promise<number | null> {
         return this.service.recoverCommittedDisputes(forkId);
     }
 
@@ -135,13 +135,13 @@ export class DisputeRpcMethods extends ARpcMethods {
      * `disputeLatestInboundMessageBlockHash` is the anchor an auditor bounds
      * the inbound range with (`DisputeValidationService.continueOtherChecks`).
      */
-    public getAuditingData(
+    public async getAuditingData(
         forkId: ForkId,
         encodedStateProof: string,
         options?: { disputeLatestInboundMessageBlockHash?: Hash }
-    ): { isPartial: boolean; encodedAuditingData: string } {
+    ): Promise<{ isPartial: boolean; encodedAuditingData: string }> {
         const { isPartial, auditingData } =
-            this.service.disputeManager.getAuditingData(
+            await this.service.disputeManager.getAuditingData(
                 forkId,
                 Codec.decode(encodedStateProof, Type.StateProof),
                 options

--- a/test/fixtures/customRpc/harnessControl/services/dispute/DisputeService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/dispute/DisputeService.ts
@@ -489,7 +489,7 @@ export class DisputeService extends ARpcService<DisputeRpcMethods> {
             if (!hasBlock || h <= targetHeight) break;
         }
 
-        const { auditingData } = this.disputeManager.getAuditingData(
+        const { auditingData } = await this.disputeManager.getAuditingData(
             dispute.input.forkId as ForkId,
             stateProof
         );
@@ -796,13 +796,14 @@ export class DisputeService extends ARpcService<DisputeRpcMethods> {
         };
     }
 
-    async recoverCommittedDisputes(forkId: ForkId): Promise<number> {
+    /** `null` = the window could not be made locally readable. */
+    async recoverCommittedDisputes(forkId: ForkId): Promise<number | null> {
         const commitments =
             await this.sm.eventSyncService.loadSynchronizedWindowCommitments(
                 this.sm.channelId,
                 forkId
             );
-        return commitments.length;
+        return commitments ? commitments.length : null;
     }
 
     public createRPCMethods(transport: ATransport): DisputeRpcMethods {

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -29,6 +29,9 @@ import type {
     BlockValidationProbeOptions,
     BlockProbeOptions,
     BlockIngestProbe,
+    BlockCalldataRecoveryProbe,
+    InboundRunRecoveryProbe,
+    ReductionChallengeProbe,
     IsDisputedForkProbe
 } from "./StubService";
 import type { StubService } from "./StubService";
@@ -789,8 +792,29 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
         return true;
     }
 
-    public async probeRejectedEventSyncLog(): Promise<EventSyncFailureProbe> {
-        return this.service.probeRejectedEventSyncLog();
+    public async probeRejectedEventSyncLog(options?: {
+        recoverOnRetry?: boolean;
+    }): Promise<EventSyncFailureProbe> {
+        return this.service.probeRejectedEventSyncLog(options);
+    }
+
+    public async probeDisputeReductionChallenge(
+        reducedForkId: ForkId
+    ): Promise<ReductionChallengeProbe> {
+        return this.service.probeDisputeReductionChallenge(reducedForkId);
+    }
+
+    public async probeInboundRunRecovery(
+        upperBlockHash: Hash,
+        options?: { failChainQueries?: boolean }
+    ): Promise<InboundRunRecoveryProbe> {
+        return this.service.probeInboundRunRecovery(upperBlockHash, options);
+    }
+
+    public async probeBlockCalldataRecovery(options?: {
+        failChainQueries?: boolean;
+    }): Promise<BlockCalldataRecoveryProbe> {
+        return this.service.probeBlockCalldataRecovery(options);
     }
 
     public async probeConcurrentCalldataRecovery(): Promise<ConcurrentCalldataRecoveryProbe> {
@@ -1282,6 +1306,110 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
         return this.service.heldInboundMessageArgs.length;
     }
 
+    /**
+     * Drop subscribed inbound logs before the scheduler records their key.
+     * Unlike `stubHoldInboundMessageEvents`, which replaces the handler, this
+     * only loses the delivery - an explicit query of the same log still reaches
+     * the real scheduler, so recovery can heal it. `dropCount` caps how many
+     * distinct keys are lost (default: all).
+     */
+    public stubDropInboundMessageLogs(dropCount?: number): boolean {
+        const eventSyncService = this.service.sm.eventSyncService;
+        // an omitted arg crosses the port as null -> normalize to "no limit"
+        this.service.inboundMessageLogDropLimit = dropCount ?? undefined;
+        if (!this.service.stubOriginals.has("inboundMessageLogs")) {
+            this.service.stubOriginals.set(
+                "inboundMessageLogs",
+                eventSyncService.scheduleLog.bind(eventSyncService)
+            );
+        }
+        const original = this.service.stubOriginals.get(
+            "inboundMessageLogs"
+        ) as typeof eventSyncService.scheduleLog;
+        eventSyncService.scheduleLog = async (...args) => {
+            const parsed =
+                this.service.sm.stateChannelManagerContract.interface.parseLog({
+                    topics: args[0].topics,
+                    data: args[0].data
+                });
+            if (parsed?.name === "InboundMessagesProcessed") {
+                const eventKey = `${args[0].transactionHash}:${args[0].index}`;
+                const limit = this.service.inboundMessageLogDropLimit;
+                const dropped = this.service.droppedInboundMessageLogKeys;
+                if (
+                    !dropped.has(eventKey) &&
+                    (limit === undefined || dropped.size < limit)
+                ) {
+                    dropped.add(eventKey);
+                    return;
+                }
+            }
+            return original(...args);
+        };
+        return true;
+    }
+
+    /** Restore scheduling. Dropped subscription payloads are recovered by query. */
+    public restoreInboundMessageLogs(): boolean {
+        const eventSyncService = this.service.sm.eventSyncService;
+        const original = this.service.stubOriginals.get("inboundMessageLogs");
+        if (original === undefined) return false;
+        eventSyncService.scheduleLog =
+            original as typeof eventSyncService.scheduleLog;
+        this.service.stubOriginals.delete("inboundMessageLogs");
+        this.service.droppedInboundMessageLogKeys.clear();
+        this.service.inboundMessageLogDropLimit = undefined;
+        return true;
+    }
+
+    public getDroppedInboundMessageLogCount(): number {
+        return this.service.droppedInboundMessageLogKeys.size;
+    }
+
+    /** Make every provider getLogs throw, so no recovery query can succeed. */
+    public stubFailChainLogQueries(): boolean {
+        this.service.failChainLogQueries();
+        return true;
+    }
+
+    /** Record every provider getLogs span and forward it. */
+    public stubCountChainLogQueries(): boolean {
+        this.service.countChainLogQueries();
+        return true;
+    }
+
+    public getChainLogQueryCount(): number {
+        return this.service.chainLogQueries.length;
+    }
+
+    public restoreChainLogQueries(): boolean {
+        return this.service.restoreChainLogQueries();
+    }
+
+    /** Make onDisputeCommitted throw for every dispatched dispute log. */
+    public stubFailDisputeCommittedHandler(): boolean {
+        this.service.failDisputeCommittedHandler();
+        return true;
+    }
+
+    public restoreDisputeCommittedHandler(): boolean {
+        return this.service.restoreDisputeCommittedHandler();
+    }
+
+    public getFailedDisputeCommittedHandlerCallCount(): number {
+        return this.service.failedDisputeCommittedHandlerCalls;
+    }
+
+    /** Make the dispute-window creation timestamp read throw. */
+    public stubFailDisputeWindowTimestampRead(): boolean {
+        this.service.failDisputeWindowTimestampRead();
+        return true;
+    }
+
+    public restoreDisputeWindowTimestampRead(): boolean {
+        return this.service.restoreDisputeWindowTimestampRead();
+    }
+
     /** Drop subscribed dispute logs before the scheduler records their key. */
     public stubHoldDisputeCommittedEvents(passFirst = true): boolean {
         const eventSyncService = this.service.sm.eventSyncService;
@@ -1355,47 +1483,12 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
 
     /** Hold subscribed calldata logs before the scheduler records their key. */
     public stubHoldCalldataPostedEvents(): boolean {
-        const eventSyncService = this.service.sm.eventSyncService;
-        if (!this.service.stubOriginals.has("calldataPostedEvents")) {
-            this.service.stubOriginals.set(
-                "calldataPostedEvents",
-                eventSyncService.scheduleLog.bind(eventSyncService)
-            );
-        }
-        const original = this.service.stubOriginals.get(
-            "calldataPostedEvents"
-        ) as typeof eventSyncService.scheduleLog;
-        eventSyncService.scheduleLog = async (...args) => {
-            const parsed =
-                this.service.sm.stateChannelManagerContract.interface.parseLog({
-                    topics: args[0].topics,
-                    data: args[0].data
-                });
-            if (parsed?.name === "BlockCalldataPosted") {
-                const eventKey = `${args[0].transactionHash}:${args[0].index}`;
-                if (!this.service.heldCalldataPostedEventKeys.has(eventKey)) {
-                    // Lose the subscribed delivery once. A later explicit
-                    // query of the same log must reach the real scheduler so
-                    // this stub accurately models missed subscription data.
-                    this.service.heldCalldataPostedEventKeys.add(eventKey);
-                    this.service.notifyCalldataPostedEventHeld();
-                    return;
-                }
-            }
-            return original(...args);
-        };
+        this.service.holdCalldataPostedEvents();
         return true;
     }
 
     public restoreCalldataPostedEvents(): boolean {
-        const eventSyncService = this.service.sm.eventSyncService;
-        const original = this.service.stubOriginals.get("calldataPostedEvents");
-        if (original === undefined) return false;
-        eventSyncService.scheduleLog =
-            original as typeof eventSyncService.scheduleLog;
-        this.service.stubOriginals.delete("calldataPostedEvents");
-        this.service.heldCalldataPostedEventKeys.clear();
-        return true;
+        return this.service.restoreCalldataPostedEvents();
     }
 
     /** Resolves once a subscribed calldata log has been held. */

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubRpcMethods.ts
@@ -14,7 +14,6 @@ import type { ForkId, Hash, Timestamp } from "@/types/types";
 import type { HarnessControlRpc } from "../../HarnessControlRpc";
 import type {
     DisputeSubmissionFailureSpec,
-    EventSyncFailureProbe,
     PausedConstructDisputeState,
     PausedConstructDisputeStatus,
     PausedReductionStatus,
@@ -790,12 +789,6 @@ export class StubRpcMethods extends ARpcMethods<P2PManager<HarnessControlRpc>> {
     public cancelScheduledReductions(): boolean {
         this.service.sm.reductionManager["cancelScheduledReductions"]();
         return true;
-    }
-
-    public async probeRejectedEventSyncLog(options?: {
-        recoverOnRetry?: boolean;
-    }): Promise<EventSyncFailureProbe> {
-        return this.service.probeRejectedEventSyncLog(options);
     }
 
     public async probeDisputeReductionChallenge(

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -170,17 +170,6 @@ export type PausedConstructDisputeState = PausedConstructDisputeStatus & {
     release: () => void;
 };
 
-export type EventSyncFailureProbe = {
-    samePromise: boolean;
-    handlerCallCount: number;
-    firstError: string | null;
-    secondError: string | null;
-    rescheduledError: string | null;
-    cursorBefore: number | null;
-    cursorAfter: number | null;
-    detachedError: string | null;
-};
-
 export type ConcurrentCalldataRecoveryProbe = {
     queryCount: number;
     firstFound: boolean;
@@ -703,116 +692,6 @@ export class StubService extends ARpcService<
             blockNumber: receipt.blockNumber,
             onChainTimestamp: chainBlock.timestamp
         };
-    }
-
-    /**
-     * Exercise failed-log retry through the real EventSyncService. With
-     * `recoverOnRetry` the handler starts succeeding after the first failure;
-     * otherwise it keeps failing. Either way the log is rescheduled twice.
-     */
-    public async probeRejectedEventSyncLog(options?: {
-        recoverOnRetry?: boolean;
-    }): Promise<EventSyncFailureProbe> {
-        const recoverOnRetry = options?.recoverOnRetry ?? true;
-        const sm = this.sm;
-        const contract = sm.stateChannelManagerContract;
-        const provider = contract.runner?.provider;
-        if (!provider) throw new Error("Expected a provider for event sync");
-        const latestBlock = await provider.getBlock("latest");
-        if (!latestBlock?.hash) throw new Error("Expected a latest block");
-        const stateSnapshot = await contract.getStateSnapshot(sm.channelId);
-        const event = contract.interface.getEvent("StateSnapshotUpdated");
-        const encodedEvent = contract.interface.encodeEventLog(event, [
-            sm.channelId,
-            stateSnapshot
-        ]);
-        const log = new Log(
-            {
-                address: String(contract.target),
-                blockHash: latestBlock.hash,
-                blockNumber: latestBlock.number + 1,
-                data: encodedEvent.data,
-                index: 0,
-                removed: false,
-                topics: encodedEvent.topics,
-                transactionHash: id(`event-sync-failure-${Date.now()}`),
-                transactionIndex: 0
-            },
-            provider
-        );
-        const eventHandler = sm.eventHandler;
-        const original = eventHandler.onStateSnapshotUpdated.bind(eventHandler);
-        let handlerCallCount = 0;
-        eventHandler.onStateSnapshotUpdated = async () => {
-            handlerCallCount += 1;
-            throw new Error("Expected event-sync rejection");
-        };
-        const cursorBefore =
-            sm.storage.eventSync.getLatestProcessedBlock(sm.channelId) ?? null;
-        try {
-            const first = sm.eventSyncService.scheduleLog(log, sm.channelId);
-            const second = sm.eventSyncService.scheduleLog(log, sm.channelId);
-            DetachedPromises.collect(first);
-            const [firstError, secondError] = await Promise.all([
-                first.then(
-                    () => null,
-                    (error: unknown) =>
-                        error instanceof Error ? error.message : String(error)
-                ),
-                second.then(
-                    () => null,
-                    (error: unknown) =>
-                        error instanceof Error ? error.message : String(error)
-                )
-            ]);
-            const detached = await DetachedPromises.collectSettledAndClear();
-            const rejected = detached.find(
-                (result): result is PromiseRejectedResult =>
-                    result.status === "rejected"
-            );
-            const detachedError = rejected
-                ? rejected.reason instanceof Error
-                    ? rejected.reason.message
-                    : String(rejected.reason)
-                : null;
-
-            // A failed log is retryable - rescheduling re-enters the handler.
-            // Once it succeeds the resolved promise is cached, so the second
-            // reschedule is a no-op; while it keeps failing every reschedule
-            // dispatches again.
-            if (recoverOnRetry) {
-                eventHandler.onStateSnapshotUpdated = async () => {
-                    handlerCallCount += 1;
-                };
-            }
-            const rescheduledError = await sm.eventSyncService
-                .scheduleLog(log, sm.channelId)
-                .then(
-                    () => null,
-                    (error: unknown) =>
-                        error instanceof Error ? error.message : String(error)
-                );
-            await sm.eventSyncService.scheduleLog(log, sm.channelId).then(
-                () => null,
-                () => null
-            );
-
-            return {
-                samePromise: first === second,
-                handlerCallCount,
-                firstError,
-                secondError,
-                rescheduledError,
-                cursorBefore,
-                cursorAfter:
-                    sm.storage.eventSync.getLatestProcessedBlock(
-                        sm.channelId
-                    ) ?? null,
-                detachedError
-            };
-        } finally {
-            eventHandler.onStateSnapshotUpdated = original;
-        }
     }
 
     get chainProvider() {

--- a/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
+++ b/test/fixtures/customRpc/harnessControl/services/stub/StubService.ts
@@ -34,6 +34,7 @@ import { recordValidationBoundary } from "./RecordingValidationStrategy";
 
 type DisputeCommittedEventKey = string;
 type CalldataPostedEventKey = string;
+type InboundMessageLogKey = string;
 
 /** Fixed identifiers for the stub-original registry (never caller-supplied). */
 export type StubKey =
@@ -72,7 +73,11 @@ export type StubKey =
     | "scheduledTasks"
     | "ingestConfirmations"
     | "onChainSlashesQuery"
-    | "localDiamondInboundMessages";
+    | "localDiamondInboundMessages"
+    | "inboundMessageLogs"
+    | "chainLogQueries"
+    | "disputeWindowTimestamp"
+    | "disputeCommittedHandler";
 
 export type ReductionSimulationErrorName =
     | "RaceConditionDisputeAlreadyReduced"
@@ -181,6 +186,51 @@ export type ConcurrentCalldataRecoveryProbe = {
     firstFound: boolean;
     secondFound: boolean;
     retryFound: boolean;
+};
+
+export type ReductionChallengeProbe = {
+    /** Recorded challenge sends - a real one would derail the session. */
+    challengeCalls: number;
+    /** The verdict: true = do not challenge. Null when the call threw. */
+    isValid: boolean | null;
+    threw: string | null;
+};
+
+export type InboundRunRecoveryProbe = {
+    /** Provider getLogs calls the recovery made (0 when storage sufficed). */
+    queryCount: number;
+    /** Each attempt's `fromBlock`, in attempt order. */
+    queriedFromBlocks: (number | null)[];
+    /** The event-sync watermark when the call started. */
+    cursorAtCall: number | null;
+    /** The `toBlock` every attempt queried up to. */
+    toBlock: number | null;
+    /** InboundMessagesProcessed logs the recovery dispatched. */
+    scheduledLogCount: number;
+    /** Blocks returned, or null when the gap survived recovery. */
+    blockCount: number | null;
+    /** Whether the peer held the requested head before the call. */
+    heldBefore: boolean;
+    heldAfter: boolean;
+    /** Set only if the recovery threw - its contract says it never does. */
+    threw: string | null;
+};
+
+/** The block range one recorded `provider.getLogs` call asked for. */
+export type ChainLogQuerySpan = {
+    fromBlock: number | null;
+    toBlock: number | null;
+};
+
+export type BlockCalldataRecoveryProbe = {
+    /** Whether the recovery ended with the calldata in local storage. */
+    recoveredCalldata: boolean;
+    /** Whether the recovery dispatched a calldata log for validation. */
+    validationScheduled: boolean;
+    /** Provider getLogs calls the recovery made. */
+    queryCount: number;
+    /** Set only if the recovery threw - its contract says it never does. */
+    threw: string | null;
 };
 
 export type DisputeStrategyResultMatrix = Record<string, string>;
@@ -315,8 +365,16 @@ export class StubService extends ARpcService<
     readonly heldInboundMessageArgs: unknown[][] = [];
     readonly passedDisputeCommittedEventKeys =
         new Set<DisputeCommittedEventKey>();
+    /** Subscribed inbound logs the drop stub has already lost once. */
+    readonly droppedInboundMessageLogKeys = new Set<InboundMessageLogKey>();
+    /** How many distinct inbound logs may be dropped (undefined = all). */
+    inboundMessageLogDropLimit?: number;
     /** Subscribed calldata logs the hold stub has already lost once. */
     readonly heldCalldataPostedEventKeys = new Set<CalldataPostedEventKey>();
+    /** getLogs spans recorded by the current chain-log-query patch. */
+    private chainLogQuerySpans: ChainLogQuerySpan[] = [];
+    /** Dispatches that reached the failing onDisputeCommitted stub. */
+    private failedDisputeCommittedCalls = 0;
     /** Resolvers waiting for the first held calldata log. */
     private readonly heldCalldataPostedWaiters: (() => void)[] = [];
     /** Whether the dispute-event hold stub should pass its first new log. */
@@ -432,6 +490,50 @@ export class StubService extends ARpcService<
         return new Promise((resolve) =>
             this.heldCalldataPostedWaiters.push(() => resolve(true))
         );
+    }
+
+    /** Hold subscribed calldata logs before the scheduler records their key. */
+    public holdCalldataPostedEvents(): void {
+        const eventSyncService = this.sm.eventSyncService;
+        if (!this.stubOriginals.has("calldataPostedEvents")) {
+            this.stubOriginals.set(
+                "calldataPostedEvents",
+                eventSyncService.scheduleLog.bind(eventSyncService)
+            );
+        }
+        const original = this.stubOriginals.get(
+            "calldataPostedEvents"
+        ) as typeof eventSyncService.scheduleLog;
+        eventSyncService.scheduleLog = async (...args) => {
+            const parsed =
+                this.sm.stateChannelManagerContract.interface.parseLog({
+                    topics: args[0].topics,
+                    data: args[0].data
+                });
+            if (parsed?.name === "BlockCalldataPosted") {
+                const eventKey = `${args[0].transactionHash}:${args[0].index}`;
+                if (!this.heldCalldataPostedEventKeys.has(eventKey)) {
+                    // Lose the subscribed delivery once. A later explicit
+                    // query of the same log must reach the real scheduler so
+                    // this stub accurately models missed subscription data.
+                    this.heldCalldataPostedEventKeys.add(eventKey);
+                    this.notifyCalldataPostedEventHeld();
+                    return;
+                }
+            }
+            return original(...args);
+        };
+    }
+
+    public restoreCalldataPostedEvents(): boolean {
+        const eventSyncService = this.sm.eventSyncService;
+        const original = this.stubOriginals.get("calldataPostedEvents");
+        if (original === undefined) return false;
+        eventSyncService.scheduleLog =
+            original as typeof eventSyncService.scheduleLog;
+        this.stubOriginals.delete("calldataPostedEvents");
+        this.heldCalldataPostedEventKeys.clear();
+        return true;
     }
 
     /**
@@ -603,8 +705,15 @@ export class StubService extends ARpcService<
         };
     }
 
-    /** Exercise rejected-log retention through the real EventSyncService. */
-    public async probeRejectedEventSyncLog(): Promise<EventSyncFailureProbe> {
+    /**
+     * Exercise failed-log retry through the real EventSyncService. With
+     * `recoverOnRetry` the handler starts succeeding after the first failure;
+     * otherwise it keeps failing. Either way the log is rescheduled twice.
+     */
+    public async probeRejectedEventSyncLog(options?: {
+        recoverOnRetry?: boolean;
+    }): Promise<EventSyncFailureProbe> {
+        const recoverOnRetry = options?.recoverOnRetry ?? true;
         const sm = this.sm;
         const contract = sm.stateChannelManagerContract;
         const provider = contract.runner?.provider;
@@ -667,20 +776,25 @@ export class StubService extends ARpcService<
                     : String(rejected.reason)
                 : null;
 
-            // A failed log is fatal - rescheduling it returns the cached
-            // rejection and never re-enters the handler, even once the handler
-            // would succeed.
-            eventHandler.onStateSnapshotUpdated = async () => {
-                handlerCallCount += 1;
-            };
-            const rescheduled = sm.eventSyncService.scheduleLog(
-                log,
-                sm.channelId
-            );
-            const rescheduledError = await rescheduled.then(
+            // A failed log is retryable - rescheduling re-enters the handler.
+            // Once it succeeds the resolved promise is cached, so the second
+            // reschedule is a no-op; while it keeps failing every reschedule
+            // dispatches again.
+            if (recoverOnRetry) {
+                eventHandler.onStateSnapshotUpdated = async () => {
+                    handlerCallCount += 1;
+                };
+            }
+            const rescheduledError = await sm.eventSyncService
+                .scheduleLog(log, sm.channelId)
+                .then(
+                    () => null,
+                    (error: unknown) =>
+                        error instanceof Error ? error.message : String(error)
+                );
+            await sm.eventSyncService.scheduleLog(log, sm.channelId).then(
                 () => null,
-                (error: unknown) =>
-                    error instanceof Error ? error.message : String(error)
+                () => null
             );
 
             return {
@@ -698,6 +812,310 @@ export class StubService extends ARpcService<
             };
         } finally {
             eventHandler.onStateSnapshotUpdated = original;
+        }
+    }
+
+    get chainProvider() {
+        const provider = this.sm.stateChannelManagerContract.runner?.provider;
+        if (!provider) throw new Error("Expected a chain provider");
+        return provider;
+    }
+
+    /** Spans of the getLogs calls seen since the current patch went in. */
+    get chainLogQueries(): readonly ChainLogQuerySpan[] {
+        return this.chainLogQuerySpans;
+    }
+
+    /** Make every provider getLogs throw -> no recovery query can succeed. */
+    failChainLogQueries(): void {
+        this.patchChainLogQueries(true);
+    }
+
+    /** Record every provider getLogs span and forward it. */
+    countChainLogQueries(): void {
+        this.patchChainLogQueries(false);
+    }
+
+    restoreChainLogQueries(): boolean {
+        const original = this.stubOriginals.get("chainLogQueries");
+        if (original === undefined) return false;
+        this.chainProvider.getLogs =
+            original as typeof this.chainProvider.getLogs;
+        this.stubOriginals.delete("chainLogQueries");
+        return true;
+    }
+
+    /**
+     * Record every provider getLogs span; with `fail` each call throws too.
+     * One such patch is active at a time - installing a second one resets the
+     * recorded spans.
+     */
+    private patchChainLogQueries(fail: boolean): void {
+        const provider = this.chainProvider;
+        if (!this.stubOriginals.has("chainLogQueries")) {
+            this.stubOriginals.set(
+                "chainLogQueries",
+                provider.getLogs.bind(provider)
+            );
+        }
+        const original = this.stubOriginals.get(
+            "chainLogQueries"
+        ) as typeof provider.getLogs;
+        this.chainLogQuerySpans = [];
+        provider.getLogs = (async (filter) => {
+            this.chainLogQuerySpans.push({
+                fromBlock:
+                    "fromBlock" in filter ? Number(filter.fromBlock) : null,
+                toBlock: "toBlock" in filter ? Number(filter.toBlock) : null
+            });
+            if (fail) throw new Error("stubbed getLogs failure");
+            return original(filter);
+        }) as typeof provider.getLogs;
+    }
+
+    /**
+     * Run the real `loadSynchronizedInboundRun` for `upperBlockHash`, bounded
+     * below by this peer's fork-genesis inbound head, recording the chain
+     * queries it makes (count and each query's span) and how many logs it
+     * dispatched.
+     */
+    public async probeInboundRunRecovery(
+        upperBlockHash: Hash,
+        options?: { failChainQueries?: boolean }
+    ): Promise<InboundRunRecoveryProbe> {
+        const sm = this.sm;
+        const genesis = sm.storage.stateSnapshots.getGenesisSnapshotByForkId(
+            sm.forkId
+        );
+        if (!genesis) throw new Error("Expected a genesis snapshot");
+        const held = () =>
+            Boolean(sm.storage.inboundMessages.getMessageBlock(upperBlockHash));
+        const heldBefore = held();
+        const cursorAtCall =
+            sm.storage.eventSync.getLatestProcessedBlock(sm.channelId) ?? null;
+
+        if (options?.failChainQueries) this.failChainLogQueries();
+        else this.countChainLogQueries();
+        // count-and-forward: the driver's dispatch count is what proves an
+        // already-applied log is not re-dispatched
+        const eventSyncService = sm.eventSyncService;
+        const originalScheduleLog =
+            eventSyncService.scheduleLog.bind(eventSyncService);
+        let scheduledLogCount = 0;
+        eventSyncService.scheduleLog = ((log, scheduledChannelId) => {
+            const parsed = sm.stateChannelManagerContract.interface.parseLog({
+                topics: log.topics,
+                data: log.data
+            });
+            if (parsed?.name === "InboundMessagesProcessed") {
+                scheduledLogCount += 1;
+            }
+            return originalScheduleLog(log, scheduledChannelId);
+        }) as typeof eventSyncService.scheduleLog;
+
+        try {
+            const run = await sm.eventSyncService.loadSynchronizedInboundRun(
+                upperBlockHash,
+                genesis.latestInboundMessageBlockHash,
+                genesis.timestamp
+            );
+            return {
+                ...this.describeChainLogQueries(),
+                cursorAtCall,
+                scheduledLogCount,
+                blockCount: run ? run.length : null,
+                heldBefore,
+                heldAfter: held(),
+                threw: null
+            };
+        } catch (error) {
+            return {
+                ...this.describeChainLogQueries(),
+                cursorAtCall,
+                scheduledLogCount,
+                blockCount: null,
+                heldBefore,
+                heldAfter: held(),
+                threw: error instanceof Error ? error.message : String(error)
+            };
+        } finally {
+            eventSyncService.scheduleLog = originalScheduleLog;
+            this.restoreChainLogQueries();
+        }
+    }
+
+    /** The recorded getLogs spans as a probe reports them. */
+    private describeChainLogQueries() {
+        const spans = this.chainLogQueries;
+        return {
+            queryCount: spans.length,
+            queriedFromBlocks: spans.map((span) => span.fromBlock),
+            toBlock: spans.length ? spans[spans.length - 1].toBlock : null
+        };
+    }
+
+    /**
+     * Lose a subscribed `BlockCalldataPosted` delivery for one of this peer's
+     * own blocks, then run the real calldata recovery for that block. With
+     * `failChainQueries` the recovery query is blinded, so the contained
+     * failure path runs instead.
+     */
+    public async probeBlockCalldataRecovery(options?: {
+        failChainQueries?: boolean;
+    }): Promise<BlockCalldataRecoveryProbe> {
+        const sm = this.sm;
+        const forkId = sm.forkId;
+        const block = await this.findOwnBlockWithoutPostedCalldata(forkId);
+
+        this.holdCalldataPostedEvents();
+        if (options?.failChainQueries) this.failChainLogQueries();
+        else this.countChainLogQueries();
+
+        try {
+            await this.postBlockCalldataOnChain(
+                Codec.encode(block.signedBlock, Type.SignedBlock) as string
+            );
+            // premise - the subscribed delivery really was lost
+            await this.waitForHeldCalldataPostedEvent();
+            const recovery =
+                await sm.eventSyncService.tryRecoverBlockCalldataAndScheduleValidation(
+                    forkId,
+                    block.height,
+                    block.author
+                );
+            return {
+                recoveredCalldata: recovery.blockCalldata !== undefined,
+                validationScheduled: recovery.validationScheduled,
+                queryCount: this.chainLogQueries.length,
+                threw: null
+            };
+        } catch (error) {
+            return {
+                recoveredCalldata: false,
+                validationScheduled: false,
+                queryCount: this.chainLogQueries.length,
+                threw: error instanceof Error ? error.message : String(error)
+            };
+        } finally {
+            this.restoreChainLogQueries();
+            this.restoreCalldataPostedEvents();
+        }
+    }
+
+    /**
+     * The newest block this peer authored whose on-chain calldata slot is
+     * still free - only its author may post it, and only once.
+     */
+    private async findOwnBlockWithoutPostedCalldata(forkId: ForkId) {
+        const latest = this.sm.storage.blocks.getLatestBlock(forkId);
+        if (!latest) throw new Error("Expected a block on the current fork");
+        for (let height = Number(latest.height); height >= 0; height--) {
+            const block = this.sm.storage.blocks.getBlock(forkId, height);
+            if (!block || block.author !== this.sm.signerAddress) continue;
+            const commitment =
+                await this.sm.stateChannelManagerContract.getBlockCallDataCommitment(
+                    this.sm.channelId,
+                    forkId,
+                    height,
+                    block.author
+                );
+            if (!commitment.found) return block;
+        }
+        throw new Error("Expected an own block with a free calldata slot");
+    }
+
+    get failedDisputeCommittedHandlerCalls(): number {
+        return this.failedDisputeCommittedCalls;
+    }
+
+    /**
+     * Make `onDisputeCommitted` throw, counting the dispatches that reached
+     * it - a re-dispatched dispute log that fails again.
+     */
+    failDisputeCommittedHandler(): void {
+        const eventHandler = this.sm.eventHandler;
+        if (!this.stubOriginals.has("disputeCommittedHandler")) {
+            this.stubOriginals.set(
+                "disputeCommittedHandler",
+                eventHandler.onDisputeCommitted.bind(eventHandler)
+            );
+        }
+        this.failedDisputeCommittedCalls = 0;
+        eventHandler.onDisputeCommitted = async () => {
+            this.failedDisputeCommittedCalls += 1;
+            throw new Error("stubbed onDisputeCommitted failure");
+        };
+    }
+
+    restoreDisputeCommittedHandler(): boolean {
+        const original = this.stubOriginals.get("disputeCommittedHandler");
+        if (original === undefined) return false;
+        this.sm.eventHandler.onDisputeCommitted =
+            original as typeof this.sm.eventHandler.onDisputeCommitted;
+        this.stubOriginals.delete("disputeCommittedHandler");
+        return true;
+    }
+
+    /** Make the dispute-window creation timestamp read throw. */
+    failDisputeWindowTimestampRead(): void {
+        const contract = this.sm.stateChannelManagerContract;
+        if (!this.stubOriginals.has("disputeWindowTimestamp")) {
+            this.stubOriginals.set(
+                "disputeWindowTimestamp",
+                contract.getDisputeWindowCreationTimestamp
+            );
+        }
+        contract.getDisputeWindowCreationTimestamp =
+            this.asRecordingContractMethod(
+                contract.getDisputeWindowCreationTimestamp,
+                async () => {
+                    throw new Error(
+                        "stubbed getDisputeWindowCreationTimestamp failure"
+                    );
+                }
+            );
+    }
+
+    restoreDisputeWindowTimestampRead(): boolean {
+        const original = this.stubOriginals.get("disputeWindowTimestamp");
+        if (original === undefined) return false;
+        this.sm.stateChannelManagerContract.getDisputeWindowCreationTimestamp =
+            original as StateChannelManagerProxy["getDisputeWindowCreationTimestamp"];
+        this.stubOriginals.delete("disputeWindowTimestamp");
+        return true;
+    }
+
+    /**
+     * Run the real `validateDisputeReductionAndChallenge` against a claimed
+     * `reducedForkId`, recording the challenge send instead of making it - a
+     * real challenge transaction would derail the session.
+     */
+    public async probeDisputeReductionChallenge(
+        reducedForkId: ForkId
+    ): Promise<ReductionChallengeProbe> {
+        const contract = this.sm.stateChannelManagerContract;
+        const original = contract.challengeDisputeReduction;
+        let challengeCalls = 0;
+        contract.challengeDisputeReduction = this.asRecordingContractMethod(
+            original,
+            async () => {
+                challengeCalls += 1;
+                return { wait: async () => null };
+            }
+        );
+        try {
+            const isValid = await this.sm.eventHandler[
+                "validateDisputeReductionAndChallenge"
+            ](this.sm.forkId, reducedForkId);
+            return { challengeCalls, isValid, threw: null };
+        } catch (error) {
+            return {
+                challengeCalls,
+                isValid: null,
+                threw: error instanceof Error ? error.message : String(error)
+            };
+        } finally {
+            contract.challengeDisputeReduction = original;
         }
     }
 

--- a/test/harness/actions/DisputeTamperingActions.ts
+++ b/test/harness/actions/DisputeTamperingActions.ts
@@ -119,6 +119,26 @@ export class DisputeTampering {
         dispute.input.timeout.participant = ZeroAddress;
         dispute.input.onChainSlashes = [];
     }
+
+    /**
+     * Upload posted auditing data with no inbound run. verifyStateProof never
+     * binds inboundMessageBlocks to the dispute's stated head, so re-pinning
+     * the auditing-data hash keeps the upload accepted while the auditor is
+     * handed nothing.
+     */
+    static emptyPostedInboundRun(
+        dispute: DisputeStruct,
+        _disputeConfirmation: DisputeConfirmationStruct,
+        auditingData?: DisputeAuditingDataStruct
+    ): void {
+        if (!auditingData) {
+            throw new Error("emptyPostedInboundRun needs posted auditing data");
+        }
+        auditingData.inboundMessageBlocks = [];
+        dispute.input.disputeAuditingDataHash = hash(
+            Codec.encode(auditingData, Type.DisputeAuditingData)
+        );
+    }
 }
 
 // Reused tamper statics are forwarded to the host as named strategies (they use

--- a/test/harness/actions/math/MathScenarioActions.ts
+++ b/test/harness/actions/math/MathScenarioActions.ts
@@ -239,7 +239,13 @@ export class MathScenarioActions extends ScenarioActions {
             chainFallbackTime?: number;
             evidenceTime?: number;
         };
-    }) {
+        /**
+         * Hold this peer's InboundMessagesProcessed handler across the join, so
+         * it never stores the inbound head the disputes will name and the other
+         * peers alone wait on the join.
+         */
+        laggingInboundPeerIndex?: number;
+    }): Promise<{ releaseLaggingInbound?: () => Promise<void> }> {
         const timeConfig = {
             evidenceTime: 12,
             ...options?.timeConfig
@@ -250,12 +256,31 @@ export class MathScenarioActions extends ScenarioActions {
             transitionCount: 0,
             timeConfig
         });
+        const laggingIndex = options?.laggingInboundPeerIndex;
+        const held =
+            laggingIndex === undefined
+                ? undefined
+                : await this.harness.rpcStub.holdInboundMessageEvents(
+                      laggingIndex
+                  );
         const forceJoin = await this.harness.join.prepareForceInboundJoinWait();
         await this.harness.transition.advanceState({ count: 2 });
-        await this.harness.join.submitPreparedForceInboundJoinWait(forceJoin);
+        await this.harness.join.submitPreparedForceInboundJoinWait(forceJoin, {
+            observePeerIndices:
+                laggingIndex === undefined
+                    ? undefined
+                    : this.harness.peers
+                          .map((peer) => peer.index)
+                          .filter((index) => index !== laggingIndex)
+        });
 
         this.harness.contextApi.captureOriginalFork();
         this.harness.event.resetEventSpies();
+        return {
+            releaseLaggingInbound: held
+                ? () => held.release({ replay: true })
+                : undefined
+        };
     }
 
     async setupTwoLeaversAcrossMilestones(options?: {
@@ -610,6 +635,58 @@ export class MathScenarioActions extends ScenarioActions {
             .request();
 
         return { observer, author, previous, forkId, parentPostTimestamp };
+    }
+
+    /**
+     * A committed dispute the observer never learned of: its reduction entry
+     * points are held so nothing auto-reduces, and its incoming
+     * dispute-committed events are suppressed, so the on-chain window is
+     * genuinely unreadable from its local storage. `passFirst` lets the first
+     * arriving dispute event through, which flips its local `isForkDisputed`.
+     */
+    async disputeWithSuppressedCommitEvents(options: {
+        observerIndex: number;
+        maliciousPeerIndex: number;
+        peerCount?: number;
+        initialBlocks?: number;
+        passFirst?: boolean;
+    }) {
+        const {
+            observerIndex,
+            maliciousPeerIndex,
+            peerCount = 4,
+            initialBlocks = 2,
+            passFirst = false
+        } = options;
+        const h = this.harness;
+        await h.lifecycle.start(peerCount, initialBlocks);
+        const forkId = h.activeForkId!;
+
+        const race = await h.rpcStub.holdReductionRace(observerIndex);
+        // drop the observer's incoming dispute-committed events before any
+        // dispute happens: the other honest peers' commitments are then
+        // genuinely never delivered here (not merely cleared from storage,
+        // which the event-dedup cache would treat as already processed and
+        // refuse to redeliver)
+        const restoreEvents = await h.rpcStub.holdDisputeCommittedEvents(
+            observerIndex,
+            { passFirst }
+        );
+
+        // real invalid transition -> honest peers dispute + commit on-chain
+        await h.byzantine.submitInvalidStateTransitionBlock(maliciousPeerIndex);
+        await h.assert.dispute.initiatedWait();
+        // exclude the observer - its own onDisputeCommitted delivery is held
+        await h.assert.dispute.committedWait({
+            peersIndices: h.peers
+                .map((peer) => peer.index)
+                .filter(
+                    (index) =>
+                        index !== observerIndex && index !== maliciousPeerIndex
+                )
+        });
+
+        return { forkId, race, restoreEvents };
     }
 
     async activeChannelWithDispute(options: {

--- a/test/harness/actions/rpcStubActions.ts
+++ b/test/harness/actions/rpcStubActions.ts
@@ -297,9 +297,56 @@ export class RpcStubActions<
     }
 
     /**
+     * Blind a peer's log recovery: every `provider.getLogs` throws, so no
+     * recovery query can succeed. Subscribed deliveries are unaffected - they
+     * arrive over `eth_subscribe`, never through `getLogs`.
+     */
+    async failChainLogQueries(peerIndex: number): Promise<{
+        restore: () => Promise<void>;
+    }> {
+        const ctl = () =>
+            this.harness.control(this.harness.getPeer(peerIndex)).stub;
+        await ctl().stubFailChainLogQueries().request();
+        this.logger.debug(`Failing chain log queries on peer ${peerIndex}`);
+        return {
+            restore: async () => {
+                await ctl().restoreChainLogQueries().request();
+            }
+        };
+    }
+
+    /**
+     * Make a peer's onDisputeCommitted throw -> every dispute log dispatched
+     * to it fails, a recovery's re-dispatch included.
+     */
+    async failDisputeCommittedHandler(peerIndex: number): Promise<{
+        /** Dispatches that reached the failing handler so far. */
+        handlerCalls: () => Promise<number>;
+        restore: () => Promise<void>;
+    }> {
+        const ctl = () =>
+            this.harness.control(this.harness.getPeer(peerIndex)).stub;
+        await ctl().stubFailDisputeCommittedHandler().request();
+        this.logger.debug(`Failing onDisputeCommitted on peer ${peerIndex}`);
+        return {
+            handlerCalls: async () =>
+                await ctl()
+                    .getFailedDisputeCommittedHandlerCallCount()
+                    .request(),
+            restore: async () => {
+                await ctl().restoreDisputeCommittedHandler().request();
+            }
+        };
+    }
+
+    /**
      * Hold a peer's InboundMessagesProcessed handler -> its chain view of the
      * inbound chain stops advancing while block ingest keeps running. Models a
      * lagging chain event: everything downstream of the handler is unapplied.
+     *
+     * This disables the handler, so on-demand inbound recovery cannot heal it
+     * either - recovery re-dispatches the log into the same held handler. Use
+     * it to stage the abstain; use `dropInboundMessageLogs` to stage recovery.
      */
     async holdInboundMessageEvents(peerIndex: number): Promise<{
         /** Chain events held so far. */
@@ -319,6 +366,50 @@ export class RpcStubActions<
             release: async (options = {}) => {
                 const { replay = true } = options;
                 await ctl().restoreInboundMessageEvents(replay).request();
+            }
+        };
+    }
+
+    /**
+     * Lose a peer's subscribed InboundMessagesProcessed deliveries before the
+     * event scheduler records them. The handler stays live, so an explicit
+     * query of the same log still applies it - this is the fixture on-demand
+     * inbound recovery can heal, unlike `holdInboundMessageEvents`.
+     *
+     * `dropCount: 1` loses one log and lets the next land, which moves the
+     * store head above the hole (`MessageBlockStorage.store` advances on any
+     * height >= the current one).
+     */
+    async dropInboundMessageLogs(
+        peerIndex: number,
+        options: { dropCount?: number } = {}
+    ): Promise<{
+        /** Distinct logs dropped so far. */
+        droppedCount: () => Promise<number>;
+        /**
+         * Wait until `count` deliveries have been lost. The subscription
+         * delivers to this peer independently of the peers a join waits on, so
+         * a test that needs the gap staged must wait for it.
+         */
+        waitUntilDropped: (count?: number, timeoutMs?: number) => Promise<void>;
+        /** Stop dropping; already-dropped logs stay recoverable by query. */
+        release: () => Promise<void>;
+    }> {
+        const ctl = () =>
+            this.harness.control(this.harness.getPeer(peerIndex)).stub;
+        await ctl().stubDropInboundMessageLogs(options.dropCount).request();
+        this.logger.debug(
+            `Dropping InboundMessagesProcessed logs on peer ${peerIndex}`,
+            { dropCount: options.dropCount }
+        );
+        const droppedCount = async () =>
+            await ctl().getDroppedInboundMessageLogCount().request();
+        return {
+            droppedCount,
+            waitUntilDropped: (count = 1, timeoutMs = 15000) =>
+                waitFor(async () => (await droppedCount()) >= count, timeoutMs),
+            release: async () => {
+                await ctl().restoreInboundMessageLogs().request();
             }
         };
     }

--- a/test/stateManager/EventSyncService.test.ts
+++ b/test/stateManager/EventSyncService.test.ts
@@ -1,9 +1,15 @@
 import { expect } from "chai";
+import { hexlify, zeroPadValue } from "ethers";
 
+import { Hash } from "@/types/types";
 import { MathTestSession as TestSession } from "@test/harness";
+import { waitFor } from "@test/utils/waitFor";
+
+// mirrors LOG_RECOVERY_ATTEMPTS in EventSyncService
+const LOG_RECOVERY_ATTEMPTS = 3;
 
 describe("EventSyncService", function () {
-    it("treats a failed log as fatal - never re-dispatched, cursor holds", async function () {
+    it("a failed log is retryable - re-dispatched, cursor advances once it succeeds", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(4, 0);
         const result = await h
@@ -12,15 +18,34 @@ describe("EventSyncService", function () {
             .request();
 
         expect(result.samePromise).to.equal(true);
-        expect(result.handlerCallCount).to.equal(1);
+        // the first delivery pair shares one dispatch, the reschedule re-enters
+        // the handler, and the second reschedule reuses the resolved promise
+        expect(result.handlerCallCount).to.equal(2);
         expect(result.firstError).to.equal("Expected event-sync rejection");
         expect(result.secondError).to.equal("Expected event-sync rejection");
         // the failure bubbles out of the detached promise
         expect(result.detachedError).to.equal("Expected event-sync rejection");
-        // rescheduling after the failure replays the rejection, it does not retry
+        // rescheduling after the failure retries it, it does not replay the
+        // cached rejection
+        expect(result.rescheduledError).to.equal(null);
+        // the log's block completed on the retry -> the watermark moves
+        expect(result.cursorAfter).to.be.greaterThan(result.cursorBefore ?? 0);
+    });
+
+    it("a log that keeps failing keeps the watermark below its block", async function () {
+        const h = TestSession.getHarness();
+        await h.lifecycle.start(4, 0);
+        const result = await h
+            .control(h.getPeer(0))
+            .stub.probeRejectedEventSyncLog({ recoverOnRetry: false })
+            .request();
+
+        // every reschedule dispatches again while the handler keeps failing
+        expect(result.handlerCallCount).to.equal(3);
         expect(result.rescheduledError).to.equal(
             "Expected event-sync rejection"
         );
+        // its block never completed -> the watermark must not move over it
         expect(result.cursorAfter).to.equal(result.cursorBefore);
     });
 
@@ -36,5 +61,369 @@ describe("EventSyncService", function () {
         expect(result.firstFound).to.equal(false);
         expect(result.secondFound).to.equal(false);
         expect(result.retryFound).to.equal(false);
+    });
+
+    describe("loadSynchronizedInboundRun", function () {
+        // the inbound head every case below asks the lagging peer to prove.
+        // topping up an existing participant moves the chain's inbound head
+        // without any block consuming it
+        const stageInboundHead = async (
+            h: ReturnType<typeof TestSession.getHarness>,
+            laggingIndex: number
+        ): Promise<Hash> => {
+            const observers = h.peers
+                .map((peer) => peer.index)
+                .filter((index) => index !== laggingIndex);
+            await h.join.forceInboundJoinWait({
+                participant: h.getPeer(observers[0]).address,
+                observePeerIndices: observers
+            });
+            return (await h
+                .control(h.getPeer(observers[0]))
+                .query.getLatestInboundMessageHash()
+                .request()) as Hash;
+        };
+
+        it("run already held → returned with no chain query", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 0);
+            const inboundHead = await stageInboundHead(h, 2);
+
+            const probe = await h
+                .control(h.getPeer(0))
+                .stub.probeInboundRunRecovery(inboundHead)
+                .request();
+
+            expect(probe.threw).to.equal(null);
+            expect(probe.heldBefore).to.equal(true);
+            expect(probe.queryCount).to.equal(0);
+            expect(probe.blockCount).to.be.greaterThan(0);
+        });
+
+        it("missed inbound log → recovered by query, the run becomes walkable", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 0);
+            const lagging = 2;
+            const dropped = await h.rpcStub.dropInboundMessageLogs(lagging);
+            const inboundHead = await stageInboundHead(h, lagging);
+
+            // premise - the delivery really was lost
+            await dropped.waitUntilDropped();
+
+            const probe = await h
+                .control(h.getPeer(lagging))
+                .stub.probeInboundRunRecovery(inboundHead)
+                .request();
+
+            expect(probe.threw).to.equal(null);
+            expect(probe.heldBefore).to.equal(false);
+            expect(probe.queryCount).to.be.greaterThan(0);
+            // the driver stops as soon as the probe is satisfied
+            expect(probe.queryCount).to.be.lessThan(LOG_RECOVERY_ATTEMPTS);
+            expect(probe.heldAfter).to.equal(true);
+            expect(probe.blockCount).to.be.greaterThan(0);
+
+            await dropped.release();
+        });
+
+        it("only the inbound log we do not hold is dispatched", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 0);
+            const lagging = 2;
+            const dropped = await h.rpcStub.dropInboundMessageLogs(lagging, {
+                dropCount: 1
+            });
+            // the first top-up's log is lost, the second one lands -> the store
+            // head sits above the hole the first left
+            await stageInboundHead(h, lagging);
+            await dropped.waitUntilDropped();
+            const inboundHead = await stageInboundHead(h, lagging);
+
+            // premise - the second log really landed, so the probe's dispatch
+            // count only counts what the recovery itself re-dispatched
+            await waitFor(
+                async () =>
+                    (await h
+                        .control(h.getPeer(lagging))
+                        .query.getLatestInboundMessageHash()
+                        .request()) === inboundHead,
+                15000
+            );
+
+            const probe = await h
+                .control(h.getPeer(lagging))
+                .stub.probeInboundRunRecovery(inboundHead)
+                .request();
+
+            expect(probe.threw).to.equal(null);
+            // the head is held, the block below it is not
+            expect(probe.heldBefore).to.equal(true);
+            expect(probe.queryCount).to.be.greaterThan(0);
+            // exactly the lost one: re-dispatching the log we already applied
+            // is pointless work, and that filter is what makes this terminate
+            expect(probe.scheduledLogCount).to.equal(1);
+            expect(probe.heldAfter).to.equal(true);
+            expect(probe.blockCount).to.be.greaterThan(0);
+
+            await dropped.release();
+        });
+
+        it("the widening span stays inside the watermark and the chain", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 0);
+            const lagging = 2;
+            // the handler is held, so the gap never closes and every attempt of
+            // the budget runs
+            const held = await h.rpcStub.holdInboundMessageEvents(lagging);
+            const inboundHead = await stageInboundHead(h, lagging);
+
+            const probe = await h
+                .control(h.getPeer(lagging))
+                .stub.probeInboundRunRecovery(inboundHead)
+                .request();
+
+            expect(probe.threw).to.equal(null);
+            expect(probe.queryCount).to.equal(LOG_RECOVERY_ATTEMPTS);
+            expect(probe.toBlock).to.be.greaterThan(0);
+            const fromBlocks = probe.queriedFromBlocks.map(
+                (fromBlock) => fromBlock ?? -1
+            );
+            for (const fromBlock of fromBlocks) {
+                expect(
+                    fromBlock,
+                    "every attempt queries a real block range"
+                ).to.be.at.least(0);
+                expect(
+                    fromBlock,
+                    "a span must not start above the chain head"
+                ).to.be.at.most(probe.toBlock ?? -1);
+                if (probe.cursorAtCall !== null) {
+                    expect(
+                        fromBlock,
+                        "a span must not start above the processed watermark"
+                    ).to.be.at.most(probe.cursorAtCall);
+                }
+            }
+            // widening only ever moves fromBlock down. on a short chain the
+            // span clamps to 0 and the doubling is not observable, so this is
+            // non-increasing, not strictly decreasing
+            expect(
+                fromBlocks.every(
+                    (fromBlock, index) =>
+                        index === 0 || fromBlock <= fromBlocks[index - 1]
+                ),
+                "the queried spans must never narrow"
+            ).to.equal(true);
+
+            await held.release({ replay: false });
+        });
+
+        it("gap survives recovery → undefined, no throw", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 0);
+            const lagging = 2;
+            // the handler itself is held, so the recovery's re-dispatch lands in
+            // the same hold -> the gap cannot be closed
+            const held = await h.rpcStub.holdInboundMessageEvents(lagging);
+            const inboundHead = await stageInboundHead(h, lagging);
+
+            const probe = await h
+                .control(h.getPeer(lagging))
+                .stub.probeInboundRunRecovery(inboundHead)
+                .request();
+
+            expect(probe.threw).to.equal(null);
+            expect(probe.heldBefore).to.equal(false);
+            // the probe never clears -> the whole attempt budget is spent
+            expect(probe.queryCount).to.equal(LOG_RECOVERY_ATTEMPTS);
+            expect(probe.heldAfter).to.equal(false);
+            expect(probe.blockCount).to.equal(null);
+
+            await held.release({ replay: false });
+        });
+
+        it("chain query fails during recovery → undefined, no throw", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 0);
+            const lagging = 2;
+            const dropped = await h.rpcStub.dropInboundMessageLogs(lagging);
+            const inboundHead = await stageInboundHead(h, lagging);
+            await dropped.waitUntilDropped();
+
+            // the same recoverable gap as above, but every getLogs throws
+            const probe = await h
+                .control(h.getPeer(lagging))
+                .stub.probeInboundRunRecovery(inboundHead, {
+                    failChainQueries: true
+                })
+                .request();
+
+            // the contract that keeps a flaky provider from evicting the peer
+            expect(probe.threw).to.equal(null);
+            // a failed query is one failed attempt - the rest still run
+            expect(probe.queryCount).to.equal(LOG_RECOVERY_ATTEMPTS);
+            expect(probe.blockCount).to.equal(null);
+
+            await dropped.release();
+        });
+    });
+
+    describe("tryRecoverBlockCalldataAndScheduleValidation", function () {
+        it("missed calldata log → recovered by query, validation scheduled", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 0);
+            // an off-wire block is authored but never posted on-chain, so its
+            // author owns a free calldata slot the probe can post into
+            const { leader } = await h.transition.authorNextBlockOffWireWait();
+
+            const probe = await h
+                .control(leader)
+                .stub.probeBlockCalldataRecovery()
+                .request();
+
+            expect(probe.threw).to.equal(null);
+            expect(probe.recoveredCalldata).to.equal(true);
+            expect(probe.validationScheduled).to.equal(true);
+            // one span already covers the whole window the calldata can be in
+            expect(probe.queryCount).to.equal(1);
+        });
+
+        it("chain queries fail → benign result, no throw, calldata absent", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 0);
+            const { leader } = await h.transition.authorNextBlockOffWireWait();
+
+            const probe = await h
+                .control(leader)
+                .stub.probeBlockCalldataRecovery({ failChainQueries: true })
+                .request();
+
+            expect(probe.threw).to.equal(null);
+            expect(probe.recoveredCalldata).to.equal(false);
+            expect(probe.validationScheduled).to.equal(false);
+            expect(probe.queryCount).to.equal(1);
+        });
+    });
+
+    describe("loadSynchronizedWindowCommitments", function () {
+        it("dispute recovery defeated → the window is reported unreadable, not thrown", async function () {
+            const h = TestSession.getHarness();
+            const observerIndex = 0;
+            const { forkId, race, restoreEvents } =
+                await h.scenario.disputeWithSuppressedCommitEvents({
+                    observerIndex,
+                    maliciousPeerIndex: 2
+                });
+
+            const blinded = await h.rpcStub.failChainLogQueries(observerIndex);
+            const recoveredCount = await h
+                .control(h.getPeer(observerIndex))
+                .dispute.recoverCommittedDisputes(forkId)
+                .request();
+            const queryCount = await h
+                .control(h.getPeer(observerIndex))
+                .stub.getChainLogQueryCount()
+                .request();
+            await blinded.restore();
+
+            // null = the window could not be made locally readable. the old
+            // code threw here, and the throw reached abort()
+            expect(recoveredCount).to.equal(null);
+            // a failed query is one failed attempt - the rest still run
+            expect(queryCount).to.equal(LOG_RECOVERY_ATTEMPTS);
+
+            await race.release({
+                replayEvents: false,
+                runHeldTasks: false,
+                keepTasksHeld: true
+            });
+            await restoreEvents(false);
+        });
+
+        it("dispute window-span read fails → failed recovery, no throw", async function () {
+            const h = TestSession.getHarness();
+            const observerIndex = 0;
+            const { forkId, race, restoreEvents } =
+                await h.scenario.disputeWithSuppressedCommitEvents({
+                    observerIndex,
+                    maliciousPeerIndex: 2
+                });
+
+            const ctl = h.control(h.getPeer(observerIndex));
+            await ctl.stub.stubCountChainLogQueries().request();
+            await ctl.stub.stubFailDisputeWindowTimestampRead().request();
+            const recoveredCount = await ctl.dispute
+                .recoverCommittedDisputes(forkId)
+                .request();
+            const queryCount = await ctl.stub.getChainLogQueryCount().request();
+            await ctl.stub.restoreDisputeWindowTimestampRead().request();
+            await ctl.stub.restoreChainLogQueries().request();
+
+            expect(recoveredCount).to.equal(null);
+            // the span read is contained ahead of the loop -> no query at all
+            expect(queryCount).to.equal(0);
+
+            await race.release({
+                replayEvents: false,
+                runHeldTasks: false,
+                keepTasksHeld: true
+            });
+            await restoreEvents(false);
+        });
+    });
+
+    describe("getSubscriptionFilter", function () {
+        // restated on purpose: this list is the oracle. dropping an event from
+        // the subscription changes which logs the peer receives at all, and the
+        // shared topic builder must not quietly reshape the filter
+        const SUBSCRIBED_EVENT_NAMES = [
+            "ChannelOpened",
+            "StateSnapshotUpdated",
+            "BlockCalldataPosted",
+            "DisputeCommitted",
+            "DisputeCommittedWithAuditingData",
+            "ChainSlashed",
+            "DisputeReducedResultCommitted",
+            "WithdrawalsUpdated",
+            "ChannelStorageCleared",
+            "DisputeKilled",
+            "InboundMessagesProcessed"
+        ] as const;
+
+        it("the subscription filter is unchanged by the shared topic builder", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 0);
+            const channelId = h.channelId!;
+
+            const filter = await h.execOnHost(
+                h.getPeer(0),
+                async (sm, args) => {
+                    const built = sm.eventSyncService.getSubscriptionFilter(
+                        args.channelId
+                    );
+                    return {
+                        address: String(built.address),
+                        topics: built.topics ?? []
+                    };
+                },
+                { channelId }
+            );
+
+            expect(filter.address).to.equal(
+                await h.channelManager.getAddress()
+            );
+            // only topic0 and the indexed channelId - the subscription has no
+            // third indexed constraint
+            expect(filter.topics.length).to.equal(2);
+            expect(filter.topics[0]).to.deep.equal(
+                SUBSCRIBED_EVENT_NAMES.map(
+                    (name) =>
+                        h.channelManager.interface.getEvent(name)!.topicHash
+                )
+            );
+            expect(filter.topics[1]).to.equal(
+                zeroPadValue(hexlify(channelId), 32)
+            );
+        });
     });
 });

--- a/test/stateManager/EventSyncService.test.ts
+++ b/test/stateManager/EventSyncService.test.ts
@@ -9,46 +9,6 @@ import { waitFor } from "@test/utils/waitFor";
 const LOG_RECOVERY_ATTEMPTS = 3;
 
 describe("EventSyncService", function () {
-    it("a failed log is retryable - re-dispatched, cursor advances once it succeeds", async function () {
-        const h = TestSession.getHarness();
-        await h.lifecycle.start(4, 0);
-        const result = await h
-            .control(h.getPeer(0))
-            .stub.probeRejectedEventSyncLog()
-            .request();
-
-        expect(result.samePromise).to.equal(true);
-        // the first delivery pair shares one dispatch, the reschedule re-enters
-        // the handler, and the second reschedule reuses the resolved promise
-        expect(result.handlerCallCount).to.equal(2);
-        expect(result.firstError).to.equal("Expected event-sync rejection");
-        expect(result.secondError).to.equal("Expected event-sync rejection");
-        // the failure bubbles out of the detached promise
-        expect(result.detachedError).to.equal("Expected event-sync rejection");
-        // rescheduling after the failure retries it, it does not replay the
-        // cached rejection
-        expect(result.rescheduledError).to.equal(null);
-        // the log's block completed on the retry -> the watermark moves
-        expect(result.cursorAfter).to.be.greaterThan(result.cursorBefore ?? 0);
-    });
-
-    it("a log that keeps failing keeps the watermark below its block", async function () {
-        const h = TestSession.getHarness();
-        await h.lifecycle.start(4, 0);
-        const result = await h
-            .control(h.getPeer(0))
-            .stub.probeRejectedEventSyncLog({ recoverOnRetry: false })
-            .request();
-
-        // every reschedule dispatches again while the handler keeps failing
-        expect(result.handlerCallCount).to.equal(3);
-        expect(result.rescheduledError).to.equal(
-            "Expected event-sync rejection"
-        );
-        // its block never completed -> the watermark must not move over it
-        expect(result.cursorAfter).to.equal(result.cursorBefore);
-    });
-
     it("joins concurrent calldata recovery onto one chain query", async function () {
         const h = TestSession.getHarness();
         await h.lifecycle.start(4, 0);

--- a/test/storage/ExitChannelBlockStorage.test.ts
+++ b/test/storage/ExitChannelBlockStorage.test.ts
@@ -95,6 +95,45 @@ describe("MessageBlockStorage - outbound behavior", () => {
             expect(latestBlocks[0]).to.deep.equal(newerBlock);
         });
 
+        it("head above a hole → truncates at the gap instead of throwing", () => {
+            storage.store(mockExitBlock);
+            const block1 = {
+                ...mockExitBlock,
+                previousBlockHash: mockBlockHash,
+                blockHeight: 1n
+            };
+            const hash1 = storage.store(block1);
+            // block 2 is never stored, so 3 and 4 sit above a hole
+            const block2 = {
+                ...mockExitBlock,
+                previousBlockHash: hash1,
+                blockHeight: 2n
+            };
+            const hash2 = ethers.keccak256(
+                Codec.encode(block2, Type.MessageBlock)
+            );
+            const block3 = {
+                ...mockExitBlock,
+                previousBlockHash: hash2,
+                blockHeight: 3n
+            };
+            const hash3 = storage.store(block3);
+            const block4 = {
+                ...mockExitBlock,
+                previousBlockHash: hash3,
+                blockHeight: 4n
+            };
+            storage.store(block4);
+
+            // the newest contiguous run, newest first
+            expect(storage.getLatestMessageBlocks()).to.deep.equal([
+                block4,
+                block3
+            ]);
+            // the limit path runs through the same walk
+            expect(storage.getLatestMessageBlocks(1)).to.deep.equal([block4]);
+        });
+
         it("returns blocks sorted from newest to oldest when no limit is provided", () => {
             storage.store(mockExitBlock);
             const followingBlock = {

--- a/test/storage/JoinChannelBlockStorage.test.ts
+++ b/test/storage/JoinChannelBlockStorage.test.ts
@@ -84,6 +84,93 @@ describe("MessageBlockStorage - inbound blocks", () => {
         });
     });
 
+    describe("tolerant range reads", () => {
+        // a chain 0..3 where block 2 was never stored, so the head sits above a
+        // hole - exactly what a missed InboundMessagesProcessed log leaves
+        let hash0: Hash;
+        let hash1: Hash;
+        let hash2: Hash;
+        let hash3: Hash;
+        let block1: MessageBlockStruct;
+        let block2: MessageBlockStruct;
+        let block3: MessageBlockStruct;
+
+        beforeEach(() => {
+            hash0 = storage.store(mockMessageBlock);
+            block1 = {
+                ...mockMessageBlock,
+                previousBlockHash: hash0,
+                blockHeight: 1n
+            };
+            hash1 = storage.store(block1);
+            block2 = {
+                ...mockMessageBlock,
+                previousBlockHash: hash1,
+                blockHeight: 2n
+            };
+            hash2 = hash(Codec.encode(block2, Type.MessageBlock));
+            block3 = {
+                ...mockMessageBlock,
+                previousBlockHash: hash2,
+                blockHeight: 3n
+            };
+            hash3 = storage.store(block3);
+        });
+
+        it("complete range → blocks oldest-first, no missingBlockHash", () => {
+            const run = storage.tryGetMessageBlocksInRange({
+                upperBlockHash: hash1,
+                lowerBlockHash: mockMessageBlock.previousBlockHash as Hash
+            });
+            expect(run.missingBlockHash).to.be.undefined;
+            expect(run.blocks).to.deep.equal([mockMessageBlock, block1]);
+        });
+
+        it("gap mid-range → blocks stop at the gap, missingBlockHash is the unheld hash", () => {
+            const run = storage.tryGetMessageBlocksInRange({
+                upperBlockHash: hash3,
+                lowerBlockHash: mockMessageBlock.previousBlockHash as Hash
+            });
+            expect(run.missingBlockHash).to.equal(hash2);
+            // only the part above the hole can be proven
+            expect(run.blocks).to.deep.equal([block3]);
+        });
+
+        it("unheld upperBlockHash → empty blocks, missingBlockHash is it", () => {
+            const run = storage.tryGetMessageBlocksInRange({
+                upperBlockHash: hash2,
+                lowerBlockHash: hash1
+            });
+            expect(run.missingBlockHash).to.equal(hash2);
+            expect(run.blocks).to.deep.equal([]);
+        });
+
+        it("upperBlockHash = ZeroHash → empty run, no gap (honest pre-genesis anchor)", () => {
+            const run = storage.tryGetMessageBlocksInRange({
+                upperBlockHash: ethers.ZeroHash,
+                lowerBlockHash: ethers.ZeroHash
+            });
+            expect(run.blocks).to.deep.equal([]);
+            expect(run.missingBlockHash).to.be.undefined;
+        });
+
+        it("empty store → empty run, no gap", () => {
+            const empty = new MessageBlockStorage();
+            const run = empty.tryGetMessageBlocksInRange();
+            expect(run.blocks).to.deep.equal([]);
+            expect(run.missingBlockHash).to.be.undefined;
+        });
+
+        it("the strict read still throws the same message on that gap", () => {
+            expect(() =>
+                storage.getMessageBlocksInRange({
+                    upperBlockHash: hash3,
+                    lowerBlockHash: mockMessageBlock.previousBlockHash as Hash
+                })
+            ).to.throw(`Block hash ${hash2} not found in storage`);
+        });
+    });
+
     describe("latest block helpers", () => {
         it("returns undefined when storage is empty", () => {
             expect(storage.getLatestMessageBlock()).to.be.undefined;

--- a/test/unit/AgreementManager.test.ts
+++ b/test/unit/AgreementManager.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { Codec, Type } from "@/utils";
-import type { BlockHeight } from "@/types/types";
+import type { BlockHeight, ForkId } from "@/types/types";
 import { MathTestSession as TestSession } from "@test/harness";
 import { hash as randomHash, randomAddress } from "../factory";
 import { waitFor } from "@test/utils/waitFor";
@@ -877,6 +877,140 @@ describe("Unit: AgreementManager", function () {
             expect(r.bogusDisputeCount).to.equal(0);
         });
 
+        // the reduce applies the chain's inbound run, which a peer whose
+        // InboundMessagesProcessed log never landed cannot walk
+        describe("inbound run the reduce applied", function () {
+            /**
+             * A committed settled-path dispute on a fork whose chain inbound
+             * head sits above `laggingIndex`'s store: the top-up of an existing
+             * participant keeps the head final-by-everyone, so no auditing data
+             * is posted and nothing back-fills the missing block.
+             */
+            const stageCommittedDisputeOverInboundGap = async (
+                h: ReturnType<typeof TestSession.getHarness>,
+                laggingIndex: number
+            ) => {
+                const observers = h.peers
+                    .map((peer) => peer.index)
+                    .filter((index) => index !== laggingIndex);
+                await h.join.forceInboundJoinWait({
+                    participant: h.getPeer(observers[0]).address,
+                    observePeerIndices: observers
+                });
+                const offenderIndex = (await h.query.getNextPeerToWrite())
+                    .index;
+                const disputerIndex = observers.find(
+                    (index) => index !== offenderIndex
+                )!;
+                await h.byzantine.submitInvalidStateTransitionBlock(
+                    offenderIndex
+                );
+                await h.assert.dispute.initiatedAndCommitedWait({
+                    peersIndices: [disputerIndex],
+                    expectedCount: 1,
+                    initiatedWithAuditingData: false
+                });
+                return { forkId: h.activeForkId!, disputerIndex };
+            };
+
+            /** reduce.staticCall over the window, then getReduceData for it. */
+            const readReduceData = (
+                h: ReturnType<typeof TestSession.getHarness>,
+                peerIndex: number,
+                forkId: ForkId
+            ) =>
+                h.execOnHost(
+                    h.getPeer(peerIndex),
+                    async (sm, args) => {
+                        const disputes =
+                            await sm.reductionManager.getSyncedForkDisputes(
+                                args.forkId
+                            );
+                        if (!disputes) {
+                            throw new Error(
+                                "expected a locally readable dispute window"
+                            );
+                        }
+                        const reducedOutput =
+                            await sm.stateChannelManagerContract.reduce.staticCall(
+                                disputes
+                            );
+                        let threw = "";
+                        let blockCount: number | null = null;
+                        try {
+                            const reduceData =
+                                await sm.agreementManager.getReduceData(
+                                    args.forkId,
+                                    reducedOutput
+                                );
+                            blockCount = reduceData
+                                ? reduceData.inboundMessageBlocks.length
+                                : null;
+                        } catch (e) {
+                            threw = e instanceof Error ? e.message : String(e);
+                        }
+                        return {
+                            threw,
+                            blockCount,
+                            disputeCount: disputes.length
+                        };
+                    },
+                    { forkId },
+                    { timeoutMs: 40000 }
+                );
+
+            it("unrecoverable reduce run → undefined, not a throw", async function () {
+                const h = TestSession.getHarness();
+                await h.setup(3);
+                await h.lifecycle.openChannel();
+                await h.transition.advanceState({
+                    count: 2,
+                    waitForFinalization: true
+                });
+                await h.assert.sync.peersInSyncWait();
+                const lagging = 2;
+                const held = await h.rpcStub.holdInboundMessageEvents(lagging);
+                const { forkId } = await stageCommittedDisputeOverInboundGap(
+                    h,
+                    lagging
+                );
+
+                const r = await readReduceData(h, lagging, forkId);
+
+                expect(r.disputeCount).to.be.greaterThan(0);
+                // it used to throw "Block hash ... not found in storage", which
+                // reached abort() through tryReduce -> failCompletion
+                expect(r.threw).to.equal("");
+                expect(r.blockCount).to.equal(null);
+                await held.release({ replay: false });
+            });
+
+            it("recoverable reduce run → the full applied run", async function () {
+                const h = TestSession.getHarness();
+                await h.setup(3);
+                await h.lifecycle.openChannel();
+                await h.transition.advanceState({
+                    count: 2,
+                    waitForFinalization: true
+                });
+                await h.assert.sync.peersInSyncWait();
+                const lagging = 2;
+                const dropped = await h.rpcStub.dropInboundMessageLogs(lagging);
+                const { forkId, disputerIndex } =
+                    await stageCommittedDisputeOverInboundGap(h, lagging);
+                await dropped.waitUntilDropped();
+
+                const lagged = await readReduceData(h, lagging, forkId);
+                const healthy = await readReduceData(h, disputerIndex, forkId);
+
+                expect(lagged.threw).to.equal("");
+                // the same run a peer that never lost the log computes
+                expect(lagged.blockCount).to.be.greaterThan(0);
+                expect(lagged.blockCount).to.equal(healthy.blockCount);
+                await dropped.release();
+            });
+        });
+
         // getReduceData's common branch (reduce keeps a real block -> resolve
         // its stored snapshot) is on the reduce path -> covered by the dispute
         // E2E suite. only the genesis branch below is a scenario that suite
@@ -908,6 +1042,12 @@ describe("Unit: AgreementManager", function () {
                         sm.forkId,
                         reducedOutput
                     );
+                    // the genesis reduce spans no inbound blocks, so the run is
+                    // trivially available - a miss here is a real regression
+                    if (!reduceData)
+                        throw new Error(
+                            "expected reduce data for the genesis reduce"
+                        );
                     const genesis =
                         sm.storage.stateSnapshots.getGenesisSnapshotByForkId(
                             sm.forkId

--- a/test/unit/BlockProductionService.test.ts
+++ b/test/unit/BlockProductionService.test.ts
@@ -86,6 +86,82 @@ describe("Unit: BlockProductionService", function () {
         });
     });
 
+    describe("getPendingInboundMessageBlocks over a gap", function () {
+        it("own head above a missing inbound log → the block is produced with no inbound carry", async function () {
+            const h = TestSession.getHarness();
+            await h.lifecycle.start(3, 1);
+            const forkId = h.activeForkId!;
+
+            // the next writer is the peer that will produce over the gap
+            const writer = await h.query.getNextPeerToWrite();
+            const other = h.peers.find((p) => p.index !== writer.index)!;
+            const observers = h.peers
+                .map((peer) => peer.index)
+                .filter((index) => index !== writer.index);
+
+            // exactly one inbound log is lost, so the next one still lands and
+            // MessageBlockStorage.store moves the head above the hole
+            const dropped = await h.rpcStub.dropInboundMessageLogs(
+                writer.index,
+                { dropCount: 1 }
+            );
+            for (const participantIndex of observers) {
+                await h.join.forceInboundJoinWait({
+                    participant: h.getPeer(participantIndex).address,
+                    observePeerIndices: observers
+                });
+            }
+            await dropped.waitUntilDropped();
+
+            const heightBefore = await h
+                .control(writer)
+                .query.getNextBlockHeight(forkId)
+                .request();
+            // the writer's head sits above a hole -> it can carry nothing, while
+            // a peer that holds the whole chain still has messages pending
+            expect(
+                await h
+                    .control(writer)
+                    .query.getPendingInboundMessageBlockCount(forkId)
+                    .request()
+            ).to.equal(0);
+            expect(
+                await h
+                    .control(other)
+                    .query.getPendingInboundMessageBlockCount(forkId)
+                    .request()
+            ).to.be.greaterThan(0);
+
+            await h.transition.advanceState({
+                count: 1,
+                waitForPeers: observers
+            });
+
+            const bundle = await h
+                .control(writer)
+                .query.getBlockByHeight(forkId, heightBefore)
+                .request();
+            const produced = Block.fromSignedBlock(
+                Codec.decode(bundle!.encodedSignedBlock, Type.SignedBlock)
+            );
+            expect(String(produced.author)).to.equal(writer.address);
+            // an empty carry is legal - detectForgedInboundMessageBlock returns
+            // early for it - so the other peers accept the block
+            expect(produced.blockStruct.messageBlocks).to.deep.equal([]);
+            for (const peerIndex of observers) {
+                expect(
+                    await h
+                        .control(h.getPeer(peerIndex))
+                        .query.getBlockHashAt(forkId, heightBefore)
+                        .request(),
+                    `peer ${peerIndex} must have accepted the block`
+                ).to.equal(bundle!.hash);
+            }
+
+            await dropped.release();
+        });
+    });
+
     describe("playTransaction → guards", function () {
         it("not my turn → throws instead of authoring", async function () {
             const h = TestSession.getHarness();

--- a/test/unit/DisputeManager.test.ts
+++ b/test/unit/DisputeManager.test.ts
@@ -290,14 +290,14 @@ describe("Unit: DisputeManager", function () {
             );
         });
 
-        // no test: `createDispute - isPartial auditingData` is unreachable from
-        // constructDispute. a peer's own proof only spans data it stored - a
-        // missing milestone snapshot already throws inside getStateProof
-        // ("Milestone built but corresponding snapshot not found") and the head
-        // snapshot is required by the "missing state snapshot" guard above it.
-        // getAuditingData only goes partial for a proof handed in by someone
-        // else, which is the audit path covered under `getAuditingData`.
-        it.skip("own proof missing referenced data → isPartial auditingData (unreachable)", function () {});
+        // the snapshot causes of `createDispute - isPartial auditingData` stay
+        // unreachable from constructDispute: a missing milestone snapshot
+        // already throws inside getStateProof ("Milestone built but
+        // corresponding snapshot not found") and the head snapshot is required
+        // by the "missing state snapshot" guard above it. the one reachable
+        // cause is an inbound run the peer's own head sits above and recovery
+        // cannot close - covered by the mid-gap case under `getAuditingData`.
+        it.skip("own proof missing a referenced snapshot → isPartial auditingData (unreachable)", function () {});
 
         it("a peer behind the head → constructDispute builds a complete dispute over what it has", async function () {
             const h = TestSession.getHarness();
@@ -466,7 +466,7 @@ describe("Unit: DisputeManager", function () {
                         height
                     );
                     const { isPartial, auditingData } =
-                        sm.disputeManager.getAuditingData(
+                        await sm.disputeManager.getAuditingData(
                             args.forkId,
                             stateProof
                         );
@@ -518,6 +518,168 @@ describe("Unit: DisputeManager", function () {
             expect(synced.isPartial).to.equal(false);
         });
 
+        // the inbound run the dispute names is rebuilt from the auditor's own
+        // store, so an auditor that never received the log has to recover it
+        describe("inbound run", function () {
+            /**
+             * A settled-path dispute from `disputerIndex` whose stated inbound
+             * head the lagging peer does not hold. Returns what an auditor needs
+             * to recompute the run.
+             */
+            const stageStatedInboundHead = async (
+                h: ReturnType<typeof TestSession.getHarness>,
+                laggingIndex: number,
+                disputerIndex: number
+            ) => {
+                await h.join.forceInboundJoinWait({
+                    participant: h.getPeer(disputerIndex).address,
+                    observePeerIndices: h.peers
+                        .map((peer) => peer.index)
+                        .filter((index) => index !== laggingIndex)
+                });
+                const forkId = h.activeForkId!;
+                const { encodedDispute } = await h
+                    .control(h.getPeer(disputerIndex))
+                    .dispute.constructDispute(forkId)
+                    .request();
+                const dispute = Codec.decode(encodedDispute, Type.Dispute);
+                const statedInboundHash = dispute.input
+                    .latestInboundMessageBlockHash as Hash;
+                // premise - the lagging peer cannot walk to the stated head
+                expect(
+                    await h
+                        .control(h.getPeer(laggingIndex))
+                        .query.getInboundMessageBlock(statedInboundHash)
+                        .request()
+                ).to.equal(null);
+                return {
+                    forkId,
+                    dispute,
+                    statedInboundHash,
+                    encodedStateProof: Codec.encode(
+                        dispute.input.stateProof,
+                        Type.StateProof
+                    ) as string
+                };
+            };
+
+            it("recoverable gap → not partial, and the hash still agrees with the disputer's", async function () {
+                const h = TestSession.getHarness();
+                await h.setup(3);
+                await h.lifecycle.openChannel();
+                const lagging = 2;
+                const dropped = await h.rpcStub.dropInboundMessageLogs(lagging);
+                const {
+                    forkId,
+                    dispute,
+                    statedInboundHash,
+                    encodedStateProof
+                } = await stageStatedInboundHead(h, lagging, 0);
+                await dropped.waitUntilDropped();
+
+                const audited = await h
+                    .control(h.getPeer(lagging))
+                    .dispute.getAuditingData(forkId, encodedStateProof, {
+                        disputeLatestInboundMessageBlockHash: statedInboundHash
+                    })
+                    .request();
+
+                expect(audited.isPartial).to.equal(false);
+                // recovery restores the agreement, not just liveness
+                expect(hash(audited.encodedAuditingData)).to.equal(
+                    dispute.input.disputeAuditingDataHash
+                );
+                await dropped.release();
+            });
+
+            it("unrecoverable gap → isPartial true, empty inbound run, no throw", async function () {
+                const h = TestSession.getHarness();
+                await h.setup(3);
+                await h.lifecycle.openChannel();
+                const lagging = 2;
+                // the handler is held, so the recovery's re-dispatch is lost too
+                const held = await h.rpcStub.holdInboundMessageEvents(lagging);
+                const { forkId, statedInboundHash, encodedStateProof } =
+                    await stageStatedInboundHead(h, lagging, 0);
+
+                const audited = await h
+                    .control(h.getPeer(lagging))
+                    .dispute.getAuditingData(forkId, encodedStateProof, {
+                        disputeLatestInboundMessageBlockHash: statedInboundHash
+                    })
+                    .request();
+
+                expect(audited.isPartial).to.equal(true);
+                // it returned instead of throwing "Block hash ... not found"
+                const auditingData = Codec.decode(
+                    audited.encodedAuditingData,
+                    Type.DisputeAuditingData
+                );
+                expect(auditingData.inboundMessageBlocks).to.deep.equal([]);
+                await held.release({ replay: false });
+            });
+
+            it("own head above an unrecoverable mid-gap → PartialAuditingDataError, not a storage throw", async function () {
+                const h = TestSession.getHarness();
+                await h.setup(3);
+                await h.lifecycle.openChannel();
+                const lagging = 2;
+                const forkId = h.activeForkId!;
+                // exactly one log is lost, so the next one lands and moves the
+                // store head above the hole
+                const dropped = await h.rpcStub.dropInboundMessageLogs(
+                    lagging,
+                    {
+                        dropCount: 1
+                    }
+                );
+                for (const participantIndex of [0, 1]) {
+                    await h.join.forceInboundJoinWait({
+                        participant: h.getPeer(participantIndex).address,
+                        observePeerIndices: [0, 1]
+                    });
+                }
+                await dropped.waitUntilDropped();
+
+                const laggingCtl = h.control(h.getPeer(lagging));
+                await laggingCtl.stub.stubFailChainLogQueries().request();
+                const r = await h.execOnHost(
+                    h.getPeer(lagging),
+                    async (sm, args) => {
+                        let threw = "";
+                        let errorName = "";
+                        try {
+                            await sm.disputeManager.constructDispute(
+                                args.forkId
+                            );
+                        } catch (e) {
+                            threw = e instanceof Error ? e.message : String(e);
+                            errorName =
+                                e instanceof Error ? e.constructor.name : "";
+                        }
+                        return {
+                            threw,
+                            errorName,
+                            storedHead:
+                                sm.storage.inboundMessages.getLatestBlockHash() ??
+                                null
+                        };
+                    },
+                    { forkId },
+                    { timeoutMs: 30000 }
+                );
+                await laggingCtl.stub.restoreChainLogQueries().request();
+
+                // premise - the head moved even though a log below it is missing
+                expect(r.storedHead).to.not.equal(null);
+                // the named contract canConstructMoreEvidence catches, and not
+                // the storage walk's throw
+                expect(r.errorName).to.equal("PartialAuditingDataError");
+                expect(r.threw).to.not.contain("not found in storage");
+                await dropped.release();
+            });
+        });
+
         it("an empty state proof → latest state snapshot falls back to genesis, not partial", async function () {
             const h = TestSession.getHarness();
             await h.lifecycle.start(3, 0); // no blocks -> empty proof at height 0
@@ -531,7 +693,7 @@ describe("Unit: DisputeManager", function () {
                         0
                     );
                     const { isPartial, auditingData } =
-                        sm.disputeManager.getAuditingData(
+                        await sm.disputeManager.getAuditingData(
                             args.forkId,
                             stateProof
                         );

--- a/test/unit/DisputeValidationService.test.ts
+++ b/test/unit/DisputeValidationService.test.ts
@@ -15,6 +15,7 @@ import {
     MathTestSession as TestSession,
     resolveTestTimeConfig
 } from "@test/harness";
+import { DisputeTampering } from "@test/harness/actions/DisputeTamperingActions";
 
 // the auditor's contract: verdict + the exact stored fraud proof. the
 // kill/counter-dispute/slash cascades stay owned by test/e2e/disputeValidation.
@@ -641,6 +642,122 @@ describe("Unit: DisputeValidationService", function () {
         // still syncs it, pinned by the test above. only a peer that left the
         // channel is outside the expected set, and it no longer audits.
         it.skip("milestones[-1].blockConfirmations[0] missing from the auditor's block storage -> audit skipped", function () {});
+
+        // the auditor rebuilds the inbound run the dispute names from its own
+        // store, on both the settled and the posted path
+        describe("inbound run the auditor does not hold", function () {
+            /** A settled-path dispute naming an inbound head peer 2 misses. */
+            const stageLaggingAuditor = async (
+                h: ReturnType<typeof TestSession.getHarness>,
+                laggingIndex: number
+            ) => {
+                await h.join.forceInboundJoinWait({
+                    participant: h.getPeer(0).address,
+                    observePeerIndices: h.peers
+                        .map((peer) => peer.index)
+                        .filter((index) => index !== laggingIndex)
+                });
+                await h
+                    .control(h.getPeer(0))
+                    .dispute.setForceExit(true)
+                    .request();
+                const { dispute } = await h.dispute.fetchConstructedDispute(0);
+                expect(dispute.postedAuditingData).to.equal(false);
+                const statedHead = dispute.input
+                    .latestInboundMessageBlockHash as Hash;
+                expect(
+                    await h
+                        .control(h.getPeer(laggingIndex))
+                        .query.getInboundMessageBlock(statedHead)
+                        .request(),
+                    "auditor must not hold the stated inbound head"
+                ).to.equal(null);
+                return { dispute, statedHead };
+            };
+
+            it("settled path, unrecoverable gap -> audit abstains: true, zero proofs", async function () {
+                const h = TestSession.getHarness();
+                await h.setup(3);
+                await h.lifecycle.openChannel();
+                const lagging = 2;
+                const held = await h.rpcStub.holdInboundMessageEvents(lagging);
+                const { dispute } = await stageLaggingAuditor(h, lagging);
+
+                const run = await h.dispute.auditDispute(lagging, dispute);
+
+                // it used to be outcome "threw" (Block hash ... not found)
+                expect(run).to.include({ outcome: "returned", isValid: true });
+                // our own missing history is nobody's fraud
+                expect(run.disputeFraudProofCount).to.equal(0);
+                await held.release({ replay: false });
+            });
+
+            it("settled path, recoverable gap -> full audit, zero proofs, the run is now held", async function () {
+                const h = TestSession.getHarness();
+                await h.setup(3);
+                await h.lifecycle.openChannel();
+                const lagging = 2;
+                const dropped = await h.rpcStub.dropInboundMessageLogs(lagging);
+                const { dispute, statedHead } = await stageLaggingAuditor(
+                    h,
+                    lagging
+                );
+                await dropped.waitUntilDropped();
+
+                const run = await h.dispute.auditDispute(lagging, dispute);
+
+                expect(run).to.include({ outcome: "returned", isValid: true });
+                expect(run.disputeFraudProofCount).to.equal(0);
+                // it audited for real instead of abstaining
+                expect(
+                    await h
+                        .control(h.getPeer(lagging))
+                        .query.getInboundMessageBlock(statedHead)
+                        .request(),
+                    "the audit must have recovered the stated inbound head"
+                ).to.not.equal(null);
+                await dropped.release();
+            });
+
+            it("posted path with an emptied posted run + gap -> same abstain, zero proofs", async function () {
+                const h = TestSession.getHarness();
+                const lagging = 1;
+                const { releaseLaggingInbound } =
+                    await h.scenario.preDisputeSetupCalldataPath({
+                        laggingInboundPeerIndex: lagging
+                    });
+                const { dispute, disputeConfirmation, auditingData } =
+                    await h.dispute.fetchConstructedDispute(0);
+                expect(dispute.postedAuditingData).to.equal(true);
+                expect(
+                    await h
+                        .control(h.getPeer(lagging))
+                        .query.getInboundMessageBlock(
+                            dispute.input.latestInboundMessageBlockHash
+                        )
+                        .request(),
+                    "auditor must not hold the stated inbound head"
+                ).to.equal(null);
+
+                // the attacker hands the auditor nothing: verifyStateProof never
+                // binds the posted run to the dispute's stated head
+                DisputeTampering.emptyPostedInboundRun(
+                    dispute,
+                    disputeConfirmation,
+                    auditingData
+                );
+
+                const run = await h.dispute.auditDispute(
+                    lagging,
+                    dispute,
+                    auditingData
+                );
+
+                expect(run).to.include({ outcome: "returned", isValid: true });
+                expect(run.disputeFraudProofCount).to.equal(0);
+                await releaseLaggingInbound?.();
+            });
+        });
 
         it("stateProof.milestones = [] AND signedBlocks = [] -> stored genesis snapshot + forkId == snapshotDataHash, true", async function () {
             const h = TestSession.getHarness();

--- a/test/unit/ReductionExecutor.test.ts
+++ b/test/unit/ReductionExecutor.test.ts
@@ -1,8 +1,363 @@
 import { expect } from "chai";
+import { ForkId } from "@/types/types";
+import { Status } from "@/types";
+import { hash as randomHash } from "@test/factory";
 import { MathTestSession as TestSession } from "@test/harness";
 import { waitFor } from "@test/utils/waitFor";
 
 describe("Unit: ReductionExecutor", function () {
+    // a reduce whose inbound run this peer cannot walk yields no reduce data.
+    // that outcome must reschedule, never reach ReductionManager.failCompletion
+    // (which answers with abort() and strands the peer for good)
+    describe("reduce data unavailable", function () {
+        /**
+         * A committed settled-path dispute whose reduce moves the inbound head
+         * past `laggingIndex`'s store. Its handler is held, so nothing - the
+         * on-demand recovery included - can close the gap until release.
+         */
+        const stageDisputeOverHeldInboundGap = async (
+            h: ReturnType<typeof TestSession.getHarness>,
+            laggingIndex: number
+        ) => {
+            await h.setup(3, {
+                timeConfig: {
+                    p2pTime: 2,
+                    agreementTime: 8,
+                    chainFallbackTime: 4,
+                    evidenceTime: 4
+                }
+            });
+            await h.lifecycle.openChannel();
+            const forkId = h.activeForkId!;
+            await h.transition.advanceState({
+                count: 2,
+                waitForFinalization: true
+            });
+            await h.assert.sync.peersInSyncWait();
+
+            const held = await h.rpcStub.holdInboundMessageEvents(laggingIndex);
+            const observers = h.peers
+                .map((peer) => peer.index)
+                .filter((index) => index !== laggingIndex);
+            // a top-up of an existing participant keeps the head
+            // final-by-everyone -> the settled path posts no auditing data, so
+            // nothing back-fills the block this peer never received
+            await h.join.forceInboundJoinWait({
+                participant: h.getPeer(observers[0]).address,
+                observePeerIndices: observers
+            });
+
+            h.event.resetEventSpies();
+            h.contextApi.captureOriginalFork();
+
+            const offenderIndex = (await h.query.getNextPeerToWrite()).index;
+            const disputerIndex = observers.find(
+                (index) => index !== offenderIndex
+            )!;
+            await h.byzantine.submitInvalidStateTransitionBlock(offenderIndex);
+            await h.assert.dispute.initiatedAndCommitedWait({
+                peersIndices: [disputerIndex],
+                expectedCount: 1,
+                initiatedWithAuditingData: false
+            });
+            return { forkId, held, disputerIndex };
+        };
+
+        it("no reduce data → the attempt reschedules, the peer keeps participating, a later attempt completes", async function () {
+            const h = TestSession.getHarness();
+            const laggingIndex = 2;
+            const { forkId, held } = await stageDisputeOverHeldInboundGap(
+                h,
+                laggingIndex
+            );
+            const scheduled =
+                await h.rpcStub.recordScheduledTasks(laggingIndex);
+
+            // let the kill period lapse - before that the attempt returns at
+            // the gate and never reaches the reduce computation
+            await waitFor(
+                async () =>
+                    h.execOnHost(
+                        h.getPeer(laggingIndex),
+                        async (sm, a) => {
+                            const { isExpired } =
+                                await sm.reductionManager.isKillPeriodExpiredCached(
+                                    a.forkId
+                                );
+                            return isExpired;
+                        },
+                        { forkId }
+                    ),
+                25000
+            );
+
+            // drive the executor directly: ReductionManager.tryReduce returns
+            // the shared completion promise, which a deferred attempt leaves
+            // pending on purpose
+            const outcome = await h.execOnHost(
+                h.getPeer(laggingIndex),
+                async (sm, args) => {
+                    let threw = "";
+                    try {
+                        await sm.reductionManager[
+                            "reductionExecutor"
+                        ].tryReduce(args.forkId);
+                    } catch (e) {
+                        threw = e instanceof Error ? e.message : String(e);
+                    }
+                    return { threw, forkIdAfter: String(sm.forkId) };
+                },
+                { forkId },
+                { timeoutMs: 40000 }
+            );
+
+            // the regression: this used to throw out of the executor, and
+            // ReductionManager answered the throw with abort()
+            expect(outcome.threw).to.equal("");
+            expect(outcome.forkIdAfter).to.equal(forkId);
+            expect(
+                (await scheduled.tasks()).map((task) => task.taskName)
+            ).to.include(`reduction-${forkId}`);
+            expect(
+                await h
+                    .control(h.getPeer(laggingIndex))
+                    .query.getStatus()
+                    .request(),
+                "a deferred reduction must not evict the peer"
+            ).to.equal(Status.PARTICIPATING);
+            expect(
+                await h
+                    .control(h.getPeer(laggingIndex))
+                    .query.getDisputeFraudProofTypes()
+                    .request()
+            ).to.deep.equal([]);
+            await scheduled.restore();
+
+            // the missing log lands -> the rescheduled attempt has the run it
+            // needs and the fork finally moves
+            await held.release();
+            await h.assert.sync.forkChangedWait({
+                originalForkId: forkId,
+                honestPeerIndices: [laggingIndex],
+                timeoutMs: 25000
+            });
+        });
+
+        it("someone else's reduction while the run is unavailable → not challenged, no throw", async function () {
+            const h = TestSession.getHarness();
+            const laggingIndex = 2;
+            const { held, disputerIndex } =
+                await stageDisputeOverHeldInboundGap(h, laggingIndex);
+
+            // a reduced fork id that matches nothing locally: with reduce data
+            // the peer would challenge it, without reduce data it must not
+            const claimedReducedForkId = randomHash() as ForkId;
+            const lagging = await h
+                .control(h.getPeer(laggingIndex))
+                .stub.probeDisputeReductionChallenge(claimedReducedForkId)
+                .request();
+
+            expect(lagging.threw).to.equal(null);
+            // true = do not challenge, and follow the chain instead
+            expect(lagging.isValid).to.equal(true);
+            expect(lagging.challengeCalls).to.equal(0);
+
+            // control: a peer that CAN rebuild the run challenges the same
+            // claim, so the probe really does observe challenges
+            const healthy = await h
+                .control(h.getPeer(disputerIndex))
+                .stub.probeDisputeReductionChallenge(claimedReducedForkId)
+                .request();
+            expect(healthy.isValid).to.equal(false);
+            expect(healthy.challengeCalls).to.equal(1);
+
+            await held.release({ replay: false });
+        });
+    });
+
+    // a window whose disputes are on-chain but unreadable locally must defer
+    // the same way, not be mistaken for an empty window (which would answer it
+    // with a fresh local dispute) and not reach failCompletion -> abort()
+    describe("dispute window unavailable", function () {
+        const observerIndex = 0;
+        const maliciousPeerIndex = 2;
+
+        /** Wait out the kill period - before it the attempt exits at the gate. */
+        const waitForKillPeriod = (
+            h: ReturnType<typeof TestSession.getHarness>,
+            forkId: ForkId
+        ) =>
+            waitFor(
+                async () =>
+                    h.execOnHost(
+                        h.getPeer(observerIndex),
+                        async (sm, a) => {
+                            const { isExpired } =
+                                await sm.reductionManager.isKillPeriodExpiredCached(
+                                    a.forkId
+                                );
+                            return isExpired;
+                        },
+                        { forkId }
+                    ),
+                20000
+            );
+
+        /** Drive the executor directly - a deferred attempt never settles. */
+        const tryReduceByHand = (
+            h: ReturnType<typeof TestSession.getHarness>,
+            forkId: ForkId
+        ) =>
+            h.execOnHost(
+                h.getPeer(observerIndex),
+                async (sm, args) => {
+                    let threw = "";
+                    try {
+                        await sm.reductionManager[
+                            "reductionExecutor"
+                        ].tryReduce(args.forkId);
+                    } catch (e) {
+                        threw = e instanceof Error ? e.message : String(e);
+                    }
+                    return { threw, forkIdAfter: String(sm.forkId) };
+                },
+                { forkId },
+                { timeoutMs: 40000 }
+            );
+
+        it("unreadable dispute window → the attempt defers instead of aborting", async function () {
+            const h = TestSession.getHarness();
+            const { forkId, race, restoreEvents } =
+                await h.scenario.disputeWithSuppressedCommitEvents({
+                    observerIndex,
+                    maliciousPeerIndex
+                });
+            const scheduled =
+                await h.rpcStub.recordScheduledTasks(observerIndex);
+            await waitForKillPeriod(h, forkId);
+
+            const commitmentsBefore = (
+                await h.channelManager.getWindowCommitments(h.channelId, forkId)
+            ).length;
+            const blinded = await h.rpcStub.failChainLogQueries(observerIndex);
+            const outcome = await tryReduceByHand(h, forkId);
+
+            // the regression: this used to throw out of the executor, and
+            // ReductionManager answered the throw with abort()
+            expect(outcome.threw).to.equal("");
+            expect(outcome.forkIdAfter).to.equal(forkId);
+            expect(
+                await h
+                    .control(h.getPeer(observerIndex))
+                    .query.getStatus()
+                    .request(),
+                "a deferred reduction must not evict the peer"
+            ).to.equal(Status.PARTICIPATING);
+            expect(
+                (await scheduled.tasks()).map((task) => task.taskName)
+            ).to.include(`reduction-${forkId}`);
+            // an unreadable window must not be answered with a fresh local
+            // dispute - that is the `disputes.length === 0` branch below it
+            expect(
+                (
+                    await h.channelManager.getWindowCommitments(
+                        h.channelId,
+                        forkId
+                    )
+                ).length,
+                "the on-chain window must not grow"
+            ).to.equal(commitmentsBefore);
+            await scheduled.restore();
+
+            // the queries come back -> the next attempt reads the window and
+            // reduces
+            await blinded.restore();
+            const recovered = await tryReduceByHand(h, forkId);
+            expect(recovered.threw).to.equal("");
+            expect(
+                recovered.forkIdAfter,
+                "the recovered attempt must move the fork"
+            ).to.not.equal(forkId);
+
+            await race.release({
+                replayEvents: false,
+                runHeldTasks: false,
+                keepTasksHeld: true
+            });
+            await restoreEvents(false);
+        });
+
+        it("a re-dispatched dispute log that fails again → failed attempt, not a fatal", async function () {
+            const h = TestSession.getHarness();
+            const { forkId, race, restoreEvents } =
+                await h.scenario.disputeWithSuppressedCommitEvents({
+                    observerIndex,
+                    maliciousPeerIndex
+                });
+            await waitForKillPeriod(h, forkId);
+
+            // the queries succeed, but every re-dispatched dispute log throws
+            // inside the handler - the Promise.all leg that used to reject out
+            // of the recovery into abort()
+            const failing =
+                await h.rpcStub.failDisputeCommittedHandler(observerIndex);
+            const outcome = await tryReduceByHand(h, forkId);
+
+            expect(outcome.threw).to.equal("");
+            expect(outcome.forkIdAfter).to.equal(forkId);
+            expect(
+                await h
+                    .control(h.getPeer(observerIndex))
+                    .query.getStatus()
+                    .request(),
+                "a failed re-dispatch must not evict the peer"
+            ).to.equal(Status.PARTICIPATING);
+            expect(
+                await failing.handlerCalls(),
+                "the recovery must really have re-dispatched the held logs"
+            ).to.be.greaterThan(0);
+            await failing.restore();
+
+            await race.release({
+                replayEvents: false,
+                runHeldTasks: false,
+                keepTasksHeld: true
+            });
+            await restoreEvents(false);
+        });
+
+        it("unreadable dispute window → the reduction is not challenged", async function () {
+            const h = TestSession.getHarness();
+            const { race, restoreEvents } =
+                await h.scenario.disputeWithSuppressedCommitEvents({
+                    observerIndex,
+                    maliciousPeerIndex
+                });
+
+            // a reduced fork id that matches nothing locally: with a readable
+            // window the peer would challenge it, without one it must not
+            const claimedReducedForkId = randomHash() as ForkId;
+            const blinded = await h.rpcStub.failChainLogQueries(observerIndex);
+            const probe = await h
+                .control(h.getPeer(observerIndex))
+                .stub.probeDisputeReductionChallenge(claimedReducedForkId)
+                .request();
+            await blinded.restore();
+
+            expect(probe.threw).to.equal(null);
+            // true = do not challenge, and follow the chain instead
+            expect(probe.isValid).to.equal(true);
+            expect(probe.challengeCalls).to.equal(0);
+
+            await race.release({
+                replayEvents: false,
+                runHeldTasks: false,
+                keepTasksHeld: true
+            });
+            await restoreEvents(false);
+        });
+    });
+
     describe("getSyncedForkDisputes", function () {
         // a dispute commitment lands on-chain before our onDisputeCommitted
         // handler stores the struct. tryReduce firing in that gap used to
@@ -12,32 +367,11 @@ describe("Unit: ReductionExecutor", function () {
         it("committed dispute missing locally → recovers via event replay, then reduces", async function () {
             const h = TestSession.getHarness();
             const observerIndex = 0;
-            const maliciousPeerIndex = 2;
-
-            await h.lifecycle.start(4, 2);
-            const forkId = h.activeForkId!;
-
-            // hold every reduction entry point so nothing auto-reduces -
-            // we call tryReduce by hand below
-            const race = await h.rpcStub.holdReductionRace(observerIndex);
-
-            // drop the observer's incoming dispute-committed events before
-            // any dispute happens: the other honest peers' commitments are
-            // then genuinely never delivered here (not merely cleared from
-            // storage, which the event-dedup cache would treat as already
-            // processed and refuse to redeliver)
-            const restoreEvents = await h.rpcStub.holdDisputeCommittedEvents(
-                observerIndex,
-                { passFirst: false }
-            );
-
-            // real invalid transition -> honest peers dispute + commit on-chain
-            await h.byzantine.submitInvalidStateTransitionBlock(
-                maliciousPeerIndex
-            );
-            await h.assert.dispute.initiatedWait();
-            // exclude the observer - its own onDisputeCommitted delivery is held
-            await h.assert.dispute.committedWait({ peersIndices: [1, 3] });
+            const { forkId, race, restoreEvents } =
+                await h.scenario.disputeWithSuppressedCommitEvents({
+                    observerIndex,
+                    maliciousPeerIndex: 2
+                });
 
             // wait out the kill period - before it expires tryReduce
             // returns undefined at the gate and never reaches recovery
@@ -91,7 +425,7 @@ describe("Unit: ReductionExecutor", function () {
                         missingBeforeCount: missingBefore.length,
                         threw,
                         recoveredAll,
-                        reducedDisputeCount: reducedDisputes.length
+                        reducedDisputeCount: reducedDisputes?.length ?? null
                     };
                 },
                 { forkId }

--- a/test/unit/SpectateService.test.ts
+++ b/test/unit/SpectateService.test.ts
@@ -12,33 +12,18 @@ describe("Unit: SpectateService", function () {
         it("committed dispute missing locally → recovers before generating the payload", async function () {
             const h = TestSession.getHarness();
             const observerIndex = 0;
-            const maliciousPeerIndex = 2;
-
-            await h.lifecycle.start(4, 2);
-            const forkId = h.activeForkId!;
-
-            // hold the observer's own scheduled reduction so it can't
-            // recover the missing dispute in the background before this
-            // test's generateSyncPayload call gets to observe the gap
-            const race = await h.rpcStub.holdReductionRace(observerIndex);
 
             // the observer's own dispute against the fault is created
             // locally (flips isForkDisputed regardless of event delivery),
             // but only the FIRST externally-arriving dispute event is let
             // through - a later honest disputer's commitment stays
             // genuinely missing from local storage
-            const restoreEvents = await h.rpcStub.holdDisputeCommittedEvents(
-                observerIndex,
-                { passFirst: true }
-            );
-
-            await h.byzantine.submitInvalidStateTransitionBlock(
-                maliciousPeerIndex
-            );
-            await h.assert.dispute.initiatedWait();
-            // exclude the observer - its own onDisputeCommitted delivery is
-            // deliberately held back except for the first event
-            await h.assert.dispute.committedWait({ peersIndices: [1, 3] });
+            const { forkId, race, restoreEvents } =
+                await h.scenario.disputeWithSuppressedCommitEvents({
+                    observerIndex,
+                    maliciousPeerIndex: 2,
+                    passFirst: true
+                });
 
             const staged = await h.execOnHost(
                 h.getPeer(observerIndex),
@@ -153,6 +138,70 @@ describe("Unit: SpectateService", function () {
             await restoreEvents(false);
         });
 
+        // no test: "reduce data unavailable -> refuse to serve" needs the local
+        // EVM mirror's inbound head to sit above what TS storage holds, because
+        // computeReductionLocally takes the reduced inbound head from the mirror
+        // (DisputeVerificationFacet.sol:109, channelBalances) while
+        // getReduceData walks TS storage. No flow produces that split:
+        // EventHandler.onInboundMessagesProcessed writes storage first and the
+        // mirror second, so the mirror is never ahead. The one route that could
+        // break the tie is onChannelStorageCleared, which moves the mirror's
+        // inbound head without storing the block - it needs a real on-chain
+        // clear to stage. The undefined outcome itself is pinned by
+        // "Unit: AgreementManager ... unrecoverable reduce run -> undefined".
+        it.skip("reduce data unavailable for a disputed window → payload refused (needs a mirror ahead of storage)", function () {});
+
+        // the sibling gap that IS stageable: the window's own disputes are
+        // on-chain but unreadable locally. we must not serve a proof we could
+        // not build - and must not throw either, which is what the old
+        // "Disputes unavailable after event recovery" did
+        it("dispute window unavailable → payload refused, no throw", async function () {
+            const h = TestSession.getHarness();
+            const observerIndex = 0;
+            const { forkId, race, restoreEvents } =
+                await h.scenario.disputeWithSuppressedCommitEvents({
+                    observerIndex,
+                    maliciousPeerIndex: 2,
+                    passFirst: true
+                });
+
+            // blinded recovery: the missing dispute can never be recovered
+            const blinded = await h.rpcStub.failChainLogQueries(observerIndex);
+            let threw = "";
+            let syncResult: unknown = "unset";
+            try {
+                syncResult = await h
+                    .control(h.getPeer(observerIndex))
+                    .spectate.generateSyncPayload(h.channelId!, forkId, 0)
+                    .request();
+            } catch (e) {
+                threw = e instanceof Error ? e.message : String(e);
+            }
+            await blinded.restore();
+
+            expect(
+                threw,
+                "generateSyncPayload must refuse, not throw"
+            ).to.equal("");
+            expect(
+                syncResult,
+                "a window we cannot read must not be served as a proof"
+            ).to.be.null;
+            expect(
+                await h
+                    .control(h.getPeer(observerIndex))
+                    .query.getDisputeFraudProofTypes()
+                    .request()
+            ).to.deep.equal([]);
+
+            await race.release({
+                replayEvents: false,
+                runHeldTasks: false,
+                keepTasksHeld: true
+            });
+            await restoreEvents(false);
+        });
+
         // the sibling above lets the first dispute event through, so the
         // responder's local EVM flips isForkDisputed on its own. with EVERY
         // dispute event held the local mirror still says "not disputed" while
@@ -162,24 +211,13 @@ describe("Unit: SpectateService", function () {
         it("all dispute events suppressed → still declines the disputed fork instead of proving it", async function () {
             const h = TestSession.getHarness();
             const observerIndex = 0;
-            const maliciousPeerIndex = 2;
-
-            await h.lifecycle.start(4, 2);
-            const forkId = h.activeForkId!;
-
-            const race = await h.rpcStub.holdReductionRace(observerIndex);
 
             // nothing gets through - the observer never learns of any dispute
-            const restoreEvents = await h.rpcStub.holdDisputeCommittedEvents(
-                observerIndex,
-                { passFirst: false }
-            );
-
-            await h.byzantine.submitInvalidStateTransitionBlock(
-                maliciousPeerIndex
-            );
-            await h.assert.dispute.initiatedWait();
-            await h.assert.dispute.committedWait({ peersIndices: [1, 3] });
+            const { forkId, race, restoreEvents } =
+                await h.scenario.disputeWithSuppressedCommitEvents({
+                    observerIndex,
+                    maliciousPeerIndex: 2
+                });
 
             const staged = await h.execOnHost(
                 h.getPeer(observerIndex),


### PR DESCRIPTION
- The bug: an honest peer that misses an on-chain InboundMessagesProcessed event can't rebuild the inbound message-block history. Before this branch, that threw — and the throw was treated as the peer's failure.
- Harm 1 — self-eviction: the throw killed the audit/reduction path, so the peer missed its turns, got timed out by others, and was slashed. Its own missing data cost it the channel.
- Harm 2 — false accusation: where it didn't throw, it judged a dispute against truncated/substituted history and could build a fraud proof slashing an honest disputer.
- Attack vector: cheap to trigger — any peer that withholds/delays gossip, or a flaky RPC provider, creates the gap. The victim punishes itself or an innocent third party; the attacker spends nothing.
- The fix, per surface: storage range reads truncate at the first missing block instead of throwing; the auditor fetches from chain first and abstains if a hole remains; the reducer waits and retries instead of aborting; a node that can't recompute someone else's reduction doesn't challenge it; a sync responder refuses rather than serving history it can't prove; and the timeout detector doesn't accuse an author whose posted block it already holds but hasn't finished validating (that claim would be refuted on-chain and slash the detector).
- The through-line: your own missing history must never become an accusation against someone else, nor a self-inflicted eviction.
