### PR TITLE
docs(spec): cut always-paid context, and keep the linker out of generated/

### DIFF
--- a/docs/spec/AGENTS.md
+++ b/docs/spec/AGENTS.md
@@ -1,7 +1,23 @@
 # Specification maintenance instructions
 
-These rules apply to every file under `docs/spec/`. Read [README.md](./README.md) and
-[governance.md](./governance.md), then the owning layer README and directly linked documents.
+These rules apply to every file under `docs/spec/`. This file is the whole of what every task
+needs; read further only where your task actually reaches:
+
+| Before you                                      | Read                                                          |
+| ----------------------------------------------- | ------------------------------------------------------------- |
+| answer a question about specified behavior      | nothing further — the owning document, then stop              |
+| edit one document inside one layer              | that layer's README                                           |
+| allocate, move, or delete an ID                 | [governance.md](./governance.md)                              |
+| change behavior across layers, or add a subject | [README.md](./README.md) and [governance.md](./governance.md) |
+| record a decision, finding, or approval         | [governance.md](./governance.md)                              |
+
+Reading all four entry documents before every task costs roughly four times this file for context
+almost none of it uses. Follow a link when the work reaches it, not in advance.
+
+Keep that true when editing this file. What every task must read before it starts is the one cost
+paid by every task, so it is the one worth arguing about: a link is cheap, an instruction to read
+something first is not. Prefer routing work to a document over requiring it in advance, and when a
+document has to be read up front, say for which work.
 
 ## Agent authority
 

--- a/docs/spec/tools/check-id-links.js
+++ b/docs/spec/tools/check-id-links.js
@@ -23,8 +23,17 @@ if (args.size) {
 }
 
 const ID_RE = () => new RegExp(AUDITABLE_ID_PATTERN, "g");
+// The optional group before the closing bracket absorbs the parenthesised
+// gloss that linkify adds to cross-document references, so --write strips a
+// glossed link back to a bare inline-code ID like any other. Without it each
+// run would nest the previous gloss inside a new one.
+//
+// The gloss is parenthesised rather than em-dashed because an ID followed by
+// " — " at the start of a line is how id-registry.js recognises a definition
+// site; an em-dash gloss on a wrapped reference line registers a competing
+// definition and flips canonical anchor ownership.
 const EXACT_ID_LINK_RE = new RegExp(
-    `(?:\\x60)?\\[+\\x60*(${AUDITABLE_ID_PATTERN})\\x60*\\]\\([^)]+\\)(?:\\x60)?`,
+    `(?:\\x60)?\\[+\\x60*(${AUDITABLE_ID_PATTERN})\\x60*(?:[ \\t]*\\([^)\\]]*\\))?\\]\\([^)]+\\)(?:\\x60)?`,
     "g"
 );
 const ID_ANCHOR_RE =
@@ -46,8 +55,21 @@ function escapeRegExp(value) {
     return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// Reports under generated/ are machine output: yarn spec:refresh rewrites them
+// wholesale from source data, and their link shapes are the generators' to
+// choose. Rewriting them here makes the two commands fight -- and worse, the
+// normalizer cannot parse a generator's nested link
+// ([[`ID`](target) · 1 plan](target)), so it strips one bracket per run and
+// settles on malformed markup while still reporting zero issues. Both writers
+// stay out; the generators own these files.
+function maintainedDocuments() {
+    return walkFiles(SPEC_ROOT, { extensions: [".md"] }).filter(
+        (document) => !specRelative(document).startsWith("generated/")
+    );
+}
+
 function normalizeIdMarkup() {
-    for (const document of walkFiles(SPEC_ROOT, { extensions: [".md"] })) {
+    for (const document of maintainedDocuments()) {
         const before = fs.readFileSync(document, "utf8");
         let markdown = before
             .replace(STANDALONE_ANCHOR_BLOCK_RE, "\n\n")
@@ -106,9 +128,51 @@ function addCanonicalAnchors(registry) {
     }
 }
 
-function linkify(registry) {
-    const documents = walkFiles(SPEC_ROOT, { extensions: [".md"] });
-    for (const document of documents) {
+// A definition states its subject once, immediately after the ID, in one of two
+// shapes: a bold statement (**`REQ-X` — Subject.**) or a section heading
+// (## OQ-1-ABC — Subject). Reading that subject lets a reference carry what
+// it points at, so an agent resolving `REQ-RPC-5-CV1R1Y` in another document
+// does not have to open that document to learn it means "Resource bounds".
+const GLOSS_STATEMENT_RE =
+    /^\s*\**\s*\x60?([A-Z][A-Z0-9.-]*)\x60?\s*—\s*([^.*—]+)/;
+const GLOSS_HEADING_RE =
+    /^#{1,4}\s+\x60?([A-Z][A-Z0-9.-]*)\x60?\s*—\s*(.+?)\s*$/;
+
+function buildGlossary(registry) {
+    const glossary = new Map();
+    const cache = new Map();
+    for (const [id, definition] of registry.definitions) {
+        // Permutation and planned-test children (.T1, .T1.P2) restate their
+        // parent and live in dense table cells; glossing them adds bytes
+        // without adding meaning.
+        if (id.includes(".")) continue;
+        if (!cache.has(definition.document))
+            cache.set(
+                definition.document,
+                fs.readFileSync(definition.document, "utf8").split(/\r?\n/)
+            );
+        const line = cache.get(definition.document)[definition.line];
+        if (!line) continue;
+        const stripped = line.replace(ID_ANCHOR_RE, "");
+        const match =
+            stripped.match(GLOSS_HEADING_RE) ||
+            stripped.match(GLOSS_STATEMENT_RE);
+        if (!match || match[1] !== id) continue;
+        const subject = match[2].replace(/\s+/g, " ").trim();
+        // A subject long enough to be prose is a sentence that got captured,
+        // not a title; skip rather than inline a paragraph into every link.
+        if (!subject || subject.length > 60) continue;
+        // The gloss is delimited by parentheses, so a subject that contains
+        // them cannot be stripped back off: the strip pattern would stop at the
+        // inner ")" and the next --write would wrap the link a second time.
+        if (/[()[\]]/.test(subject)) continue;
+        glossary.set(id, subject);
+    }
+    return glossary;
+}
+
+function linkify(registry, glossary = new Map()) {
+    for (const document of maintainedDocuments()) {
         const before = fs.readFileSync(document, "utf8");
         let markdown = before.replace(EXACT_ID_LINK_RE, (_, id) => `\`${id}\``);
         let fenced = false;
@@ -147,10 +211,24 @@ function linkify(registry) {
                     replaceStart -= 1;
                     replaceEnd += 1;
                 }
+                // Gloss only what points out of this document. A same-file
+                // reference is one anchor jump away, so naming its subject
+                // again costs bytes on every mention and saves no lookup.
+                //
+                // Table rows are excluded because the registry reads an ID
+                // column cell as a definition candidate: extra text beside the
+                // ID there registers a competing "table" definition in the
+                // referencing document and flips canonical anchor ownership.
+                const inTableRow = line.trimStart().startsWith("|");
+                const gloss =
+                    inTableRow || definition.document === document
+                        ? null
+                        : glossary.get(id);
+                const label = gloss ? `\`${id}\` (${gloss})` : `\`${id}\``;
                 replacements.push({
                     start: replaceStart,
                     end: replaceEnd,
-                    value: `[\`${id}\`](${canonicalTarget(document, {
+                    value: `[${label}](${canonicalTarget(document, {
                         ...definition,
                         id
                     })})`
@@ -275,7 +353,7 @@ if (write) {
     let registry = buildIdRegistry();
     addCanonicalAnchors(registry);
     registry = buildIdRegistry();
-    linkify(registry);
+    linkify(registry, buildGlossary(registry));
 }
 
 const result = check();


### PR DESCRIPTION
Reading `docs/spec/` cost more than it needed to before a task began.

## Lazy-load the entry point

`docs/spec/AGENTS.md` opened by telling every agent to read `README.md`, `governance.md` and the owning layer README before touching anything — roughly 15KB of instructions paid on every task regardless of what the task was. It now routes each kind of work to the document it actually needs, so a read-only question stops at the owning document instead of four entry files first.

Same content, demoted from always to on demand, with a short rule beside the table to keep it that way: what every task must read before it starts is the one cost every task pays, and a link is cheap where an instruction to read something first is not.

## Keep the linker out of `generated/`

`check-id-links.js --write` rewrites every `.md` it walks, generated reports included — and it cannot parse a generator's nested link. Given ``[[`ID`](target) · 1 plan](target)`` it strips one bracket per run and settles on malformed markup while still reporting zero issues.

`normalizeIdMarkup` and `linkify` now share a filter that skips `generated/`. Those files belong to their generators, and since #470 they aren't even tracked, so `yarn spec:ids:fix` was corrupting untracked local output for no reason.

## Gloss capability

The linker can now carry a definition's own subject in the link text, so a reference is readable without opening its target:

```
[`REQ-RPC-5-CV1R1Y` (Resource bounds)](rpc.md#req-rpc-5-cv1r1y)
```

The subject is read from the definition site, never invented, and only where a definition states one. **The rewrite that applies it across the tree is deliberately not here** — it touches ~170 documents and belongs after the in-flight spec review, so the glosses reflect corrected text.

Two format constraints are encoded and commented, both learned the hard way: the gloss is parenthesised because an ID followed by " — " at line start is how `id-registry.js` recognises a definition site, and subjects containing brackets are skipped because the strip pattern that makes `--write` idempotent stops at the first `)`.

## Not included

An earlier version of this branch also committed refreshed `generated/` reports and added a separate spec workflow. Both are dropped: #470 gitignored `generated/`, and `ci.yml` already has a `spec` job.

Verified on this base: `yarn spec:ids:check` reports 6,617 definitions and 0 issues, `yarn spec:refresh` completes, and a `--write` leaves `generated/` byte-identical.
