### PR TITLE
fix(test-runner): drop the fs-ext host lock for a pure-JS pid lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ethers": "6.13.7"
   },
   "devDependencies": {
+    "@hyperswarm/dht": "^6.0.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
     "@nomicfoundation/hardhat-ethers": "^3.0.0",
     "@nomicfoundation/hardhat-foundry": "^1.1.3",
@@ -50,6 +51,7 @@
     "sinon": "^20.0.0",
     "solidity-coverage": "^0.8.1",
     "source-map-support": "^0.5.21",
+    "tar": "^7.4.3",
     "tsc-alias": "^1.8.16",
     "typechain": "^8.3.0",
     "vite": "^7.1.5",
@@ -58,7 +60,6 @@
   "dependencies": {
     "@ethereumjs/evm": "^3.1.0",
     "@ganache/console.log": "^0.4.2",
-    "@hyperswarm/dht": "^6.0.1",
     "@hyperswarm/dht-relay": "0.3.0",
     "@nomiclabs/hardhat-ethers": "2.2.3",
     "@nomiclabs/hardhat-waffle": "2.0.6",
@@ -67,14 +68,12 @@
     "buffer": "^6.0.3",
     "ethereum-waffle": "4.0.10",
     "fflate": "^0.8.2",
-    "fs-ext": "^2.1.1",
     "get-webrtc": "^1.0.1",
     "glob": "10.3.10",
     "hardhat": "^2.22.1",
     "hyperswarm": "4.3.5",
     "mocha": "10.7.3",
     "prompt": "1.3.0",
-    "tar": "^7.4.3",
     "ts-morph": "^27.0.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
@@ -82,6 +81,7 @@
     "ws": "^8.18.0"
   },
   "engines": {
+    "node": ">=20",
     "yarn": ">=1.15"
   },
   "scripts": {
@@ -200,16 +200,12 @@
   },
   "author": "",
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "fs-ext"
-    ]
+    "onlyBuiltDependencies": []
   },
   "peer3TestDistribution": {
     "prepareScript": "test:parallel:prepare",
     "cachedPrepareScript": "test:parallel:prepare:cached-contracts",
-    "verifyNativeModules": [
-      "fs-ext"
-    ],
+    "verifyNativeModules": [],
     "contractCompileInputs": [
       "contracts/",
       "hardhat.config.ts",

--- a/scripts/e2e-parallel/distributed/hostLock.js
+++ b/scripts/e2e-parallel/distributed/hostLock.js
@@ -10,11 +10,6 @@ const HOST_LOCK_PATH = path.join(HOST_LOCK_DIR, "server-v8.lock");
 
 function acquireHostLock(options = {}) {
     if (options.allowSharedHost) return { release() {} };
-    if (process.platform !== "darwin" && process.platform !== "linux") {
-        throw new Error(
-            "Host locking is unsupported; pass --allow-shared-host to bypass it"
-        );
-    }
     return acquireOsFileLock(
         options.lockPath || HOST_LOCK_PATH,
         "Another test:parallel:server owns this host",
@@ -22,58 +17,100 @@ function acquireHostLock(options = {}) {
     );
 }
 
+// Exclusive across processes via an atomic link() of a pid file. A lock whose
+// owner died is reclaimed, which is what flock(2) gave us for free before —
+// without the native fs-ext binding (and it works on Windows).
 function acquireOsFileLock(lockPath, contentionMessage, options = {}) {
-    if (process.platform !== "darwin" && process.platform !== "linux") {
-        throw new Error("OS-held file locking is unsupported on this platform");
-    }
-    let fsExt;
-    try {
-        fsExt = require("fs-ext");
-    } catch (error) {
-        // Keep the underlying loader error: "module not found" vs a native
-        // ABI mismatch vs an unbuilt binding need different fixes.
-        throw new Error(
-            `fs-ext is required for distributed worker locking: ${error.message}`
-        );
-    }
     fs.mkdirSync(path.dirname(lockPath), {
         recursive: true,
         mode: options.mode
     });
-    try {
-        if (fs.lstatSync(lockPath).isSymbolicLink()) {
-            throw new Error(
-                `Host lock must not be a symbolic link: ${lockPath}`
-            );
-        }
-    } catch (error) {
-        if (error.code !== "ENOENT") throw error;
-    }
-    const flags =
-        fs.constants.O_CREAT |
-        fs.constants.O_APPEND |
-        fs.constants.O_RDWR |
-        (fs.constants.O_NOFOLLOW || 0);
-    const fd = fs.openSync(lockPath, flags, 0o600);
-    try {
-        fsExt.flockSync(fd, "exnb");
-    } catch (error) {
-        fs.closeSync(fd);
-        if (error.code === "EAGAIN" || error.code === "EWOULDBLOCK") {
-            throw new Error(contentionMessage);
-        }
-        throw error;
+    rejectSymlink(lockPath);
+    if (!claimLock(lockPath)) {
+        // Someone holds it. Reclaim only if the recorded owner is gone, then
+        // race the other reclaimers for the free slot exactly once.
+        if (!clearStaleLock(lockPath)) throw new Error(contentionMessage);
+        if (!claimLock(lockPath)) throw new Error(contentionMessage);
     }
     let released = false;
     return {
-        fd,
         release() {
             if (released) return;
             released = true;
-            fsExt.flockSync(fd, "un");
-            fs.closeSync(fd);
+            // Only drop the file while we still own it: a lock we were judged
+            // stale for belongs to whoever reclaimed it.
+            if (readLockOwner(lockPath) === process.pid) {
+                fs.rmSync(lockPath, { force: true });
+            }
         }
     };
+}
+
+// Writes the pid first, then links it into place, so the lock file is never
+// observed empty by a concurrent staleness check.
+function claimLock(lockPath) {
+    const stagingPath = `${lockPath}.${process.pid}.staging`;
+    // A crash can leave our own staging file behind; "wx" would then refuse.
+    fs.rmSync(stagingPath, { force: true });
+    fs.writeFileSync(stagingPath, String(process.pid), {
+        mode: 0o600,
+        flag: "wx"
+    });
+    try {
+        fs.linkSync(stagingPath, lockPath);
+        return true;
+    } catch (error) {
+        if (error.code === "EEXIST") return false;
+        throw error;
+    } finally {
+        fs.rmSync(stagingPath, { force: true });
+    }
+}
+
+function clearStaleLock(lockPath) {
+    const ownerPid = readLockOwner(lockPath);
+    if (ownerPid === undefined) return true; // vanished under us; the slot is free
+    if (ownerPid !== null && isProcessAlive(ownerPid)) return false;
+    fs.rmSync(lockPath, { force: true });
+    return true;
+}
+
+// pid of the owner, `null` when the file is unreadable as one, `undefined`
+// when there is no lock file at all.
+function readLockOwner(lockPath) {
+    rejectSymlink(lockPath);
+    let contents;
+    try {
+        contents = fs.readFileSync(lockPath, "utf8");
+    } catch (error) {
+        if (error.code === "ENOENT") return undefined;
+        throw error;
+    }
+    const ownerPid = Number.parseInt(contents.trim(), 10);
+    return Number.isInteger(ownerPid) && ownerPid > 0 ? ownerPid : null;
+}
+
+function isProcessAlive(pid) {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (error) {
+        // EPERM means the process exists but is owned by another user.
+        return error.code === "EPERM";
+    }
+}
+
+function rejectSymlink(lockPath) {
+    let stats;
+    try {
+        stats = fs.lstatSync(lockPath);
+    } catch (error) {
+        if (error.code === "ENOENT") return;
+        throw error;
+    }
+    if (stats.isSymbolicLink()) {
+        throw new Error(`Host lock must not be a symbolic link: ${lockPath}`);
+    }
 }
 
 module.exports = {

--- a/test/scripts/e2eParallelWorkerLease.test.ts
+++ b/test/scripts/e2eParallelWorkerLease.test.ts
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { spawnSync } from "child_process";
 
 const {
     WorkerLeaseManager
@@ -180,9 +181,7 @@ describe("distributed worker lease", function () {
         ).to.throw("Invalid worker progress");
     });
 
-    it("uses an OS-held host lock and allows the explicit bypass", function () {
-        if (process.platform !== "darwin" && process.platform !== "linux")
-            this.skip();
+    it("holds the host lock exclusively and allows the explicit bypass", function () {
         const lockPath = path.join("/tmp", `peer3-lock-test-${process.pid}`);
         const first = acquireHostLock({ lockPath, workRoot: "/tmp/root-a" });
         try {
@@ -201,9 +200,58 @@ describe("distributed worker lease", function () {
         fs.rmSync(lockPath, { force: true });
     });
 
+    it("reclaims a host lock whose owning process is gone", function () {
+        const lockPath = path.join(
+            os.tmpdir(),
+            `peer3-lock-stale-${process.pid}`
+        );
+        // spawnSync has reaped the child by the time it returns, so its pid
+        // names a process that is definitively gone.
+        const deadPid = spawnSync(process.execPath, ["-e", ""]).pid;
+        fs.writeFileSync(lockPath, String(deadPid));
+        try {
+            const reclaimed = acquireHostLock({ lockPath });
+            expect(fs.readFileSync(lockPath, "utf8")).to.equal(
+                String(process.pid)
+            );
+            reclaimed.release();
+            expect(fs.existsSync(lockPath)).to.equal(false);
+        } finally {
+            fs.rmSync(lockPath, { force: true });
+        }
+    });
+
+    it("reclaims a host lock whose owner cannot be read", function () {
+        const lockPath = path.join(
+            os.tmpdir(),
+            `peer3-lock-corrupt-${process.pid}`
+        );
+        fs.writeFileSync(lockPath, "not-a-pid");
+        try {
+            acquireHostLock({ lockPath }).release();
+            expect(fs.existsSync(lockPath)).to.equal(false);
+        } finally {
+            fs.rmSync(lockPath, { force: true });
+        }
+    });
+
+    it("refuses a host lock path that is a symbolic link", function () {
+        const root = fs.mkdtempSync(
+            path.join(os.tmpdir(), "host-lock-symlink-test-")
+        );
+        const lockPath = path.join(root, "host.lock");
+        fs.writeFileSync(path.join(root, "target"), "");
+        fs.symlinkSync(path.join(root, "target"), lockPath);
+        try {
+            expect(() => acquireHostLock({ lockPath })).to.throw(
+                /must not be a symbolic link/
+            );
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
     it("locks identical source independently for two orchestrator identities", function () {
-        if (process.platform !== "darwin" && process.platform !== "linux")
-            this.skip();
         const root = fs.mkdtempSync(
             path.join(os.tmpdir(), "environment-lock-test-")
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5717,13 +5717,6 @@ fromentries@^1.2.0:
   resolved "https://registry.yarnpkg.com/fromentries/-/fromentries-1.3.2.tgz#e4bca6808816bf8f93b52750f1127f5a6fd86e3a"
   integrity sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==
 
-fs-ext@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/fs-ext/-/fs-ext-2.1.1.tgz#f60bdb6506681ccc21e5ea5623bc990dd0216fd7"
-  integrity sha512-/TrISPOFhCkbgIRWK9lzscRzwPCu0PqtCcvMc9jsHKBgZGoqA0VzhspVht5Zu8lxaXjIYIBWILHpRotYkCCcQA==
-  dependencies:
-    nan "^2.21.0"
-
 fs-extra@^0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
@@ -7990,11 +7983,6 @@ mylas@^2.1.9:
   version "2.1.14"
   resolved "https://registry.yarnpkg.com/mylas/-/mylas-2.1.14.tgz#bfa0a2bcbc4bb69f0af324dc7f38689ad56f12cc"
   integrity sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==
-
-nan@^2.21.0:
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.28.0.tgz#126717fd359d5a03d3edf7c44e6ce9b707fb57f5"
-  integrity sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==
 
 nano-base32@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Summary

Fixes the dependency problem reported in review on #421 (`package.json` L61/L70/L77).

`fs-ext`, `tar` and `@hyperswarm/dht` were in `dependencies`, but none is referenced under `src/` — the consumers are `scripts/e2e-parallel/distributed/*` and `test/`. `fs-ext` additionally pulls `nan` and needs a node-gyp build, so a plain `yarn install --frozen-lockfile` failed on any host without a working native toolchain, and `hostLock.js` required it unconditionally — meaning the test suite could not run at all without a built binding. `acquireHostLock` also refused to run on Windows.

Changes:

- **`hostLock.js` no longer uses `flock(2)`.** The lock is now an atomic `link()` of a pid file: the owner writes its pid to a staging file and links it into place (so the lock file is never observed empty), and a lock whose recorded owner no longer answers `process.kill(pid, 0)` is reclaimed. That restores the release-on-owner-death behaviour `flock` gave for free, with no native code. The existing symlink rejection is kept.
- **Platform gates removed.** `link()` and `process.kill(pid, 0)` work everywhere, so `acquireHostLock`/`acquireOsFileLock` no longer throw on Windows and the two `this.skip()` guards in the lease tests are gone.
- **`fs-ext` removed outright** from `package.json` and `yarn.lock` (along with its now-orphaned `nan` entry). `tar` and `@hyperswarm/dht` move to `devDependencies`. `@hyperswarm/dht-relay` stays in `dependencies` — it is used by `src/HolepunchRelay.ts`.
- `pnpm.onlyBuiltDependencies` and `peer3TestDistribution.verifyNativeModules` are now empty lists. Both consumers already handle an empty list (`workspacePreparation.js:15`, `runtimeBundle.js:175`); the plumbing stays for the next native dependency.
- `engines.node` declared as `>=20`, matching CI.

Stacked on #447 (stack #446: #443 → #445 → #447 → #448). No code dependency on #447 — the commit cherry-picks cleanly onto it, which is also how I confirmed the two PRs touch no common files.

It is stacked rather than branched as a sibling because `test-containers` is an active branch that keeps moving; a single chain is one rebase instead of two. Going the other way (onto `dispute` or `fix-flakes`) is not free: `test-containers` deleted two lease tests and rewrote a third, so the commit conflicts in `e2eParallelWorkerLease.test.ts` on those bases.

## Test Plan

- `test/scripts/e2eParallelWorkerLease.test.ts` — the existing exclusivity/bypass case keeps its coverage (renamed, since the lock is no longer OS-held), plus three new cases: reclaiming a lock whose owning process is gone, reclaiming one whose owner cannot be parsed, and refusing a symlinked lock path.
- `yarn tsc --noEmit -p tsconfig.json` — clean for the touched files. (Four pre-existing errors remain in `DisputeFraudProofService.ts` / `DisputeValidationService.ts` / `Codec.ts` / `DisputeManager.test.ts` from stale typechain output; unrelated to this change and present on the base.)
- Behaviour verified directly against the module: exclusivity while held, `allowSharedHost` bypass, lock file removed on release, reacquire after release, reclaim of a dead-pid lock, reclaim of an unparseable lock, symlink rejection, independent paths not contending, and a second **process** blocked with the contention message.
- Full run left to the distributed pool.
